### PR TITLE
Expose reusable function

### DIFF
--- a/lua/null-ls/code-actions.lua
+++ b/lua/null-ls/code-actions.lua
@@ -26,13 +26,17 @@ M.handler = function(method, original_params, handler)
         original_params.bufnr = bufnr
 
         s.clear_actions()
-        generators.run(u.make_params(original_params, methods.internal.CODE_ACTION), postprocess, function(actions)
-            -- sort actions on title
-            table.sort(actions, function(a, b)
-                return a.title < b.title
-            end)
-            handler(actions)
-        end)
+        generators.run_registered(
+            u.make_params(original_params, methods.internal.CODE_ACTION),
+            postprocess,
+            function(actions)
+                -- sort actions on title
+                table.sort(actions, function(a, b)
+                    return a.title < b.title
+                end)
+                handler(actions)
+            end
+        )
         original_params._null_ls_handled = true
     end
 

--- a/lua/null-ls/diagnostics.lua
+++ b/lua/null-ls/diagnostics.lua
@@ -37,12 +37,16 @@ M.handler = function(original_params)
     end
 
     original_params.bufnr = vim.uri_to_bufnr(uri)
-    generators.run(u.make_params(original_params, methods.internal.DIAGNOSTICS), postprocess, function(diagnostics)
-        vim.lsp.handlers[methods.lsp.PUBLISH_DIAGNOSTICS](nil, nil, {
-            diagnostics = diagnostics,
-            uri = uri,
-        }, original_params.client_id, nil, {})
-    end)
+    generators.run_registered(
+        u.make_params(original_params, methods.internal.DIAGNOSTICS),
+        postprocess,
+        function(diagnostics)
+            vim.lsp.handlers[methods.lsp.PUBLISH_DIAGNOSTICS](nil, nil, {
+                diagnostics = diagnostics,
+                uri = uri,
+            }, original_params.client_id, nil, {})
+        end
+    )
 end
 
 return M

--- a/lua/null-ls/formatting.lua
+++ b/lua/null-ls/formatting.lua
@@ -90,7 +90,7 @@ M.handler = function(method, original_params, handler)
         u.debug_log("received LSP formatting request")
 
         original_params.bufnr = bufnr
-        generators.run(u.make_params(original_params, methods.internal.FORMATTING), nil, apply_edits)
+        generators.run_registered(u.make_params(original_params, methods.internal.FORMATTING), nil, apply_edits)
 
         original_params._null_ls_handled = true
     end
@@ -99,7 +99,7 @@ M.handler = function(method, original_params, handler)
         u.debug_log("received LSP rangeFormatting request")
 
         original_params.bufnr = bufnr
-        generators.run(u.make_params(original_params, methods.internal.RANGE_FORMATTING), nil, apply_edits)
+        generators.run_registered(u.make_params(original_params, methods.internal.RANGE_FORMATTING), nil, apply_edits)
 
         original_params._null_ls_handled = true
     end

--- a/lua/null-ls/generators.lua
+++ b/lua/null-ls/generators.lua
@@ -3,14 +3,13 @@ local u = require("null-ls.utils")
 
 local M = {}
 
-M.run = function(params, postprocess, callback)
+M.run = function(generators, params, postprocess, callback)
     -- NOTE: avoid importing plenary elsewhere to limit server dependencies
     local a = require("plenary.async_lib")
 
     local runner = a.async(function()
         u.debug_log("running generators for method " .. params.method)
 
-        local generators = c.generators(params.method)
         if not generators then
             u.debug_log("no generators registered")
             return {}
@@ -54,6 +53,11 @@ M.run = function(params, postprocess, callback)
     a.run(runner(), function(results)
         callback(results, params)
     end)
+end
+
+M.run_registered = function(params, postprocess, callback)
+    local generators = c.generators(params.method)
+    M.run(generators, params, postprocess, callback)
 end
 
 M.can_run = function(filetype, method)

--- a/test/spec/generators_spec.lua
+++ b/test/spec/generators_spec.lua
@@ -65,7 +65,7 @@ describe("generators", function()
             end,
         }
 
-        local wrapped_run = a.wrap(generators.run, 3)
+        local wrapped_run = a.wrap(generators.run_registered, 3)
 
         it("should immediately return when method has no registered generators", function()
             register(method, mock_sync_generator)


### PR DESCRIPTION
Exposes two functions:

- `require("null-ls.formatting").apply_edits`
- `require("null-ls.generators").run`

With this change, plugins built on top of `null-ls` will be able to use these as utility functions even if they don't want to use the LSP setup. For example:

- Provide command/keymaps to run formatters bypassing the LSP stuffs.