### PR TITLE
feat: added support for lspconfig & builtin for selene [DRAFT]

### DIFF
--- a/lua/null-ls/client.lua
+++ b/lua/null-ls/client.lua
@@ -10,6 +10,7 @@ local api = vim.api
 local schedule = vim.schedule_wrap
 
 local function on_init(client)
+    s.set({ client_id = client.id })
     handlers.setup_client(client)
     s.initialize(client)
 end
@@ -18,10 +19,8 @@ local on_exit = function()
     s.reset()
 end
 
-local start_client = function()
-    s.reset()
-
-    local client_id = lsp.start_client({
+local function get_client_config()
+    return {
         cmd = {
             c.get().nvim_executable,
             "--headless",
@@ -38,8 +37,12 @@ local start_client = function()
         on_attach = c.get().on_attach,
         name = "null-ls",
         flags = { debounce_text_changes = c.get().debounce },
-    })
+    }
+end
 
+local start_client = function()
+    s.reset()
+    local client_id = lsp.start_client(get_client_config())
     -- this completes before the client is initialized
     -- and signals that start_client should not be called again
     s.set({ client_id = client_id })
@@ -69,6 +72,8 @@ local M = {}
 M.start = start_client
 
 M.try_attach = try_attach
+
+M.get_client_config = get_client_config
 
 -- triggered after dynamically registering sources
 M.attach_or_refresh = schedule(function()

--- a/lua/null-ls/code-actions.lua
+++ b/lua/null-ls/code-actions.lua
@@ -22,7 +22,7 @@ M.handler = function(method, original_params, handler, bufnr)
 
         s.clear_actions()
         generators.run(u.make_params(original_params, methods.internal.CODE_ACTION), postprocess, function(actions)
-            handler(nil, method, actions, s.get().client_id, bufnr)
+            handler(nil, method, actions, original_params.client_id, bufnr)
         end)
 
         original_params._null_ls_handled = true

--- a/lua/null-ls/diagnostics.lua
+++ b/lua/null-ls/diagnostics.lua
@@ -39,7 +39,7 @@ M.handler = function(original_params)
         vim.lsp.handlers[methods.lsp.PUBLISH_DIAGNOSTICS](nil, nil, {
             diagnostics = diagnostics,
             uri = uri,
-        }, s.get().client_id, nil, {})
+        }, original_params.client_id, nil, {})
     end)
 end
 

--- a/lua/null-ls/diagnostics.lua
+++ b/lua/null-ls/diagnostics.lua
@@ -34,7 +34,7 @@ M.handler = function(original_params)
         return
     end
 
