### PR TITLE
[Feature] Add extra formatters

### DIFF
--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -187,6 +187,18 @@ local sources = {null_ls.builtins.formatting.erlfmt}
 - Command: `erlfmt`
 - Arguments: `{ "-" }`
 
+#### [fish_indent](https://linux.die.net/man/1/fish_indent)
+
+```lua
+local sources = {null_ls.builtins.formatting.fish_indent}
+```
+
+`fish_indent` is used to indent or otherwise prettify a piece of fish code.
+
+- Filetypes: `{ "fish" }`
+- Command: `fish_indent`
+- Arguments: `{}`
+
 #### [goimports](https://pkg.go.dev/golang.org/x/tools/cmd/goimports)
 
 ```lua

--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -55,17 +55,195 @@ default options passed to each built-in source.
 
 ### Formatting
 
-#### [StyLua](https://github.com/JohnnyMorganz/StyLua)
+#### [Asmfmt](https://github.com/klauspost/asmfmt)
 
 ```lua
-local sources = {null_ls.builtins.formatting.stylua}
+local sources = {null_ls.builtins.formatting.asmfmt}
 ```
 
-A fast and opinionated Lua formatter written in Rust. Highly recommended!
+Go Assembler Formatter that will format your assembler code in a similar way that gofmt formats your Go code.
 
-- Filetypes: `{ "lua" }`
-- Command: `stylua`
+- Filetypes: `{ "asm" }`
+- Command: `asmfmt`
+- Arguments: `{}`
+
+#### [Bean Format](https://beancount.github.io/docs/running_beancount_and_generating_reports.html#bean-format)
+
+```lua
+local sources = {null_ls.builtins.formatting.bean_format}
+```
+
+This pure text processing tool will reformat Beancount input to right-align all the numbers at the same, minimal column. It left-aligns all the currencies. It only modifies whitespace.
+
+- Filetypes: `{ "beancount" }`
+- Command: `bean-format`
 - Arguments: `{ "-" }`
+
+#### [Black](https://github.com/psf/black)
+
+```lua
+local sources = {null_ls.builtins.formatting.black}
+```
+
+Black is the uncompromising Python code formatter.
+
+- Filetypes: `{ "python" }`
+- Command: `black`
+- Arguments: `{ "--quiet", "--fast", "-" }`
+
+#### [clang-format](https://www.kernel.org/doc/html/latest/process/clang-format.html)
+
+```lua
+local sources = {null_ls.builtins.formatting.clang_format}
+```
+
+clang-format is a tool to format C/C++/… code according to a set of rules and heuristics.
+
+- Filetypes: `{ "c", "cpp", "cs", "java" }`
+- Command: `clang-format`
+- Arguments: `{ "-assume-filename=<FILENAME>" }`
+
+#### [cmake-format](https://github.com/cheshirekow/cmake_format)
+
+```lua
+local sources = {null_ls.builtins.formatting.cmake_format}
+```
+
+Can format your listfiles nicely so that they don't look like crap.
+
+- Filetypes: `{ "cmake" }`
+- Command: `cmake-format`
+- Arguments: `{ "-" }`
+
+#### [Crystal Format](https://crystal-lang.org/2015/10/16/crystal-0.9.0-released.html)
+
+```lua
+local sources = {null_ls.builtins.formatting.crystal_format}
+```
+A tool for automatically checking and correcting the style of code in a project.
+
+- Filetypes: `{ "crystal" }`
+- Command: `crystal`
+- Arguments: `{ "tool", "format" }`
+
+#### [dfmt](https://github.com/dlang-community/dfmt)
+
+```lua
+local sources = {null_ls.builtins.formatting.dfmt}
+```
+
+dfmt is a formatter for D source code
+
+- Filetypes: `{ "d" }`
+- Command: `dfmt`
+- Arguments: `{}`
+
+#### [Dart Format](https://dart.dev/tools/dart-format)
+
+```lua
+local sources = {null_ls.builtins.formatting.dart_format}
+```
+
+Replace the whitespace in your program with formatting that follows Dart guidelines.
+
+- Filetypes: `{ "dart" }`
+- Command: `dart`
+- Arguments: `{ "format" }`
+
+#### [elm-format](https://github.com/avh4/elm-format)
+
+```lua
+local sources = {null_ls.builtins.formatting.elm_format}
+```
+
+`elm-format` formats Elm source code according to a standard set of rules based on the [official Elm Style Guide](https://elm-lang.org/docs/style-guide)
+
+- Filetypes: `{ "elm" }`
+- Command: `elm-format`
+- Arguments: `{ "--stdin", "--elm-version=0.19" }`
+
+#### [eslint_d](https://github.com/mantoni/eslint_d.js)
+
+An absurdly fast formatter (and linter). For full integration, check out
+[nvim-lsp-ts-utils](https://github.com/jose-elias-alvarez/nvim-lsp-ts-utils).
+
+```lua
+local sources = {null_ls.builtins.formatting.eslint_d}
+```
+
+- Filetypes: `{ "javascript", "javascriptreact", "typescript", "typescriptreact" }`
+- Command: `eslint_d`
+- Arguments: ` { "--fix-to-stdout", "--stdin", "--stdin-filepath", "$FILENAME" }`
+
+#### [erlfmt](https://github.com/WhatsApp/erlfmt)
+
+```lua
+local sources = {null_ls.builtins.formatting.erlfmt}
+```
+
+`erlfmt` is an opinionated Erlang code formatter.
+
+- Filetypes: `{ "erlang" }`
+- Command: `erlfmt`
+- Arguments: `{ "-" }`
+
+#### [goimports](https://pkg.go.dev/golang.org/x/tools/cmd/goimports)
+
+```lua
+local sources = {null_ls.builtins.formatting.goimports}
+```
+`goimports` updates your Go import lines, adding missing ones and removing unreferenced ones. 
+
+- Filetypes: `{ "go" }`
+- Command: `goimports`
+- Arguments: `{}`
+
+#### [gofmt](https://pkg.go.dev/cmd/gofmt)
+
+```lua
+local sources = {null_ls.builtins.formatting.gofmt}
+```
+Gofmt formats Go programs. It uses tabs for indentation and blanks for alignment. Alignment assumes that an editor is using a fixed-width font. 
+
+- Filetypes: `{ "go" }`
+- Command: `gofmt`
+- Arguments: `{}`
+
+#### [gofumpt](https://github.com/mvdan/gofumpt)
+
+```lua
+local sources = {null_ls.builtins.formatting.gofumpt}
+```
+
+Enforce a stricter format than gofmt, while being backwards compatible. That is, gofumpt is happy with a subset of the formats that gofmt is happy with.
+
+- Filetypes: `{ "go" }`
+- Command: `gofumpt`
+- Arguments: `{}`
+
+#### [isort](https://github.com/PyCQA/isort)
+
+```lua
+local sources = {null_ls.builtins.formatting.isort}
+```
+
+isort is a Python utility / library to sort imports alphabetically, and automatically separated into sections and by type.
+
+- Filetypes: `{ "python" }`
+- Command: `isort`
+- Arguments: `{ "--stdout", "--profile", "black", "-" }`
+
+#### [json.tool](https://docs.python.org/3/library/json.html#module-json.tool)
+
+```lua
+local sources = {null_ls.builtins.formatting.json_tool}
+```
+
+The json.tool module provides a simple command line interface to validate and pretty-print JSON objects.
+
+- Filetypes: `{ "json" }`
+- Command: `python`
+- Arguments: `{ "-m", "json.tool" }`
 
 #### [LuaFormatter](https://github.com/Koihik/LuaFormatter)
 
@@ -78,6 +256,54 @@ local sources = {null_ls.builtins.formatting.lua_format}
 - Filetypes: `{ "lua" }`
 - Command: `lua-format`
 - Arguments: `{ "-i" }`
+
+#### [Mix](https://hexdocs.pm/mix/1.12/Mix.html)
+
+```lua
+local sources = {null_ls.builtins.formatting.mix}
+```
+
+Mix is a build tool that provides tasks for creating, compiling, and testing Elixir projects, managing its dependencies, and more.
+
+- Filetypes: `{ "elixir" }`
+- Command: `mix`
+- Arguments: `{ "format", "-" }`
+
+#### [Nginx Beautifier](https://github.com/vasilevich/nginxbeautifier)
+
+```lua
+local sources = {null_ls.builtins.formatting.nginx_beautifier}
+```
+
+This Javascript script beautifies and formats Nginx configuration files.
+
+- Filetypes: `{ "nginx" }`
+- Command: `nginxbeautifier`
+- Arguments: `{ "-i" }`
+
+#### [perltidy](http://perltidy.sourceforge.net/)
+
+```lua
+local sources = {null_ls.builtins.formatting.perltidy}
+```
+
+Perltidy is a Perl script which indents and reformats Perl scripts to make them easier to read. If you write Perl scripts, or spend much time reading them, you will probably find it useful.
+
+- Filetypes: `{ "perl" }`
+- Command: `perltidy`
+- Arguments: `{ "-q" }`
+
+#### [phpcbf](https://github.com/squizlabs/PHP_CodeSniffer)
+
+```lua
+local sources = {null_ls.builtins.formatting.phpcbf}
+```
+
+Tokenizes PHP files and detects violations of a defined set of coding standards.
+
+- Filetypes: `{ "php" }`
+- Command: `phpcbf`
+- Arguments: `{ "--standard=PSR12", "-" }`
 
 #### [Prettier](https://github.com/prettier/prettier)
 
@@ -115,18 +341,118 @@ filetypes.
 - Command: `prettierd`
 - Arguments: `{ "$FILENAME" }`
 
-#### [eslint_d](https://github.com/mantoni/eslint_d.js)
-
-An absurdly fast formatter (and linter). For full integration, check out
-[nvim-lsp-ts-utils](https://github.com/jose-elias-alvarez/nvim-lsp-ts-utils).
+#### [formatR](https://github.com/yihui/formatR)
 
 ```lua
