### PR TITLE
feat: no longer needed to spawn nvim

### DIFF
--- a/lua/null-ls/init.lua
+++ b/lua/null-ls/init.lua
@@ -37,6 +37,7 @@ M.config = function(user_config)
     if vim.g.null_ls_disable then
         return
     end
+    require("null-ls.rpc")
     config.setup(user_config or {})
     require("null-ls.lspconfig").setup()
 end

--- a/lua/null-ls/rpc.lua
+++ b/lua/null-ls/rpc.lua
@@ -25,12 +25,27 @@ rpc.start = function(cmd, ...)
     return rpc_start(cmd, ...)
 end
 
+local function get_client(pid)
+    for _, client in pairs(vim.lsp.get_active_clients()) do
+        if client.rpc.pid == pid then
+            return client
+        end
+    end
+end
+
 function M.start(...)
     lastpid = lastpid + 1
     local pid = lastpid
     local stopped = false
 
+    local client
     local function handle(method, _params, callback)
+        client = client or get_client(pid)
+
+        if client then
+            print("client: " .. client.id)
+        end
+
         local send_response = function(result)
             if callback then
                 callback(nil, result)

--- a/lua/null-ls/rpc.lua
+++ b/lua/null-ls/rpc.lua
@@ -1,0 +1,84 @@
+local methods = require("null-ls.methods")
+
+local rpc = require("vim.lsp.rpc")
+local rpc_start = rpc.start
+
+local M = {}
+
+local capabilities = {
+    codeActionProvider = true,
+    executeCommandProvider = true,
+    documentFormattingProvider = true,
+    documentRangeFormattingProvider = true,
+    textDocumentSync = {
+        change = 1, -- prompt LSP client to send full document text on didOpen and didChange
+        openClose = true,
+    },
+}
+
+local lastpid = 5000
+
+rpc.start = function(cmd, ...)
+    if cmd == "nvim" then
+        return M.start(cmd, ...)
+    end
+    return rpc_start(cmd, ...)
+end
+
+function M.start(...)
+    lastpid = lastpid + 1
+    local pid = lastpid
+    local stopped = false
+
+    local function handle(method, _params, callback)
+        local send_response = function(result)
+            if callback then
+                callback(nil, result)
+            end
+        end
+
+        local send_nil_response = function()
+            send_response(vim.NIL)
+        end
+        if method == methods.lsp.INITIALIZE then
+            send_response({ capabilities = capabilities })
+        end
+        if method == methods.lsp.SHUTDOWN then
+            send_nil_response()
+        end
+        if method == methods.lsp.EXECUTE_COMMAND then
+            stopped = true
+            send_nil_response()
+        end
+        if method == methods.lsp.CODE_ACTION then
+            send_nil_response()
+        end
+        if method == methods.lsp.DID_CHANGE then
+            send_nil_response()
+        end
+    end
+
+    local function request(method, params, callback)
+        print("request: " .. method)
+        handle(method, params, callback)
+    end
+
+    local function notify(method, params)
+        print("notify: " .. method)
+        handle(method, params)
+    end
+
+    return {
+        request = request,
+        notify = notify,
+        pid = pid,
+        handle = {
+            is_closing = function()
+                return stopped
+            end,
+            kill = function()
+                stopped = true
+            end,
+        },
+    }
+end


### PR DESCRIPTION
I found a fairly easy way to prevent the need to spawn a headless nvim to make rpc work.

This PR can be merged on your `lspconfig` branch.

What it does:

* wraps `vim.lsp.rpc.start` and will return a custom rpc implementation if the cmd is `nvim` (kept it like this for now so the normal way also still works, but ideally this should be changed to something like `null-ls`)
* everyhing that `server.lua` does is now handled by the curstom rpc.lua
* there's no longer any need for timers or server restarts
* implemented shutdown

Everything should work as before, but now without needing to spawn an actual nvim process 🙂

I left some debugging statements in there, that should be removed, but might be good if you want to test.

### Possible further improvements

* the patching of the handlers could be removed and all moved inside the custom rpc module.
* the rpc module also gets the client for the current call, which could be used to implement the other handlers. (will be `nil` while initializing)
* some of the code could be removed by moving the handlers to rpc.lua:
   - most stuff in `client.lua`
   - `server.lua`
   - things in `util` to talk to RPC
   - the apply text edits is no longer necesary, since we can let nvim handle that as before now. (that fix for marks will no longer been needed after the nvim_buf_set_text PR has been merged upstream)
   - autocmds.lua

### making things a little less hacky

I can see to get a PR upstream that would allow an lsp config to have a custom `start` method.  Then we no longer would need to patch `vim.lsp.rpc.start` and simply pass the custom method in the config.

After this and after moving the handlers to the rpc module, I don't think there would be any wrapping needed aymore of runtime stuff.