### PR TITLE
Add workaround for systems without vim.loop.fs_mkstemp()

### DIFF
--- a/lua/null-ls/loop.lua
+++ b/lua/null-ls/loop.lua
@@ -163,9 +163,9 @@ M.timer = function(timeout, interval, should_start, callback)
 end
 
 M.temp_file = function(content)
-    local fd, tmp_path = uv.fs_mkstemp("/tmp/null-ls-XXXXXX")
-
-    uv.fs_write(fd, content)
+    local tmp_path = os.tmpname()
+    local fd = uv.fs_open(tmp_path, 'w', 0)
+    uv.fs_write(fd, content, -1)
     uv.fs_close(fd)
 
     return tmp_path, function()


### PR DESCRIPTION
vim.loop.fs_mkstemp() is only exposed in luvit 1.34.1+ however nvim is built with 1.30.1. Provide a workaround until nvim updates luvit.