### PR TITLE
add stylua config search argument

### DIFF
--- a/lua/null-ls/builtins/formatting.lua
+++ b/lua/null-ls/builtins/formatting.lua
@@ -19,7 +19,7 @@ M.lua_format = h.make_builtin({
 M.stylua = h.make_builtin({
     method = FORMATTING,
     filetypes = { "lua" },
-    generator_opts = { command = "stylua", args = { "-" }, to_stdin = true },
+    generator_opts = { command = "stylua", args = { "-s", "-" }, to_stdin = true },
     factory = h.formatter_factory,
 })
 


### PR DESCRIPTION
This adds the `-s` argument to stylua which causes stylua to automatically
search for a config file until the root is found and if no config is found it
uses config files in `$XDG_CONFIG_HOME` as a fallback. This is still a bit janky
as stylua doesn't seem to be informed of the root directory of the language
server and therefore seems to search for config files in the current `:pwd` of
vim itself.
