### PR TITLE
Add shellcheck code to diagnostics

### DIFF
--- a/lua/null-ls/builtins/diagnostics.lua
+++ b/lua/null-ls/builtins/diagnostics.lua
@@ -206,7 +206,7 @@ M.shellcheck = h.make_builtin({
                     end_row = diagnostic.endLine,
                     end_col = diagnostic.endColumn == diagnostic.column and diagnostic.endColumn
                         or diagnostic.endColumn - 1,
-                    message = diagnostic.message,
+                    message = "[SC" .. diagnostic.code .. "] " .. diagnostic.message,
                     source = "shellcheck",
                     severity = diagnostic.level == "error" and 1
                         or diagnostic.level == "warning" and 2


### PR DESCRIPTION
A small change is to show shellcheck's problematic code and diagnostic message together.
```
echo $HOME     ■ [SC2086] Double quote to prevent globbing and word splitting.
```
It's realy helpful and quicker to get more information about the problem from shellcheck's wiki
https://github.com/koalaman/shellcheck/wiki/SC2086

It's also easier to ignore some specific messages
```
# shellcheck disable=SC2086
echo $HOME
# the problem is now ignored
```