-    original_params.bufnr = s.get().attached[uri]
+    original_params.bufnr = vim.uri_to_bufnr(uri)
     generators.run(u.make_params(original_params, methods.internal.DIAGNOSTICS), postprocess, function(diagnostics)
         vim.lsp.handlers[methods.lsp.PUBLISH_DIAGNOSTICS](nil, nil, {
             diagnostics = diagnostics,

--- a/lua/null-ls/formatting.lua
+++ b/lua/null-ls/formatting.lua
@@ -74,7 +74,7 @@ M.handler = function(method, original_params, handler, bufnr)
         end
 
         -- call original handler with empty response so buf.request_sync() doesn't time out
-        handler(nil, methods.lsp.FORMATTING, {}, s.get().client_id, bufnr)
+        handler(nil, methods.lsp.FORMATTING, {}, original_params.client_id, bufnr)
         u.debug_log("successfully applied edits")
     end
 

--- a/lua/null-ls/handlers.lua
+++ b/lua/null-ls/handlers.lua
@@ -106,6 +106,7 @@ M.setup_client = function(client)
         end
 
         params.method = method
+        params.client_id = client.id
         diagnostics.handler(params)
 
         -- no need to actually send notifications to server,
@@ -118,6 +119,7 @@ M.setup_client = function(client)
         handler = handler or lsp.handlers[method]
         params = params or {}
 
+        params.client_id = client.id
         params.method = method
         code_actions.handler(method, params, handler, bufnr)
         formatting.handler(method, params, handler, bufnr)

--- a/lua/null-ls/helpers.lua
+++ b/lua/null-ls/helpers.lua
@@ -64,7 +64,8 @@ local line_output_wrapper = function(params, done, on_output)
 end
 
 M.generator_factory = function(opts)
-    local command, args, on_output, format, to_stderr, to_stdin, ignore_errors, check_exit_code, timeout, to_temp_file, use_cache = opts.command,
+    local command, args, on_output, format, to_stderr, to_stdin, ignore_errors, check_exit_code, timeout, to_temp_file, use_cache =
+        opts.command,
         opts.args,
         opts.on_output,
         opts.format,
@@ -157,7 +158,9 @@ M.generator_factory = function(opts)
             end
 
             local spawn_args = args or {}
+            local client = vim.lsp.get_client_by_id(params.client_id)
             local spawn_opts = {
+                cwd = client.config.root_dir,
                 input = to_stdin and get_content(params) or nil,
                 handler = wrapper,
                 bufnr = params.bufnr,

--- a/lua/null-ls/init.lua
+++ b/lua/null-ls/init.lua
@@ -33,7 +33,7 @@ M.disable = function()
     M.shutdown()
 end
 
-M.setup_lspconfig = function(user_config)
+M.config = function(user_config)
     if vim.g.null_ls_disable then
         return
     end

--- a/lua/null-ls/init.lua
+++ b/lua/null-ls/init.lua
@@ -33,6 +33,14 @@ M.disable = function()
     M.shutdown()
 end
 
+M.setup_lspconfig = function(user_config)
+    if vim.g.null_ls_disable then
+        return
+    end
+    config.setup(user_config or {})
+    require("null-ls.lspconfig").setup()
+end
+
 M.setup = function(user_config)
     if vim.g.null_ls_disable then
         return

--- a/lua/null-ls/init.lua
+++ b/lua/null-ls/init.lua
@@ -42,13 +42,9 @@ M.config = function(user_config)
 end
 
 M.setup = function(user_config)
-    if vim.g.null_ls_disable then
-        return
-    end
-    config.setup(user_config or {})
-
-    autocommands.setup()
-    handlers.setup()
+    user_config = user_config or {}
+    M.config(user_config)
+    require("lspconfig")["null-ls"].setup({ on_attach = user_config.on_attach })
 end
 
 return M

--- a/lua/null-ls/loop.lua
+++ b/lua/null-ls/loop.lua
@@ -108,7 +108,7 @@ M.spawn = function(cmd, args, opts)
         close_handle(handle)
     end)
 
-    handle = uv.spawn(cmd, { args = parse_args(args, bufnr), stdio = stdio, cwd = vim.fn.getcwd() }, close)
+    handle = uv.spawn(cmd, { args = parse_args(args, bufnr), stdio = stdio, cwd = opts.cwd or vim.fn.getcwd() }, close)
     if timeout then
         timer = M.timer(timeout, nil, true, function()
             close(TIMEOUT_EXIT_CODE)

--- a/lua/null-ls/lspconfig.lua
+++ b/lua/null-ls/lspconfig.lua
@@ -1,6 +1,5 @@
 local client = require("null-ls.client")
 local config = require("null-ls.config")
-local state = require("null-ls.state")
 
 local M = {}
 

--- a/lua/null-ls/lspconfig.lua
+++ b/lua/null-ls/lspconfig.lua
@@ -1,0 +1,24 @@
+local client = require("null-ls.client")
+local config = require("null-ls.config")
+local state = require("null-ls.state")
+
+local M = {}
+
+function M.setup()
+    local configs = require("lspconfig/configs")
+    local util = require("lspconfig/util")
+
+    local config_def = client.get_client_config()
+    config_def.root_dir = util.root_pattern("Makefile", ".git")
+    config_def.filetypes = config.get()._filetypes
+
+    configs["null-ls"] = {
+        default_config = config_def,
+        on_new_config = function(new_config, root_dir)
+            print("on_new_config")
+            -- state.reset()
+        end,
+    }
+end
+
+return M

--- a/lua/null-ls/state.lua
+++ b/lua/null-ls/state.lua
@@ -43,12 +43,8 @@ M.notify_client = notify_client
 
 M.get_rtp = function()
     if not state.rtp then
-        for _, path in ipairs(vim.split(vim.o.rtp, ",")) do
-            if path:find("null-ls.nvim", 1, true) then
-                state.rtp = path
-                break
-            end
-        end
+        local me = debug.getinfo(1, "S").source:sub(2)
+        state.rtp = vim.fn.fnamemodify(me, ":p:h:h:h")
         assert(state.rtp, "null-ls.nvim must be available on your rtp")
     end
     return state.rtp

--- a/lua/null-ls/utils.lua
+++ b/lua/null-ls/utils.lua
@@ -55,6 +55,7 @@ M.make_params = function(original_params, method)
     local content = get_content_from_params(original_params)
 
     return {
+        client_id = original_params.client_id,
         content = content,
         lsp_method = lsp_method,
         method = method,


### PR DESCRIPTION
Hi!

First of all, thank you for this amazing plugin.

This PR makes `null-ls` configurable with `lspconfig`.

With this change, autocommands or managing the null-ls client is now taken care of by lspconfig instead.

I haven't removed any code and haven't also change the way it works using `null-ls.setup`.

The lspconfig way is currently accessible by doing:

```lua
local nls = require("null-ls")

nls.setup_lspconfig({
	sources = {
		nls.builtins.formatting.prettierd,
		nls.builtins.formatting.stylua,
		nls.builtins.formatting.eslint_d,
		nls.builtins.diagnostics.shellcheck,
		nls.builtins.diagnostics.markdownlint,
		nls.builtins.diagnostics.selene,
	},
})

local lspconfig = require("lspconfig")
lspconfig["null-ls"].setup({ on_attach = function(client) end })
```

I also added a new builtin for [selene](https://github.com/Kampfkarren/selene), a lua linter.

## Why?

* all exisiting lspconfig functionality can now be used with null-ls
* root_dir detection works, and I made some changes so that the root_dir is used to spawn generators
* when restoring a session with multiple open splits, the different buffers will now correctly be checked for diagnostics
* LspInfo now correctly displays all info for null-ls
* simplifies the null-ls code since the client managing code is no longer needed
* other plugins can now properly inject custom things in null-ls too (I have an unreleased plugin for managing vim stuff with json schemas)

Let me know what you think.

**LspInfo:**
![image](https://user-images.githubusercontent.com/292349/123424237-6fe37680-d575-11eb-933f-1978e9706a1b.png)