-local sources = {null_ls.builtins.formatting.eslint_d}
+local sources = {null_ls.builtins.formatting.format_r}
 ```
 
-- Filetypes: `{ "javascript", "javascriptreact", "typescript", "typescriptreact" }`
-- Command: `eslint_d`
-- Arguments: ` { "--fix-to-stdout", "--stdin", "--stdin-filepath", "$FILENAME" }`
+Format R code automatically.
+
+- Filetypes: `{ "r", "rmd" }`
+- Command: `R`
+- Arguments: `{ 
+  "--slave",
+  "--no-restore",
+  "--no-save",
+  '-e "formatR::tidy_source(text=readr::read_file(file(\\"stdin\\")), arrow=FALSE)"'
+  }`
+
+#### [Rufo](https://github.com/ruby-formatter/rufo)
+
+```lua
+local sources = {null_ls.builtins.formatting.rufo}
+```
+
+Rufo is as an opinionated ruby formatter.
+
+- Filetypes: `{ "ruby" }`
+- Command: `rufo`
+- Arguments: `{ "-x" }`
+
+#### [rustfmt](https://github.com/rust-lang/rustfmt)
+
+```lua
+local sources = {null_ls.builtins.formatting.rustfmt}
+```
+
+A tool for formatting Rust code according to style guidelines.
+
+- Filetypes: `{ "rust" }`
+- Command: `rustfmt`
+- Arguments: `{ "--emit=stdout", "--edition=2018" }`
+
+#### [sqlformat](https://manpages.ubuntu.com/manpages/xenial/man1/sqlformat.1.html)
+
+```lua
+local sources = {null_ls.builtins.formatting.sqlformat}
+```
+
+The  `sqlformat` command-line tool can be used to reformat SQL file according to specified options.
+
+- Filetypes: `{ "sql" }`
+- Command: `sqlformat`
+- Arguments: `{ "--reindent", "-" }`
+
+#### [scalafmt](https://github.com/scalameta/scalafmt)
+
+```lua
+local sources = {null_ls.builtins.formatting.scalafmt}
+```
+
+Code formatter for Scala
+
+- Filetypes: `{ "scala" }`
+- Command: `scalafmt`
+- Arguments: `{ "--stdin" }`
+
+#### [shfmt](https://github.com/mvdan/sh)
+
+```lua
+local sources = {null_ls.builtins.formatting.shfmt}
+```
+
+A shell parser, formatter, and interpreter with bash support
+
+- Filetypes: `{ "sh" }`
+- Command: `shfmt`
+- Arguments: `{}`
+
+#### [StyLua](https://github.com/JohnnyMorganz/StyLua)
+
+```lua
+local sources = {null_ls.builtins.formatting.stylua}
+```
+
+A fast and opinionated Lua formatter written in Rust. Highly recommended!
+
+- Filetypes: `{ "lua" }`
+- Command: `stylua`
+- Arguments: `{ "-" }`
+
+#### [swfitformat](https://github.com/nicklockwood/SwiftFormat)
+
+```lua
+local sources = {null_ls.builtins.formatting.swiftformat}
+```
+
+SwiftFormat is a code library and command-line tool for reformatting Swift code on macOS or Linux.
+
+- Filetypes: `{ "swift" }`
+- Command: `swiftformat`
+- Arguments: `{}`
+
+#### [terraform_fmt](https://www.terraform.io/docs/cli/commands/fmt.html)
+
+```lua
+local sources = {null_ls.builtins.formatting.terraform_fmt}
+```
+
+The terraform fmt command is used to rewrite Terraform configuration files to a canonical format and style. 
+
+- Filetypes: `{ "tf", "hcl" }`
+- Command: `terraform`
+- Arguments: `{ "fmt", "-" }`
 
 #### trim_whitespace
 
@@ -139,6 +465,30 @@ local sources = { null_ls.builtins.formatting.trim_whitespace.with({ filetypes =
 - Filetypes: none (must specify in `with()`, as above)
 - Command: `awk`
 - Arguments: `{ '{ sub(/[ \t]+$/, ""); print }' }`
+
+#### [uncrustify](https://github.com/uncrustify/uncrustify)
+
+```lua
+local sources = {null_ls.builtins.formatting.uncrustify}
+```
+
+A source code beautifier for C, C++, C#, ObjectiveC, D, Java, Pawn and VALA.
+
+- Filetypes: `{ "c", "cpp", "cs", "java" }`
+- Command: `uncrustify`
+- Arguments: `{ "-q", "-l <LANG>" }`
+
+#### [yapf](https://github.com/google/yapf)
+
+```lua
+local sources = {null_ls.builtins.formatting.yapf}
+```
+
+A formatter for Python files
+
+- Filetypes: `{ "python" }`
+- Command: `yapf`
+- Arguments: `{ "--quiet" }`
 
 ### Diagnostics
 

--- a/lua/null-ls/builtins/formatting.lua
+++ b/lua/null-ls/builtins/formatting.lua
@@ -143,6 +143,17 @@ M.eslint_d = h.make_builtin({
     factory = h.formatter_factory,
 })
 
+M.erl_fmt = h.make_builtin({
+    method = FORMATTING,
+    filetypes = { "erlang" },
+    generator_opts = {
+        command = "erlfmt",
+        args = { "-" },
+        to_stdin = true,
+    },
+    factory = h.formatter_factory,
+})
+
 M.goimports = h.make_builtin({
     method = FORMATTING,
     filetypes = { "go" },

--- a/lua/null-ls/builtins/formatting.lua
+++ b/lua/null-ls/builtins/formatting.lua
@@ -55,6 +55,19 @@ M.isort = h.make_builtin({
     factory = h.formatter_factory,
 })
 
+M.yapf = h.make_builtin({
+    method = FORMATTING,
+    filetypes = { "python" },
+    generator_opts = {
+        command = "yapf",
+        args = {
+            "--quiet",
+        },
+        to_stdin = true,
+    },
+    factory = h.formatter_factory,
+})
+
 local get_prettier_generator_args = function(common_args)
     return function(params)
         local args = vim.deepcopy(common_args)
@@ -163,6 +176,20 @@ M.trim_whitespace = h.make_builtin({
     generator_opts = {
         command = "awk",
         args = { '{ sub(/[ \t]+$/, ""); print }' },
+        to_stdin = true,
+    },
+    factory = h.formatter_factory,
+})
+
+M.terraform = h.make_builtin({
+    method = FORMATTING,
+    filetypes = { "tf", "hcl" },
+    generator_opts = {
+        command = "terraform",
+        args = {
+            "fmt",
+            "-",
+        },
         to_stdin = true,
     },
     factory = h.formatter_factory,

--- a/lua/null-ls/builtins/formatting.lua
+++ b/lua/null-ls/builtins/formatting.lua
@@ -40,6 +40,11 @@ local function get_uncrustify_args()
     return { "-q", format_type }
 end
 
+local function get_clang_format_args()
+    local assume_filename = "-assume-filename=" .. vim.fn.expand("%:t")
+    return { assume_filename }
+end
+
 M.asmfmt = h.make_builtin({
     method = FORMATTING,
     filetypes = { "asm" },
@@ -72,6 +77,17 @@ M.black = h.make_builtin({
             "--fast",
             "-",
         },
+        to_stdin = true,
+    },
+    factory = h.formatter_factory,
+})
+
+M.clang_format = h.make_builtin({
+    method = FORMATTING,
+    filetypes = { "c", "cpp", "cs", "java" },
+    generator_opts = {
+        command = "clang-format",
+        args = get_clang_format_args(),
         to_stdin = true,
     },
     factory = h.formatter_factory,

--- a/lua/null-ls/builtins/formatting.lua
+++ b/lua/null-ls/builtins/formatting.lua
@@ -376,6 +376,17 @@ M.rustfmt = h.make_builtin({
     factory = h.formatter_factory,
 })
 
+M.sql_fmt = h.make_builtin({
+    method = FORMATTING,
+    filetypes = { "sql" },
+    generator_opts = {
+        command = "sqlfmt",
+        args = {},
+        to_stdin = true,
+    },
+    factory = h.formatter_factory,
+})
+
 M.scalafmt = h.make_builtin({
     method = FORMATTING,
     filetypes = { "scala" },

--- a/lua/null-ls/builtins/formatting.lua
+++ b/lua/null-ls/builtins/formatting.lua
@@ -83,6 +83,17 @@ M.cmake_format = h.make_builtin({
     factory = h.formatter_factory,
 })
 
+M.crystal_format = h.make_builtin({
+    method = FORMATTING,
+    filetypes = { "crystal" },
+    generator_opts = {
+        command = "crystal",
+        args = { "tool", "format" },
+        to_stdin = true,
+    },
+    factory = h.formatter_factory,
+})
+
 M.dart_format = h.make_builtin({
     method = FORMATTING,
     filetypes = { "dart" },

--- a/lua/null-ls/builtins/formatting.lua
+++ b/lua/null-ls/builtins/formatting.lua
@@ -151,6 +151,17 @@ M.prettier_d_slim = h.make_builtin({
     factory = h.formatter_factory,
 })
 
+M.scalafmt = h.make_builtin({
+    method = FORMATTING,
+    filetypes = { "scala" },
+    generator_opts = {
+        command = "scalafmt",
+        args = { "--stdin" },
+        to_stdin = true,
+    },
+    factory = h.formatter_factory,
+})
+
 M.shfmt = h.make_builtin({
     method = FORMATTING,
     filetypes = {
@@ -170,7 +181,7 @@ M.stylua = h.make_builtin({
     factory = h.formatter_factory,
 })
 
-M.swift = h.make_builtin({
+M.swiftformat = h.make_builtin({
     method = FORMATTING,
     filetypes = { "swift" },
     generator_opts = {

--- a/lua/null-ls/builtins/formatting.lua
+++ b/lua/null-ls/builtins/formatting.lua
@@ -66,6 +66,50 @@ M.eslint_d = h.make_builtin({
     factory = h.formatter_factory,
 })
 
+M.goimports = h.make_builtin({
+    method = FORMATTING,
+    filetypes = { "go" },
+    generator_opts = {
+        command = "goimports",
+        args = {},
+        to_stdin = true,
+    },
+    factory = h.formatter_factory,
+})
+
+M.gofmt = h.make_builtin({
+    method = FORMATTING,
+    filetypes = { "go" },
+    generator_opts = {
+        command = "gofmt",
+        args = {},
+        to_stdin = true,
+    },
+    factory = h.formatter_factory,
+})
+
+M.gofumports = h.make_builtin({
+    method = FORMATTING,
+    filetypes = { "go" },
+    generator_opts = {
+        command = "gofumports",
+        args = {},
+        to_stdin = true,
+    },
+    factory = h.formatter_factory,
+})
+
+M.gofumpt = h.make_builtin({
+    method = FORMATTING,
+    filetypes = { "go" },
+    generator_opts = {
+        command = "gofumpt",
+        args = {},
+        to_stdin = true,
+    },
+    factory = h.formatter_factory,
+})
+
 M.isort = h.make_builtin({
     method = FORMATTING,
     filetypes = { "python" },

--- a/lua/null-ls/builtins/formatting.lua
+++ b/lua/null-ls/builtins/formatting.lua
@@ -139,6 +139,7 @@ M.eslint_d = h.make_builtin({
         "javascriptreact",
         "typescript",
         "typescriptreact",
+        "vue",
     },
     generator_opts = {
         command = "eslint_d",

--- a/lua/null-ls/builtins/formatting.lua
+++ b/lua/null-ls/builtins/formatting.lua
@@ -176,6 +176,17 @@ M.erlfmt = h.make_builtin({
     factory = h.formatter_factory,
 })
 
+M.fish_indent = h.make_builtin({
+    method = FORMATTING,
+    filetypes = { "fish" },
+    generator_opts = {
+        command = "fish_indent",
+        args = {},
+        to_stdin = true,
+    },
+    factory = h.formatter_factory,
+})
+
 M.format_r = h.make_builtin({
     method = FORMATTING,
     filetypes = { "r", "rmd" },

--- a/lua/null-ls/builtins/formatting.lua
+++ b/lua/null-ls/builtins/formatting.lua
@@ -72,6 +72,17 @@ M.black = h.make_builtin({
     factory = h.formatter_factory,
 })
 
+M.cmake_format = h.make_builtin({
+    method = FORMATTING,
+    filetypes = { "cmake" },
+    generator_opts = {
+        command = "cmake-format",
+        args = { "-" },
+        to_stdin = true,
+    },
+    factory = h.formatter_factory,
+})
+
 M.dart_format = h.make_builtin({
     method = FORMATTING,
     filetypes = { "dart" },

--- a/lua/null-ls/builtins/formatting.lua
+++ b/lua/null-ls/builtins/formatting.lua
@@ -247,6 +247,17 @@ M.mix = h.make_builtin({
     factory = h.formatter_factory,
 })
 
+M.nginx_beautifier = h.make_builtin({
+    method = FORMATTING,
+    filetypes = { "nginx" },
+    generator_opts = {
+        command = "nginxbeautifier",
+        args = { "-i" },
+        to_stdin = true,
+    },
+    factory = h.formatter_factory,
+})
+
 M.phpcbf = h.make_builtin({
     method = FORMATTING,
     filetypes = { "php" },

--- a/lua/null-ls/builtins/formatting.lua
+++ b/lua/null-ls/builtins/formatting.lua
@@ -151,6 +151,17 @@ M.prettier_d_slim = h.make_builtin({
     factory = h.formatter_factory,
 })
 
+M.rustfmt = h.make_builtin({
+    method = FORMATTING,
+    filetypes = { "rust" },
+    generator_opts = {
+        command = "rustfmt",
+        args = { "--emit=stdout", "--edition=2018" },
+        to_stdin = true,
+    },
+    factory = h.formatter_factory,
+})
+
 M.scalafmt = h.make_builtin({
     method = FORMATTING,
     filetypes = { "scala" },

--- a/lua/null-ls/builtins/formatting.lua
+++ b/lua/null-ls/builtins/formatting.lua
@@ -35,6 +35,17 @@ local get_prettier_generator_args = function(common_args)
     end
 end
 
+M.asmfmt = h.make_builtin({
+    method = FORMATTING,
+    filetypes = { "asm" },
+    generator_opts = {
+        command = "asmfmt",
+        args = {},
+        to_stdin = true,
+    },
+    factory = h.formatter_factory,
+})
+
 M.black = h.make_builtin({
     method = FORMATTING,
     filetypes = { "python" },

--- a/lua/null-ls/builtins/formatting.lua
+++ b/lua/null-ls/builtins/formatting.lua
@@ -82,6 +82,17 @@ M.isort = h.make_builtin({
     factory = h.formatter_factory,
 })
 
+M.json_tool = h.make_builtin({
+    method = FORMATTING,
+    filetypes = { "json" },
+    generator_opts = {
+        command = "python",
+        args = { "-m", "json.tool" },
+        to_stdin = true,
+    },
+    factory = h.formatter_factory,
+})
+
 M.lua_format = h.make_builtin({
     method = FORMATTING,
     filetypes = { "lua" },

--- a/lua/null-ls/builtins/formatting.lua
+++ b/lua/null-ls/builtins/formatting.lua
@@ -50,6 +50,17 @@ M.black = h.make_builtin({
     factory = h.formatter_factory,
 })
 
+M.dart_format = h.make_builtin({
+    method = FORMATTING,
+    filetypes = { "dart" },
+    generator_opts = {
+        command = "dart",
+        args = { "format" },
+        to_stdin = true,
+    },
+    factory = h.formatter_factory,
+})
+
 M.eslint_d = h.make_builtin({
     method = FORMATTING,
     filetypes = {
@@ -307,7 +318,7 @@ M.swiftformat = h.make_builtin({
     factory = h.formatter_factory,
 })
 
-M.terraform = h.make_builtin({
+M.terraform_fmt = h.make_builtin({
     method = FORMATTING,
     filetypes = { "tf", "hcl" },
     generator_opts = {

--- a/lua/null-ls/builtins/formatting.lua
+++ b/lua/null-ls/builtins/formatting.lua
@@ -93,6 +93,17 @@ M.lua_format = h.make_builtin({
     factory = h.formatter_factory,
 })
 
+M.phpcbf = h.make_builtin({
+    method = FORMATTING,
+    filetypes = { "php" },
+    generator_opts = {
+        command = "phpcbf",
+        args = { "--standard=PSR12", "-" },
+        to_stdin = true,
+    },
+    factory = h.formatter_factory,
+})
+
 M.prettier = h.make_builtin({
     method = { FORMATTING, RANGE_FORMATTING },
     filetypes = {

--- a/lua/null-ls/builtins/formatting.lua
+++ b/lua/null-ls/builtins/formatting.lua
@@ -94,6 +94,17 @@ M.crystal_format = h.make_builtin({
     factory = h.formatter_factory,
 })
 
+M.dfmt = h.make_builtin({
+    method = FORMATTING,
+    filetypes = { "d" },
+    generator_opts = {
+        command = "dfmt",
+        args = {},
+        to_stdin = true,
+    },
+    factory = h.formatter_factory,
+})
+
 M.dart_format = h.make_builtin({
     method = FORMATTING,
     filetypes = { "dart" },

--- a/lua/null-ls/builtins/formatting.lua
+++ b/lua/null-ls/builtins/formatting.lua
@@ -148,6 +148,17 @@ M.lua_format = h.make_builtin({
     factory = h.formatter_factory,
 })
 
+M.mix = h.make_builtin({
+    method = FORMATTING,
+    filetypes = { "elixir" },
+    generator_opts = {
+        command = "mix",
+        args = { "format" },
+        to_stdin = true,
+    },
+    factory = h.formatter_factory,
+})
+
 M.phpcbf = h.make_builtin({
     method = FORMATTING,
     filetypes = { "php" },

--- a/lua/null-ls/builtins/formatting.lua
+++ b/lua/null-ls/builtins/formatting.lua
@@ -258,6 +258,17 @@ M.nginx_beautifier = h.make_builtin({
     factory = h.formatter_factory,
 })
 
+M.perl_tidy = h.make_builtin({
+    method = FORMATTING,
+    filetypes = { "perl" },
+    generator_opts = {
+        command = "perltidy",
+        args = { "-q" },
+        to_stdin = true,
+    },
+    factory = h.formatter_factory,
+})
+
 M.phpcbf = h.make_builtin({
     method = FORMATTING,
     filetypes = { "php" },

--- a/lua/null-ls/builtins/formatting.lua
+++ b/lua/null-ls/builtins/formatting.lua
@@ -6,68 +6,6 @@ local RANGE_FORMATTING = methods.internal.RANGE_FORMATTING
 
 local M = {}
 
-M.lua_format = h.make_builtin({
-    method = FORMATTING,
-    filetypes = { "lua" },
-    generator_opts = {
-        command = "lua-format",
-        args = { "-i" },
-        to_stdin = true,
-    },
-    factory = h.formatter_factory,
-})
-
-M.stylua = h.make_builtin({
-    method = FORMATTING,
-    filetypes = { "lua" },
-    generator_opts = { command = "stylua", args = { "-s", "-" }, to_stdin = true },
-    factory = h.formatter_factory,
-})
-
-M.black = h.make_builtin({
-    method = FORMATTING,
-    filetypes = { "python" },
-    generator_opts = {
-        command = "black",
-        args = {
-            "--quiet",
-            "--fast",
-            "-",
-        },
-        to_stdin = true,
-    },
-    factory = h.formatter_factory,
-})
-
-M.isort = h.make_builtin({
-    method = FORMATTING,
-    filetypes = { "python" },
-    generator_opts = {
-        command = "isort",
-        args = {
-            "--stdout",
-            "--profile",
-            "black",
-            "-",
-        },
-        to_stdin = true,
-    },
-    factory = h.formatter_factory,
-})
-
-M.yapf = h.make_builtin({
-    method = FORMATTING,
-    filetypes = { "python" },
-    generator_opts = {
-        command = "yapf",
-        args = {
-            "--quiet",
-        },
-        to_stdin = true,
-    },
-    factory = h.formatter_factory,
-})
-
 local get_prettier_generator_args = function(common_args)
     return function(params)
         local args = vim.deepcopy(common_args)
@@ -96,6 +34,64 @@ local get_prettier_generator_args = function(common_args)
         return args
     end
 end
+
+M.black = h.make_builtin({
+    method = FORMATTING,
+    filetypes = { "python" },
+    generator_opts = {
+        command = "black",
+        args = {
+            "--quiet",
+            "--fast",
+            "-",
+        },
+        to_stdin = true,
+    },
+    factory = h.formatter_factory,
+})
+
+M.eslint_d = h.make_builtin({
+    method = FORMATTING,
+    filetypes = {
+        "javascript",
+        "javascriptreact",
+        "typescript",
+        "typescriptreact",
+    },
+    generator_opts = {
+        command = "eslint_d",
+        args = { "--fix-to-stdout", "--stdin", "--stdin-filename", "$FILENAME" },
+        to_stdin = true,
+    },
+    factory = h.formatter_factory,
+})
+
+M.isort = h.make_builtin({
+    method = FORMATTING,
+    filetypes = { "python" },
+    generator_opts = {
+        command = "isort",
+        args = {
+            "--stdout",
+            "--profile",
+            "black",
+            "-",
+        },
+        to_stdin = true,
+    },
+    factory = h.formatter_factory,
+})
+
+M.lua_format = h.make_builtin({
+    method = FORMATTING,
+    filetypes = { "lua" },
+    generator_opts = {
+        command = "lua-format",
+        args = { "-i" },
+        to_stdin = true,
+    },
+    factory = h.formatter_factory,
+})
 
 M.prettier = h.make_builtin({
     method = { FORMATTING, RANGE_FORMATTING },
@@ -155,27 +151,31 @@ M.prettier_d_slim = h.make_builtin({
     factory = h.formatter_factory,
 })
 
-M.eslint_d = h.make_builtin({
+M.shfmt = h.make_builtin({
     method = FORMATTING,
     filetypes = {
-        "javascript",
-        "javascriptreact",
-        "typescript",
-        "typescriptreact",
+        "sh",
     },
     generator_opts = {
-        command = "eslint_d",
-        args = { "--fix-to-stdout", "--stdin", "--stdin-filename", "$FILENAME" },
+        command = "shfmt",
         to_stdin = true,
     },
     factory = h.formatter_factory,
 })
 
-M.trim_whitespace = h.make_builtin({
+M.stylua = h.make_builtin({
     method = FORMATTING,
+    filetypes = { "lua" },
+    generator_opts = { command = "stylua", args = { "-s", "-" }, to_stdin = true },
+    factory = h.formatter_factory,
+})
+
+M.swift = h.make_builtin({
+    method = FORMATTING,
+    filetypes = { "swift" },
     generator_opts = {
-        command = "awk",
-        args = { '{ sub(/[ \t]+$/, ""); print }' },
+        command = "swiftformat",
+        args = {},
         to_stdin = true,
     },
     factory = h.formatter_factory,
@@ -195,13 +195,24 @@ M.terraform = h.make_builtin({
     factory = h.formatter_factory,
 })
 
-M.shfmt = h.make_builtin({
+M.trim_whitespace = h.make_builtin({
     method = FORMATTING,
-    filetypes = {
-        "sh",
-    },
     generator_opts = {
-        command = "shfmt",
+        command = "awk",
+        args = { '{ sub(/[ \t]+$/, ""); print }' },
+        to_stdin = true,
+    },
+    factory = h.formatter_factory,
+})
+
+M.yapf = h.make_builtin({
+    method = FORMATTING,
+    filetypes = { "python" },
+    generator_opts = {
+        command = "yapf",
+        args = {
+            "--quiet",
+        },
         to_stdin = true,
     },
     factory = h.formatter_factory,

--- a/lua/null-ls/builtins/formatting.lua
+++ b/lua/null-ls/builtins/formatting.lua
@@ -151,6 +151,22 @@ M.prettier_d_slim = h.make_builtin({
     factory = h.formatter_factory,
 })
 
+M.r_tidy = h.make_builtin({
+    method = FORMATTING,
+    filetypes = { "r", "rmd" },
+    generator_opts = {
+        command = "R",
+        args = {
+            "--slave",
+            "--no-restore",
+            "--no-save",
+            '-e "formatR::tidy_source(text=readr::read_file(file(\\"stdin\\")), arrow=FALSE)"',
+        },
+        to_stdin = true,
+    },
+    factory = h.formatter_factory,
+})
+
 M.rufo = h.make_builtin({
     method = FORMATTING,
     filetypes = { "ruby" },

--- a/lua/null-ls/builtins/formatting.lua
+++ b/lua/null-ls/builtins/formatting.lua
@@ -40,11 +40,6 @@ local function get_uncrustify_args()
     return { "-q", format_type }
 end
 
-local function get_clang_format_args()
-    local assume_filename = "-assume-filename=" .. vim.fn.expand("%:t")
-    return { assume_filename }
-end
-
 M.asmfmt = h.make_builtin({
     method = FORMATTING,
     filetypes = { "asm" },
@@ -87,7 +82,7 @@ M.clang_format = h.make_builtin({
     filetypes = { "c", "cpp", "cs", "java" },
     generator_opts = {
         command = "clang-format",
-        args = get_clang_format_args(),
+        args = { "-assume-filename=" .. vim.fn.expand("%:t") },
         to_stdin = true,
     },
     factory = h.formatter_factory,

--- a/lua/null-ls/builtins/formatting.lua
+++ b/lua/null-ls/builtins/formatting.lua
@@ -35,6 +35,11 @@ local get_prettier_generator_args = function(common_args)
     end
 end
 
+local function get_uncrustify_args()
+    local format_type = "-l " .. vim.bo.filetype:upper()
+    return { "-q", format_type }
+end
+
 M.asmfmt = h.make_builtin({
     method = FORMATTING,
     filetypes = { "asm" },
@@ -447,6 +452,17 @@ M.trim_whitespace = h.make_builtin({
     generator_opts = {
         command = "awk",
         args = { '{ sub(/[ \t]+$/, ""); print }' },
+        to_stdin = true,
+    },
+    factory = h.formatter_factory,
+})
+
+M.uncrustify = h.make_builtin({
+    method = FORMATTING,
+    filetypes = { "c", "cpp", "cs", "java" },
+    generator_opts = {
+        command = "uncrustify",
+        args = get_uncrustify_args(),
         to_stdin = true,
     },
     factory = h.formatter_factory,

--- a/lua/null-ls/builtins/formatting.lua
+++ b/lua/null-ls/builtins/formatting.lua
@@ -165,12 +165,28 @@ M.eslint_d = h.make_builtin({
     factory = h.formatter_factory,
 })
 
-M.erl_fmt = h.make_builtin({
+M.erlfmt = h.make_builtin({
     method = FORMATTING,
     filetypes = { "erlang" },
     generator_opts = {
         command = "erlfmt",
         args = { "-" },
+        to_stdin = true,
+    },
+    factory = h.formatter_factory,
+})
+
+M.format_r = h.make_builtin({
+    method = FORMATTING,
+    filetypes = { "r", "rmd" },
+    generator_opts = {
+        command = "R",
+        args = {
+            "--slave",
+            "--no-restore",
+            "--no-save",
+            '-e "formatR::tidy_source(text=readr::read_file(file(\\"stdin\\")), arrow=FALSE)"',
+        },
         to_stdin = true,
     },
     factory = h.formatter_factory,
@@ -192,17 +208,6 @@ M.gofmt = h.make_builtin({
     filetypes = { "go" },
     generator_opts = {
         command = "gofmt",
-        args = {},
-        to_stdin = true,
-    },
-    factory = h.formatter_factory,
-})
-
-M.gofumports = h.make_builtin({
-    method = FORMATTING,
-    filetypes = { "go" },
-    generator_opts = {
-        command = "gofumports",
         args = {},
         to_stdin = true,
     },
@@ -280,7 +285,7 @@ M.nginx_beautifier = h.make_builtin({
     factory = h.formatter_factory,
 })
 
-M.perl_tidy = h.make_builtin({
+M.perltidy = h.make_builtin({
     method = FORMATTING,
     filetypes = { "perl" },
     generator_opts = {
@@ -360,22 +365,6 @@ M.prettier_d_slim = h.make_builtin({
     factory = h.formatter_factory,
 })
 
-M.r_tidy = h.make_builtin({
-    method = FORMATTING,
-    filetypes = { "r", "rmd" },
-    generator_opts = {
-        command = "R",
-        args = {
-            "--slave",
-            "--no-restore",
-            "--no-save",
-            '-e "formatR::tidy_source(text=readr::read_file(file(\\"stdin\\")), arrow=FALSE)"',
-        },
-        to_stdin = true,
-    },
-    factory = h.formatter_factory,
-})
-
 M.rufo = h.make_builtin({
     method = FORMATTING,
     filetypes = { "ruby" },
@@ -398,12 +387,12 @@ M.rustfmt = h.make_builtin({
     factory = h.formatter_factory,
 })
 
-M.sql_fmt = h.make_builtin({
+M.sqlformat = h.make_builtin({
     method = FORMATTING,
     filetypes = { "sql" },
     generator_opts = {
-        command = "sqlfmt",
-        args = {},
+        command = "sqlformat",
+        args = { "--reindent", "-" },
         to_stdin = true,
     },
     factory = h.formatter_factory,

--- a/lua/null-ls/builtins/formatting.lua
+++ b/lua/null-ls/builtins/formatting.lua
@@ -46,6 +46,17 @@ M.asmfmt = h.make_builtin({
     factory = h.formatter_factory,
 })
 
+M.bean_format = h.make_builtin({
+    method = FORMATTING,
+    filetypes = { "beancount" },
+    generator_opts = {
+        command = "bean-format",
+        args = {},
+        to_stdin = true,
+    },
+    factory = h.formatter_factory,
+})
+
 M.black = h.make_builtin({
     method = FORMATTING,
     filetypes = { "python" },

--- a/lua/null-ls/builtins/formatting.lua
+++ b/lua/null-ls/builtins/formatting.lua
@@ -151,6 +151,17 @@ M.prettier_d_slim = h.make_builtin({
     factory = h.formatter_factory,
 })
 
+M.rufo = h.make_builtin({
+    method = FORMATTING,
+    filetypes = { "ruby" },
+    generator_opts = {
+        command = "rufo",
+        args = { "-x" },
+        to_stdin = true,
+    },
+    factory = h.formatter_factory,
+})
+
 M.rustfmt = h.make_builtin({
     method = FORMATTING,
     filetypes = { "rust" },

--- a/lua/null-ls/builtins/formatting.lua
+++ b/lua/null-ls/builtins/formatting.lua
@@ -116,6 +116,17 @@ M.dart_format = h.make_builtin({
     factory = h.formatter_factory,
 })
 
+M.elm_format = h.make_builtin({
+    method = FORMATTING,
+    filetypes = { "elm" },
+    generator_opts = {
+        command = "elm-format",
+        args = { "--stdin", "--elm-version=0.19" },
+        to_stdin = true,
+    },
+    factory = h.formatter_factory,
+})
+
 M.eslint_d = h.make_builtin({
     method = FORMATTING,
     filetypes = {
@@ -219,7 +230,7 @@ M.mix = h.make_builtin({
     filetypes = { "elixir" },
     generator_opts = {
         command = "mix",
-        args = { "format" },
+        args = { "format", "-" },
         to_stdin = true,
     },
     factory = h.formatter_factory,


### PR DESCRIPTION
Fixes #50
Fixes #52 

also sorted the formatters, hope you don't mind :sweat_smile: 

- **c, cpp, cs, java**
  - [x] clang-format
  - [x] uncrustify
- **asm**
  - [x] asmfmt
- **beancount**
  - [x] bean-format
- **cmake**
  - [x] cmake-format
- **crystal**
  - [x] crystal tool format
- **d**
  - [x] dfmt
- **dart**
  - [x] dart format
- **elixir**
  - [x] mix
- **elm**
  - [x] elm-format
- **erlang**
  - [x] erlfmt
- **fish**
  - [x] fish_indent
- **go**
  - [x] goimports
  - [x] gofmt
  - [x] gofumpt
- **json**
  - [x] python json_tool
- **nginx**
  - [x] nginxbeautifier
- **perl**
  - [x] perltidy
- **php**
  - [x] phpcbf
- **python**
  - [x] yapf
- **r**
  - [x] tidy_source
- **ruby**
  - [x] rufo
- **rust**
  - [x] rustfmt
- **scala**
  - [x] scalafmt
- **sql**
  - [x] sqlformat
- **swift**
  - [x] swiftformat
- **terraform**
  - [x] terraformt-fmt
- **vue**
  - [x] eslint_d