### PR TITLE
Consolidate range conversion

### DIFF
--- a/doc/MAIN.md
+++ b/doc/MAIN.md
@@ -243,11 +243,12 @@ callbacks are schedule-wrapped, making it safe to call any API function.
 #### Diagnostics
 
 ```lua
+-- null-ls assumes ranges are 1-indexed, so sources should offset if not
 return { {
-    row, -- number, optional (defaults to 0)
-    col, -- number, optional (defaults to 0)
-    end_row, -- number, optional (defaults to row value)
-    end_col, -- number, optional (defaults to -1),
+    row, -- number, optional (defaults to first line)
+    col, -- number, optional (defaults to beginning of line)
+    end_row, -- number, optional (defaults to row)
+    end_col, -- number, optional (defaults to end of line),
     source, -- string, optional (defaults to "null-ls")
     message, -- string
     severity, -- 1 (error), 2 (warning), 3 (information), 4 (hint)
@@ -261,10 +262,10 @@ them in the editor.
 
 ```lua
 return { {
-    row, -- number, optional (defaults to 0)
-    col, -- number, optional (defaults to 0)
-    end_row, -- number, optional (defaults to row value)
-    end_col, -- number, optional (defaults to -1),
+    row, -- number, optional (see diagnostics for defaults)
+    col, -- number, optional
+    end_row, -- number, optional
+    end_col, -- number, optional
     text, -- string
 } }
 ```

--- a/lua/null-ls/builtins/diagnostics.lua
+++ b/lua/null-ls/builtins/diagnostics.lua
@@ -90,7 +90,7 @@ local from_pattern = function(pattern, groups, overrides)
     overrides = overrides or {}
     local severities = vim.tbl_extend("force", default_severities, overrides.severities or {})
     local defaults = overrides.diagnostic or {}
-    defaults.source = source
+    local offsets = overrides.offsets or {}
     local attr_adapters = make_attr_adapters(severities, overrides.adapters or {})
 
     return function(line, params)
@@ -101,7 +101,7 @@ local from_pattern = function(pattern, groups, overrides)
             entries[groups[i]] = match
         end
 
-        return make_diagnostic(entries, defaults, attr_adapters, params, overrides.offsets or {})
+        return make_diagnostic(entries, defaults, attr_adapters, params, offsets)
     end
 end
 
@@ -137,7 +137,7 @@ local from_json = function(overrides)
     local attributes = vim.tbl_extend("force", default_json_attributes, overrides.attributes or {})
     local severities = vim.tbl_extend("force", default_severities, overrides.severities or {})
     local defaults = overrides.diagnostic or {}
-    defaults.source = source
+    local offsets = overrides.offsets or {}
     local attr_adapters = make_attr_adapters(severities, overrides.adapters or {})
 
     return function(params)
@@ -148,7 +148,7 @@ local from_json = function(overrides)
                 entries[attr] = json_diagnostic[json_key]
             end
 
-            local diagnostic = make_diagnostic(entries, defaults, attr_adapters, params, overrides.offsets or {})
+            local diagnostic = make_diagnostic(entries, defaults, attr_adapters, params, offsets)
             if diagnostic then
                 table.insert(diagnostics, diagnostic)
             end

--- a/lua/null-ls/config.lua
+++ b/lua/null-ls/config.lua
@@ -81,8 +81,12 @@ local register_source = function(source, filetypes)
             name = { name, "string", true },
         })
 
-        local fn, async = generator.fn, generator.async
-        validate({ fn = { fn, "function" }, async = { async, "boolean", true } })
+        local fn, async, opts = generator.fn, generator.async, generator.opts
+        validate({
+            fn = { fn, "function" },
+            async = { async, "boolean", true },
+            opts = { opts, "table", true },
+        })
 
         if not config._generators[method] then
             config._generators[method] = {}
@@ -90,6 +94,7 @@ local register_source = function(source, filetypes)
         register_filetypes(filetypes)
 
         generator.filetypes = filetypes
+        generator.opts = opts or {}
         table.insert(config._generators[method], generator)
     end
     require("null-ls.lspconfig").on_register_source(methods)

--- a/lua/null-ls/diagnostics.lua
+++ b/lua/null-ls/diagnostics.lua
@@ -17,9 +17,11 @@ local convert_range = function(diagnostic)
     return u.range.to_lsp({ row = row, col = col, end_row = end_row, end_col = end_col })
 end
 
-local postprocess = function(diagnostic, params)
+local postprocess = function(diagnostic, params, index)
     diagnostic.range = convert_range(diagnostic)
-    diagnostic.source = diagnostic.source or params.command or "null-ls"
+    diagnostic.source = diagnostic.source
+        or params.generators[index] and params.generators[index].opts.command
+        or "null-ls"
 end
 
 M.handler = function(original_params)

--- a/lua/null-ls/diagnostics.lua
+++ b/lua/null-ls/diagnostics.lua
@@ -5,17 +5,16 @@ local generators = require("null-ls.generators")
 
 local M = {}
 
+-- assume 1-indexed ranges
 local convert_range = function(diagnostic)
-    local start_line = u.string.to_number_safe(diagnostic.row, 0, -1)
-    local start_char = u.string.to_number_safe(diagnostic.col, 0)
-    local end_line = u.string.to_number_safe(diagnostic.end_row, start_line, -1)
-    -- default to end of line
-    local end_char = u.string.to_number_safe(diagnostic.end_col, -1)
+    local row = u.string.to_number_safe(diagnostic.row, 1)
+    local col = u.string.to_number_safe(diagnostic.col, 1)
+    -- default end_row to row
+    local end_row = u.string.to_number_safe(diagnostic.end_row, row)
+    -- default end_col to -1, which wraps to the end of the line (after range.to_lsp conversion)
+    local end_col = u.string.to_number_safe(diagnostic.end_col, 0)
 
-    return {
-        start = { line = start_line, character = start_char },
-        ["end"] = { line = end_line, character = end_char },
-    }
+    return u.range.to_lsp({ row = row, col = col, end_row = end_row, end_col = end_col })
 end
 
 local postprocess = function(diagnostic, params)

--- a/lua/null-ls/generators.lua
+++ b/lua/null-ls/generators.lua
@@ -16,7 +16,7 @@ M.run = function(generators, params, postprocess, callback)
         end
 
         local futures, all_results = {}, {}
-        for _, generator in ipairs(generators) do
+        for index, generator in ipairs(generators) do
             if u.filetype_matches(generator.filetypes, params.ft) then
                 table.insert(
                     futures,
@@ -35,7 +35,7 @@ M.run = function(generators, params, postprocess, callback)
                         elseif type(results) == "table" then
                             for _, result in ipairs(results) do
                                 if postprocess then
-                                    postprocess(result, params)
+                                    postprocess(result, params, index)
                                 end
 
                                 table.insert(all_results, result)
@@ -43,6 +43,8 @@ M.run = function(generators, params, postprocess, callback)
                         end
                     end)
                 )
+
+                table.insert(params.generators, generator)
             end
         end
 

--- a/lua/null-ls/helpers.lua
+++ b/lua/null-ls/helpers.lua
@@ -169,9 +169,6 @@ M.generator_factory = function(opts)
                 end
             end
 
-            -- Set the command used as value for the diagnostic source.
-            params.command = command
-
             local spawn_args = args or {}
             local client = vim.lsp.get_client_by_id(params.client_id)
             spawn_args = type(spawn_args) == "function" and spawn_args(params) or spawn_args
@@ -196,6 +193,7 @@ M.generator_factory = function(opts)
             loop.spawn(command, spawn_args, spawn_opts)
         end,
         filetypes = opts.filetypes,
+        opts = opts,
         async = true,
     }
 end

--- a/lua/null-ls/utils.lua
+++ b/lua/null-ls/utils.lua
@@ -104,6 +104,7 @@ M.make_params = function(original_params, method)
         bufnr = bufnr,
         bufname = api.nvim_buf_get_name(bufnr),
         ft = api.nvim_buf_get_option(bufnr, "filetype"),
+        generators = {},
     }
 
     if original_params.range then

--- a/test/spec/builtins/diagnostics_spec.lua
+++ b/test/spec/builtins/diagnostics_spec.lua
@@ -13,8 +13,8 @@ describe("diagnostics", function()
             local diagnostic = parser(output, { content = file })
             assert.are.same({
                 row = "1", --
-                col = "46",
-                end_col = 58,
+                col = 47,
+                end_col = 59,
                 severity = 1,
                 message = '"is deprecated" may be passive voice',
             }, diagnostic)
@@ -51,7 +51,7 @@ describe("diagnostics", function()
         end)
     end)
 
-    describe("teal", function()
+    describe("tl check", function()
         local linter = diagnostics.teal
         local parser = linter._opts.on_output
         local file = {
@@ -68,6 +68,7 @@ describe("diagnostics", function()
                 end_col = 17,
                 severity = 1,
                 message = "module not found: 'settings'",
+                source = "tl check",
             }, diagnostic)
         end)
         it("should create a diagnostic (quote field is not between quotes)", function()
@@ -79,6 +80,7 @@ describe("diagnostics", function()
                 end_col = 3,
                 severity = 1,
                 message = "unknown variable: vim",
+                source = "tl check",
             }, diagnostic)
         end)
     end)

--- a/test/spec/diagnostics_spec.lua
+++ b/test/spec/diagnostics_spec.lua
@@ -21,7 +21,11 @@ describe("diagnostics", function()
         local mock_params
         before_each(function()
             s.set({ client_id = mock_client_id })
-            mock_params = { textDocument = { uri = mock_uri }, client_id = mock_client_id }
+            mock_params = {
+                textDocument = { uri = mock_uri },
+                client_id = mock_client_id,
+                generators = {},
+            }
         end)
 
         after_each(function()
@@ -46,10 +50,12 @@ describe("diagnostics", function()
             s.set({ attached = { [mock_params.textDocument.uri] = mock_bufnr } })
             diagnostics.handler(mock_params)
 
-            assert.stub(u.make_params).was_called_with(
-                { bufnr = mock_bufnr, textDocument = mock_params.textDocument, client_id = mock_client_id },
-                methods.internal.DIAGNOSTICS
-            )
+            assert.stub(u.make_params).was_called_with({
+                bufnr = mock_bufnr,
+                textDocument = mock_params.textDocument,
+                client_id = mock_client_id,
+                generators = {},
+            }, methods.internal.DIAGNOSTICS)
         end)
 
         it("should send results of diagnostic generators to lsp handler", function()
@@ -77,7 +83,7 @@ describe("diagnostics", function()
             it("should convert range when all positions are defined", function()
                 local diagnostic = { row = 1, col = 5, end_row = 2, end_col = 6 }
 
-                postprocess(diagnostic, mock_params)
+                postprocess(diagnostic, mock_params, 1)
 
                 assert.same(diagnostic.range, {
                     ["end"] = { character = 5, line = 1 },
@@ -93,7 +99,7 @@ describe("diagnostics", function()
                     end_col = 6,
                 }
 
-                postprocess(diagnostic, mock_params)
+                postprocess(diagnostic, mock_params, 1)
 
                 assert.same(diagnostic.range, {
                     ["end"] = { character = 5, line = 1 },
@@ -109,7 +115,7 @@ describe("diagnostics", function()
                     end_col = 6,
                 }
 
-                postprocess(diagnostic, mock_params)
+                postprocess(diagnostic, mock_params, 1)
 
                 assert.same(diagnostic.range, {
                     ["end"] = { character = 5, line = 1 },
@@ -125,7 +131,7 @@ describe("diagnostics", function()
                     end_col = 6,
                 }
 
-                postprocess(diagnostic, mock_params)
+                postprocess(diagnostic, mock_params, 1)
 
                 assert.same(diagnostic.range, {
                     ["end"] = { character = 5, line = 0 },
@@ -141,7 +147,7 @@ describe("diagnostics", function()
                     end_col = nil,
                 }
 
-                postprocess(diagnostic, mock_params)
+                postprocess(diagnostic, mock_params, 1)
 
                 assert.same(diagnostic.range, {
                     ["end"] = { character = -1, line = 1 },
@@ -157,7 +163,7 @@ describe("diagnostics", function()
                     end_col = nil,
                 }
 
-                postprocess(diagnostic, mock_params)
+                postprocess(diagnostic, mock_params, 1)
 
                 assert.same(diagnostic.range, {
                     ["end"] = { character = -1, line = 0 },
@@ -174,24 +180,24 @@ describe("diagnostics", function()
                     source = "mock-source",
                 }
 
-                postprocess(diagnostic, mock_params)
+                postprocess(diagnostic, mock_params, 1)
 
                 assert.equals(diagnostic.source, "mock-source")
             end)
 
-            it("should get source from params.command", function()
-                mock_params.command = "mock-command"
+            it("should set source from generator command", function()
                 local diagnostic = { row = 1, col = 5, end_row = 2, end_col = 6 }
+                mock_params.generators = { [1] = { opts = { command = "mock-source" } } }
 
-                postprocess(diagnostic, mock_params)
+                postprocess(diagnostic, mock_params, 1)
 
-                assert.equals(diagnostic.source, "mock-command")
+                assert.equals(diagnostic.source, "mock-source")
             end)
 
             it("should set default source when undefined", function()
                 local diagnostic = { row = 1, col = 5, end_row = 2, end_col = 6 }
 
-                postprocess(diagnostic, mock_params)
+                postprocess(diagnostic, mock_params, 1)
 
                 assert.equals(diagnostic.source, "null-ls")
             end)

--- a/test/spec/diagnostics_spec.lua
+++ b/test/spec/diagnostics_spec.lua
@@ -80,8 +80,8 @@ describe("diagnostics", function()
                 postprocess(diagnostic, mock_params)
 
                 assert.same(diagnostic.range, {
-                    ["end"] = { character = 6, line = 1 },
-                    start = { character = 5, line = 0 },
+                    ["end"] = { character = 5, line = 1 },
+                    start = { character = 4, line = 0 },
                 })
             end)
 
@@ -96,8 +96,8 @@ describe("diagnostics", function()
                 postprocess(diagnostic, mock_params)
 
                 assert.same(diagnostic.range, {
-                    ["end"] = { character = 6, line = 1 },
-                    start = { character = 5, line = 0 },
+                    ["end"] = { character = 5, line = 1 },
+                    start = { character = 4, line = 0 },
                 })
             end)
 
@@ -112,7 +112,7 @@ describe("diagnostics", function()
                 postprocess(diagnostic, mock_params)
 
                 assert.same(diagnostic.range, {
-                    ["end"] = { character = 6, line = 1 },
+                    ["end"] = { character = 5, line = 1 },
                     start = { character = 0, line = 0 },
                 })
             end)
@@ -128,8 +128,8 @@ describe("diagnostics", function()
                 postprocess(diagnostic, mock_params)
 
                 assert.same(diagnostic.range, {
-                    ["end"] = { character = 6, line = 0 },
-                    start = { character = 5, line = 0 },
+                    ["end"] = { character = 5, line = 0 },
+                    start = { character = 4, line = 0 },
                 })
             end)
 
@@ -145,7 +145,7 @@ describe("diagnostics", function()
 
                 assert.same(diagnostic.range, {
                     ["end"] = { character = -1, line = 1 },
-                    start = { character = 5, line = 0 },
+                    start = { character = 4, line = 0 },
                 })
             end)
 

--- a/test/spec/e2e_spec.lua
+++ b/test/spec/e2e_spec.lua
@@ -232,7 +232,7 @@ describe("e2e", function()
             assert.equals(tl_check_diagnostic.message, "in return value: got string, expected number")
             assert.equals(tl_check_diagnostic.source, "tl")
             assert.same(tl_check_diagnostic.range, {
-                start = { character = 53, line = 0 },
+                start = { character = 52, line = 0 },
                 ["end"] = { character = -1, line = 0 },
             })
         end)

--- a/test/spec/e2e_spec.lua
+++ b/test/spec/e2e_spec.lua
@@ -230,7 +230,7 @@ describe("e2e", function()
 
             local tl_check_diagnostic = buf_diagnostics[1]
             assert.equals(tl_check_diagnostic.message, "in return value: got string, expected number")
-            assert.equals(tl_check_diagnostic.source, "tl")
+            assert.equals(tl_check_diagnostic.source, "tl check")
             assert.same(tl_check_diagnostic.range, {
                 start = { character = 52, line = 0 },
                 ["end"] = { character = -1, line = 0 },

--- a/test/spec/helpers_spec.lua
+++ b/test/spec/helpers_spec.lua
@@ -304,7 +304,7 @@ describe("helpers", function()
                 local wrapper = loop.spawn.calls[1].refs[3].handler
                 wrapper(nil, "output")
 
-                assert.stub(on_output).was_called_with({ output = "output", command = command }, done)
+                assert.stub(on_output).was_called_with({ output = "output" }, done)
             end)
 
             it("should set output to error_output and error_output to nil if to_stderr = true", function()
@@ -315,7 +315,7 @@ describe("helpers", function()
                 local wrapper = loop.spawn.calls[1].refs[3].handler
                 wrapper("error output", nil)
 
-                assert.stub(on_output).was_called_with({ output = "error output", command = command }, done)
+                assert.stub(on_output).was_called_with({ output = "error output" }, done)
             end)
 
             it("should throw error if error_output exists and format ~= raw", function()
@@ -336,7 +336,7 @@ describe("helpers", function()
                 local wrapper = loop.spawn.calls[1].refs[3].handler
                 wrapper("error output", nil)
 
-                assert.stub(on_output).was_called_with({ err = "error output", command = command }, done)
+                assert.stub(on_output).was_called_with({ err = "error output" }, done)
             end)
 
             it("should set params.err if format == json_raw", function()
@@ -347,7 +347,7 @@ describe("helpers", function()
                 local wrapper = loop.spawn.calls[1].refs[3].handler
                 wrapper("error output", nil)
 
-                assert.stub(on_output).was_called_with({ err = "error output", command = command })
+                assert.stub(on_output).was_called_with({ err = "error output" })
             end)
 
             it("should call json_output_wrapper and return if format == json", function()
@@ -358,7 +358,7 @@ describe("helpers", function()
                 local wrapper = loop.spawn.calls[1].refs[3].handler
                 wrapper(nil, vim.fn.json_encode({ key = "val" }))
 
-                assert.stub(on_output).was_called_with({ output = { key = "val" }, command = command })
+                assert.stub(on_output).was_called_with({ output = { key = "val" } })
             end)
 
             it("should call json_output_wrapper and return if format == json_raw", function()
@@ -369,7 +369,7 @@ describe("helpers", function()
                 local wrapper = loop.spawn.calls[1].refs[3].handler
                 wrapper(nil, vim.fn.json_encode({ key = "val" }))
 
-                assert.stub(on_output).was_called_with({ output = { key = "val" }, command = command })
+                assert.stub(on_output).was_called_with({ output = { key = "val" } })
             end)
 
             it("should call line_output_wrapper and return if format == line", function()
@@ -380,7 +380,7 @@ describe("helpers", function()
                 local wrapper = loop.spawn.calls[1].refs[3].handler
                 wrapper(nil, "output")
 
-                assert.stub(on_output).was_called_with("output", { output = "output", command = command })
+                assert.stub(on_output).was_called_with("output", { output = "output" })
             end)
 
             it("should call set_cache with bufnr, command, and output if use_cache is true", function()


### PR DESCRIPTION
The main goal of this PR is to consolidate range conversion by clarifying that diagnostics provided to null-ls should be 1-indexed and sources are therefore responsible for offsetting their ranges if that's not the case.

As part of that, I've updated the new diagnostic helpers from #57 to allow sources to define optional offsets, which if present will be applied to each diagnostic before returning to the null-ls diagnostics handler. The handler is now only responsible for converting strings to numbers, setting defaults if necessary, and converting Lua ranges to the correct LSP format. 

So far, I've found that `write-good` uses 0-indexed columns. Other line-based built-ins probably need to be offset, too, but I think the best course of action is to rely on users to find and report issues. I don't believe we had any sources that didn't use 1-indexed rows, and incorrect columns is annoying but not the end of the world, so we can fix it as we go. 

I've also bundled in a fix for an issue involving default command names. I forgot that `params` is generated only once per LSP request, so if the user has defined multiple diagnostic generators, `command` will be overwritten. I've removed `command` from `params` completely and re-written the diagnostic helpers to require `command` as their first argument, which is more verbose but avoids unnecessary complexity. 

@Tastyep Let me know what you think so I can merge this and you can fix any conflicts with your new PR. 