### PR TITLE
feat: builtin vale

### DIFF
--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -185,6 +185,22 @@ local sources = {null_ls.builtins.diagnostics.markdownlint}
 - Command: `markdownlint`
 - Arguments: `{ "--stdin" }`
 
+#### [vale](https://docs.errata.ai/vale/about)
+
+Syntax-aware linter for prose built with speed and extensibility in mind.
+
+vale does include a syntax by itself, so you probably need to grab a `vale.ini`
+(at "~/.vale.ini") and a `StylesPath` (somewhere, pointed from `vale.ini`) from
+[here](https://docs.errata.ai/vale/about#open-source-configurations).
+
+```lua
+local sources = {null_ls.builtins.diagnostics.vale}
+```
+
+- Filetypes: `{ "markdown" }`
+- Command: `write-good`
+- Arguments: `{ "--text=$TEXT", "--parse" }`
+
 ### tl check via [teal](https://github.com/teal-language/tl)
 
 Turns `tl check` into a linter. It writes the buffer's content to a temporary

--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -197,9 +197,9 @@ vale does include a syntax by itself, so you probably need to grab a `vale.ini`
 local sources = {null_ls.builtins.diagnostics.vale}
 ```
 
-- Filetypes: `{ "markdown" }`
-- Command: `write-good`
-- Arguments: `{ "--text=$TEXT", "--parse" }`
+- Filetypes: `{ "markdown", "tex" }`
+- Command: `vale`
+- Arguments: `{ "--no-exit", "--output=JSON", "$FILENAME" }`
 
 ### tl check via [teal](https://github.com/teal-language/tl)
 

--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -189,8 +189,9 @@ local sources = {null_ls.builtins.diagnostics.markdownlint}
 
 Syntax-aware linter for prose built with speed and extensibility in mind.
 
-vale does include a syntax by itself, so you probably need to grab a `vale.ini`
-(at "~/.vale.ini") and a `StylesPath` (somewhere, pointed from `vale.ini`) from
+vale does not include a syntax by itself, so you probably need to grab a
+`vale.ini` (at "~/.vale.ini") and a `StylesPath` (somewhere, pointed from
+`vale.ini`) from
 [here](https://docs.errata.ai/vale/about#open-source-configurations).
 
 ```lua

--- a/lua/null-ls/builtins/diagnostics.lua
+++ b/lua/null-ls/builtins/diagnostics.lua
@@ -88,6 +88,40 @@ M.markdownlint = h.make_builtin({
     factory = h.generator_factory,
 })
 
+M.vale = h.make_builtin({
+    method = DIAGNOSTICS,
+    filetypes = { "markdown", "tex" },
+    generator_opts = {
+        command = "vale",
+        format = "json",
+        args = { "--no-exit", "--output=JSON", "$FILENAME" },
+        on_output = function(params, done)
+            local diagnostics = {}
+            if not params.output or params.output == "" then
+                return done()
+            end
+            for _, diagnostic in ipairs(params.output[params.bufname]) do
+                if diagnostic then
+                    local severity = 1
+                    if diagnostic.Severity == "warning" then
+                        severity = 2
+                    end
+                    table.insert(diagnostics, {
+                        row = diagnostic.Line,
+                        col = diagnostic.Span[1],
+                        end_col = diagnostic.Span[2],
+                        source = diagnostic.Check .. " (vale)",
+                        message = diagnostic.Message,
+                        severity = severity,
+                    })
+                end
+            end
+            return diagnostics
+        end,
+    },
+    factory = h.generator_factory,
+})
+
 M.teal = h.make_builtin({
     method = DIAGNOSTICS,
     filetypes = { "teal" },

--- a/lua/null-ls/builtins/diagnostics.lua
+++ b/lua/null-ls/builtins/diagnostics.lua
@@ -107,7 +107,7 @@ M.vale = h.make_builtin({
                 end
                 table.insert(diagnostics, {
                     row = diagnostic.Line,
-                    col = diagnostic.Span[1],
+                    col = diagnostic.Span[1] - 1,
                     end_col = diagnostic.Span[2],
                     code = diagnostic.Check,
                     source = "vale",

--- a/lua/null-ls/builtins/diagnostics.lua
+++ b/lua/null-ls/builtins/diagnostics.lua
@@ -97,24 +97,23 @@ M.vale = h.make_builtin({
         args = { "--no-exit", "--output=JSON", "$FILENAME" },
         on_output = function(params, done)
             local diagnostics = {}
-            if not params.output or params.output == "" then
+            if not params.output or type(params.output) ~= "table" then
                 return done()
             end
             for _, diagnostic in ipairs(params.output[params.bufname]) do
-                if diagnostic then
-                    local severity = 1
-                    if diagnostic.Severity == "warning" then
-                        severity = 2
-                    end
-                    table.insert(diagnostics, {
-                        row = diagnostic.Line,
-                        col = diagnostic.Span[1],
-                        end_col = diagnostic.Span[2],
-                        source = diagnostic.Check .. " (vale)",
-                        message = diagnostic.Message,
-                        severity = severity,
-                    })
+                local severity = 1
+                if diagnostic.Severity == "warning" then
+                    severity = 2
                 end
+                table.insert(diagnostics, {
+                    row = diagnostic.Line,
+                    col = diagnostic.Span[1],
+                    end_col = diagnostic.Span[2],
+                    code = diagnostic.Check,
+                    source = "vale",
+                    message = diagnostic.Message,
+                    severity = severity,
+                })
             end
             return diagnostics
         end,


### PR DESCRIPTION
### Description

[vale](https://docs.errata.ai/vale/about) is an open-source syntax-aware linter for prose built with speed and extensibility in mind (repo [here](https://github.com/errata-ai/vale)).

It supports adding syntax files (from, for instance, Linode, Gitlab or write-good) and per project syntax styles and it is quite fast.

### Implementation
* Added Diagnostics built-in `vale`.
* Parsed as JSON (all the buffer at once).
* The user is expected to have a `.vale.ini` or `_vale.ini` somewhere at `$HOME` or at the current working directory (you can take one from https://docs.errata.ai/vale/about#open-source-configurations, put the `.vale.init` at home and modify it to point to the `StylesPath`).
* Added some documentation.

TODO:
* [ ] Some tests.
* [x] Will this be accepted? I don't know lua so it would be nice to know before I try to start learning how to do functional testing here.