### PR TITLE
enhance: show vale suggestions as style LSP diagnostics

### DIFF
--- a/lua/null-ls/builtins/diagnostics.lua
+++ b/lua/null-ls/builtins/diagnostics.lua
@@ -97,14 +97,11 @@ M.vale = h.make_builtin({
         args = { "--no-exit", "--output=JSON", "$FILENAME" },
         on_output = function(params, done)
             local diagnostics = {}
+            local severities = { error = 1, warning = 2, suggestion = 4 }
             if not params.output or type(params.output) ~= "table" then
                 return done()
             end
             for _, diagnostic in ipairs(params.output[params.bufname]) do
-                local severity = 1
-                if diagnostic.Severity == "warning" then
-                    severity = 2
-                end
                 table.insert(diagnostics, {
                     row = diagnostic.Line,
                     col = diagnostic.Span[1] - 1,
@@ -112,7 +109,7 @@ M.vale = h.make_builtin({
                     code = diagnostic.Check,
                     source = "vale",
                     message = diagnostic.Message,
-                    severity = severity,
+                    severity = severities[diagnostic.Severity],
                 })
             end
             return diagnostics


### PR DESCRIPTION
### Description

I forgot `vale`'s **suggestion** severity. This is a tiny PR that simply adds them.

### Implementation

`vale`'s **suggestion** severities are turned into LSP **hint (4)** severities (errors are 1 and warnings as 2, as before).