### PR TITLE
fix(client): fix rtp by using --noplugin

### DIFF
--- a/lua/null-ls/client.lua
+++ b/lua/null-ls/client.lua
@@ -24,8 +24,7 @@ local start_client = function()
         cmd = {
             "nvim",
             "--headless",
-            "-u",
-            "NONE",
+            "--noplugin",
             "-c",
             "lua require'null-ls'.start_server()",
         },


### PR DESCRIPTION
See [this issue](https://github.com/jose-elias-alvarez/nvim-lsp-ts-utils/issues/30). Using `-u NONE` works with packer.nvim but not vim-plug, and `--noplugin` works for both. 

I want to investigate performance implications from the change (so far, it seems like CPU time is *slightly* higher, but CPU usage is still minimal) and also verify check other plugin managers for compatibility. 