### PR TITLE
[WIP] feat: add conditional source registration

### DIFF
--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -65,6 +65,46 @@ See [CONFIG](CONFIG.md) to learn about `diagnostics_format`. Note that
 specifying `diagnostics_format` for a built-in will override your global
 `diagnostics_format` for that source.
 
+## Conditional registration
+
+null-ls supports dynamic registration, meaning that you can register sources
+whenever you want. To simplify this, built-ins have access to the `conditional`
+option, which should be a function that returns a boolean or `nil` indicating
+whether null-ls should register the source. null-ls will pass a single argument
+to the function, which is a table of utilities to handle common conditional
+checks (though you can use whatever you want, as long as the return value
+matches).
+
+For example, to conditionally register `stylua` by checking if the root
+directory has a `stylua.toml` file:
+
+```lua
+local sources = {
+    null_ls.builtins.formatting.stylua.with({
+        condition = function(utils)
+            return utils.root_has_file("stylua.toml")
+        end,
+    }),
+}
+```
+
+To conditionally register one of two or more sources, you can use the
+`conditional` helper, which should return a source or `nil` and will register
+the first source returned.
+
+```lua
+local sources = {
+    require("null-ls.helpers").conditional(function(utils)
+        return utils.root_has_file(".eslintrc.js") and b.formatting.eslint_d or b.formatting.prettier
+    end),
+}
+```
+
+Note that if you pass conditional sources into `null_ls.config`, null-ls will
+check and register them at the point that you source your plugin config. To
+handle advanced dynamic registration behavior, you can use `null_ls.register`
+with a relevant `autocommand` event listener.
+
 ## Available Sources
 
 ### Formatting
@@ -134,6 +174,7 @@ Can format your listfiles nicely so that they don't look like crap.
 ```lua
 local sources = {null_ls.builtins.formatting.crystal_format}
 ```
+
 A tool for automatically checking and correcting the style of code in a project.
 
 - Filetypes: `{ "crystal" }`
@@ -218,7 +259,8 @@ local sources = {null_ls.builtins.formatting.fish_indent}
 ```lua
 local sources = {null_ls.builtins.formatting.goimports}
 ```
-`goimports` updates your Go import lines, adding missing ones and removing unreferenced ones. 
+
+`goimports` updates your Go import lines, adding missing ones and removing unreferenced ones.
 
 - Filetypes: `{ "go" }`
 - Command: `goimports`
@@ -229,7 +271,8 @@ local sources = {null_ls.builtins.formatting.goimports}
 ```lua
 local sources = {null_ls.builtins.formatting.gofmt}
 ```
-Gofmt formats Go programs. It uses tabs for indentation and blanks for alignment. Alignment assumes that an editor is using a fixed-width font. 
+
+Gofmt formats Go programs. It uses tabs for indentation and blanks for alignment. Alignment assumes that an editor is using a fixed-width font.
 
 - Filetypes: `{ "go" }`
 - Command: `gofmt`
@@ -253,390 +296,4 @@ Enforce a stricter format than gofmt, while being backwards compatible. That is,
 local sources = {null_ls.builtins.formatting.isort}
 ```
 
-isort is a Python utility / library to sort imports alphabetically, and automatically separated into sections and by type.
-
-- Filetypes: `{ "python" }`
-- Command: `isort`
-- Arguments: `{ "--stdout", "--profile", "black", "-" }`
-
-#### [json.tool](https://docs.python.org/3/library/json.html#module-json.tool)
-
-```lua
-local sources = {null_ls.builtins.formatting.json_tool}
-```
-
-The json.tool module provides a simple command line interface to validate and pretty-print JSON objects.
-
-- Filetypes: `{ "json" }`
-- Command: `python`
-- Arguments: `{ "-m", "json.tool" }`
-
-#### [LuaFormatter](https://github.com/Koihik/LuaFormatter)
-
-A flexible but slow Lua formatter. Not recommended for formatting on save.
-
-```lua
-local sources = {null_ls.builtins.formatting.lua_format}
-```
-
-- Filetypes: `{ "lua" }`
-- Command: `lua-format`
-- Arguments: `{ "-i" }`
-
-#### [Mix](https://hexdocs.pm/mix/1.12/Mix.html)
-
-```lua
-local sources = {null_ls.builtins.formatting.mix}
-```
-
-Mix is a build tool that provides tasks for creating, compiling, and testing Elixir projects, managing its dependencies, and more.
-
-- Filetypes: `{ "elixir" }`
-- Command: `mix`
-- Arguments: `{ "format", "-" }`
-
-#### [Nginx Beautifier](https://github.com/vasilevich/nginxbeautifier)
-
-```lua
-local sources = {null_ls.builtins.formatting.nginx_beautifier}
-```
-
-This Javascript script beautifies and formats Nginx configuration files.
-
-- Filetypes: `{ "nginx" }`
-- Command: `nginxbeautifier`
-- Arguments: `{ "-i" }`
-
-#### [perltidy](http://perltidy.sourceforge.net/)
-
-```lua
-local sources = {null_ls.builtins.formatting.perltidy}
-```
-
-Perltidy is a Perl script which indents and reformats Perl scripts to make them easier to read. If you write Perl scripts, or spend much time reading them, you will probably find it useful.
-
-- Filetypes: `{ "perl" }`
-- Command: `perltidy`
-- Arguments: `{ "-q" }`
-
-#### [phpcbf](https://github.com/squizlabs/PHP_CodeSniffer)
-
-```lua
-local sources = {null_ls.builtins.formatting.phpcbf}
-```
-
-Tokenizes PHP files and detects violations of a defined set of coding standards.
-
-- Filetypes: `{ "php" }`
-- Command: `phpcbf`
-- Arguments: `{ "--standard=PSR12", "-" }`
-
-#### [Prettier](https://github.com/prettier/prettier)
-
-Supports both `textDocument/formatting` and `textDocument/rangeFormatting`
-(may not work on some filetypes).
-
-```lua
-local sources = {null_ls.builtins.formatting.prettier}
-```
-
-- Filetypes: `{ "javascript", "javascriptreact", "typescript", "typescriptreact", "vue", "css", "html", "json", "yaml", "markdown" }`
-- Command: `prettier`
-- Arguments: `{ "--stdin-filepath", "$FILENAME" }`
-
-#### [prettier_d_slim](https://github.com/mikew/prettier_d_slim)
-
-A faster version of Prettier that doesn't seem to work well on non-JavaScript
-filetypes. Supports both `textDocument/formatting` and `textDocument/rangeFormatting`
-(may not work on some filetypes).
-
-```lua
-local sources = {null_ls.builtins.formatting.prettier_d_slim}
-```
-
-- Filetypes: `{ "javascript", "javascriptreact", "typescript", "typescriptreact", "vue" }`
-- Command: `prettier_d_slim`
-- Arguments: ` { "--stdin", "--stdin-filepath", "$FILENAME" }`
-
-#### [prettierd](https://github.com/fsouza/prettierd)
-
-Another "Prettier, but faster" formatter, with better support for non-JavaScript
-filetypes.
-
-- Filetypes: `{ "javascript", "javascriptreact", "typescript", "typescriptreact", "vue", "css", "html", "json", "yaml", "markdown" }`
-- Command: `prettierd`
-- Arguments: `{ "$FILENAME" }`
-
-#### [formatR](https://github.com/yihui/formatR)
-
-```lua
-local sources = {null_ls.builtins.formatting.format_r}
-```
-
-Format R code automatically.
-
-- Filetypes: `{ "r", "rmd" }`
-- Command: `R`
-- Arguments: `{ 
-  "--slave",
-  "--no-restore",
-  "--no-save",
-  '-e "formatR::tidy_source(text=readr::read_file(file(\\"stdin\\")), arrow=FALSE)"'
-  }`
-
-#### [Rufo](https://github.com/ruby-formatter/rufo)
-
-```lua
-local sources = {null_ls.builtins.formatting.rufo}
-```
-
-Rufo is as an opinionated ruby formatter.
-
-- Filetypes: `{ "ruby" }`
-- Command: `rufo`
-- Arguments: `{ "-x" }`
-
-#### [rustfmt](https://github.com/rust-lang/rustfmt)
-
-```lua
-local sources = {null_ls.builtins.formatting.rustfmt}
-```
-
-A tool for formatting Rust code according to style guidelines.
-
-- Filetypes: `{ "rust" }`
-- Command: `rustfmt`
-- Arguments: `{ "--emit=stdout", "--edition=2018" }`
-
-#### [sqlformat](https://manpages.ubuntu.com/manpages/xenial/man1/sqlformat.1.html)
-
-```lua
-local sources = {null_ls.builtins.formatting.sqlformat}
-```
-
-The  `sqlformat` command-line tool can be used to reformat SQL file according to specified options.
-
-- Filetypes: `{ "sql" }`
-- Command: `sqlformat`
-- Arguments: `{ "--reindent", "-" }`
-
-#### [scalafmt](https://github.com/scalameta/scalafmt)
-
-```lua
-local sources = {null_ls.builtins.formatting.scalafmt}
-```
-
-Code formatter for Scala
-
-- Filetypes: `{ "scala" }`
-- Command: `scalafmt`
-- Arguments: `{ "--stdin" }`
-
-#### [shfmt](https://github.com/mvdan/sh)
-
-```lua
-local sources = {null_ls.builtins.formatting.shfmt}
-```
-
-A shell parser, formatter, and interpreter with bash support
-
-- Filetypes: `{ "sh" }`
-- Command: `shfmt`
-- Arguments: `{}`
-
-#### [StyLua](https://github.com/JohnnyMorganz/StyLua)
-
-```lua
-local sources = {null_ls.builtins.formatting.stylua}
-```
-
-A fast and opinionated Lua formatter written in Rust. Highly recommended!
-
-- Filetypes: `{ "lua" }`
-- Command: `stylua`
-- Arguments: `{ "-" }`
-
-#### [swfitformat](https://github.com/nicklockwood/SwiftFormat)
-
-```lua
-local sources = {null_ls.builtins.formatting.swiftformat}
-```
-
-SwiftFormat is a code library and command-line tool for reformatting Swift code on macOS or Linux.
-
-- Filetypes: `{ "swift" }`
-- Command: `swiftformat`
-- Arguments: `{}`
-
-#### [terraform_fmt](https://www.terraform.io/docs/cli/commands/fmt.html)
-
-```lua
-local sources = {null_ls.builtins.formatting.terraform_fmt}
-```
-
-The terraform fmt command is used to rewrite Terraform configuration files to a canonical format and style. 
-
-- Filetypes: `{ "tf", "hcl" }`
-- Command: `terraform`
-- Arguments: `{ "fmt", "-" }`
-
-#### trim_whitespace
-
-A simple wrapper around `awk` to remove trailing whitespace.
-
-```lua
-local sources = { null_ls.builtins.formatting.trim_whitespace.with({ filetypes = { ... } }) }
-```
-
-- Filetypes: none (must specify in `with()`, as above)
-- Command: `awk`
-- Arguments: `{ '{ sub(/[ \t]+$/, ""); print }' }`
-
-#### [uncrustify](https://github.com/uncrustify/uncrustify)
-
-```lua
-local sources = {null_ls.builtins.formatting.uncrustify}
-```
-
-A source code beautifier for C, C++, C#, ObjectiveC, D, Java, Pawn and VALA.
-
-- Filetypes: `{ "c", "cpp", "cs", "java" }`
-- Command: `uncrustify`
-- Arguments: `{ "-q", "-l <LANG>" }`
-
-#### [yapf](https://github.com/google/yapf)
-
-```lua
-local sources = {null_ls.builtins.formatting.yapf}
-```
-
-A formatter for Python files
-
-- Filetypes: `{ "python" }`
-- Command: `yapf`
-- Arguments: `{ "--quiet" }`
-
-### Diagnostics
-
-#### [ChkTeX](https://www.nongnu.org/chktex/)
-
-A LaTeX semantic linter.
-
-```lua
-local sources = {null_ls.builtins.diagnostics.chktex}
-```
-
-- Filetypes: `{ "tex" }`
-- Command: `chktex`
-- Arguments: `{ "-q", "-I0", "-f%l:%c:%d:%k:%m\n" }`
-
-#### [ESLint](https://github.com/eslint/eslint)
-
-A linter for the JavaScript ecosystem. Note that the null-ls builtin requires
-your ESLint executable to be available on your `$PATH`. To use local (project)
-executables, use the integration in
-[nvim-lsp-ts-utils](https://github.com/jose-elias-alvarez/nvim-lsp-ts-utils).
-
-```lua
-local sources = {null_ls.builtins.diagnostics.eslint}
-
--- if you want to use eslint_d
-local sources = {null_ls.builtins.diagnostics.eslint.with({command = "eslint_d"})}
-```
-
-- Filetypes: `{ "javascript", "javascriptreact", "typescript", "typescriptreact", "vue" }`
-- Command: `eslint`
-- Arguments: `{ "-f", "json", "--stdin", "--stdin-filename", "$FILENAME" }`
-
-#### [hadolint](https://github.com/hadolint/hadolint)
-
-A smarter Dockerfile linter that helps you build best practice Docker images.
-
-```lua
-local sources = {null_ls.builtins.diagnostics.hadolint}
-```
-
-- Filetypes: `{ "dockerfile" }`
-- Command: `hadolint`
-- Arguments: `{ "--no-fail", "--format=json", "$FILENAME" }`
-
-#### [write-good](https://github.com/btford/write-good)
-
-English prose linter.
-
-```lua
-local sources = {null_ls.builtins.diagnostics.write_good}
-```
-
-- Filetypes: `{ "markdown" }`
-- Command: `write-good`
-- Arguments: `{ "--text=$TEXT", "--parse" }`
-
-#### [markdownlint](https://github.com/DavidAnson/markdownlint) via [markdownlint-cli](https://github.com/igorshubovych/markdownlint-cli)
-
-Markdown style and syntax checker.
-
-```lua
-local sources = {null_ls.builtins.diagnostics.markdownlint}
-```
-
-- Filetypes: `{ "markdown" }`
-- Command: `markdownlint`
-- Arguments: `{ "--stdin" }`
-
-#### [vale](https://docs.errata.ai/vale/about)
-
-Syntax-aware linter for prose built with speed and extensibility in mind.
-
-vale does not include a syntax by itself, so you probably need to grab a
-`vale.ini` (at "~/.vale.ini") and a `StylesPath` (somewhere, pointed from
-`vale.ini`) from
-[here](https://docs.errata.ai/vale/about#open-source-configurations).
-
-```lua
-local sources = {null_ls.builtins.diagnostics.vale}
-```
-
-- Filetypes: `{ "markdown", "tex" }`
-- Command: `vale`
-- Arguments: `{ "--no-exit", "--output=JSON", "$FILENAME" }`
-
-### tl check via [teal](https://github.com/teal-language/tl)
-
-Turns `tl check` into a linter. It writes the buffer's content to a temporary
-file, so it works on change, not (only) on save!
-
-Note that Neovim doesn't support Teal files out-of-the-box, so you'll probably
-want to use [vim-teal](https://github.com/teal-language/vim-teal).
-
-```lua
-local sources = {null_ls.builtins.diagnostics.teal}
-```
-
-- Filetypes: `{ "teal" }`
-- Command: `tl`
-- Arguments: `{ "check", "$FILENAME" }`
-
-#### [misspell](https://github.com/client9/misspell)
-
-Correct commonly misspelled English words in source files
-
-```lua
-local sources = {null_ls.builtins.diagnostics.misspell}
-```
-
-- Filetypes: `{ "*" }`
-- Command: `misspell`
-- Arguments: `{ "$FILENAME" }`
-
-#### [vim-vint](https://github.com/Vimjas/vint)
-
-Linter for vimscript.
-
-```lua
-local sources = {null_ls.builtins.diagnostics.vint}
-```
-
-- Filetypes: `{ "vim" }`
-- Command: `vint`
-- Arguments: `{ "-s", "-j", "$FILENAME" }`
+isort is a Python

--- a/lua/null-ls/config.lua
+++ b/lua/null-ls/config.lua
@@ -65,6 +65,13 @@ local register_filetypes = function(filetypes)
 end
 
 local register_source = function(source, filetypes)
+    if type(source) == "function" then
+        source = source()
+        if not source then
+            return
+        end
+    end
+
     local generator, name = source.generator, source.name
     filetypes = filetypes or source.filetypes
 
@@ -103,7 +110,7 @@ end
 
 local register = function(to_register)
     -- register a single source
-    if to_register.method then
+    if type(to_register) == "function" or (type(to_register) == "table" and to_register.method) then
         register_source(to_register)
         return
     end

--- a/lua/null-ls/helpers.lua
+++ b/lua/null-ls/helpers.lua
@@ -247,10 +247,23 @@ M.make_builtin = function(opts)
         builtin.filetypes = user_opts.filetypes or builtin.filetypes
         builtin._opts = vim.tbl_deep_extend("force", builtin._opts, user_opts)
 
+        local condition = user_opts.condition
+        if condition then
+            return function()
+                return condition(u.make_conditional_utils()) and builtin
+            end
+        end
+
         return builtin
     end
 
     return builtin
+end
+
+M.conditional = function(condition)
+    return function()
+        return condition(u.make_conditional_utils())
+    end
 end
 
 if _G._TEST then

--- a/lua/null-ls/utils.lua
+++ b/lua/null-ls/utils.lua
@@ -1,3 +1,5 @@
+local lsputil = require("lspconfig.util")
+
 local c = require("null-ls.config")
 local methods = require("null-ls.methods")
 
@@ -112,6 +114,19 @@ M.make_params = function(original_params, method)
     end
 
     return params
+end
+
+M.make_conditional_utils = function()
+    local cwd = vim.loop.cwd()
+
+    return {
+        root_has_file = function(name)
+            return lsputil.path.exists(lsputil.path.join(cwd, name))
+        end,
+        root_matches = function(pattern)
+            return cwd:find(pattern) ~= nil
+        end,
+    }
 end
 
 M.buf = {

--- a/test/spec/config_spec.lua
+++ b/test/spec/config_spec.lua
@@ -46,6 +46,17 @@ describe("config", function()
             assert.equals(vim.tbl_count(c.get()._filetypes), 2)
         end)
 
+        it("should register function source", function()
+            c.register(function()
+                return mock_source
+            end)
+
+            local generators = c.generators()
+
+            assert.equals(vim.tbl_count(generators), 1)
+            assert.equals(vim.tbl_count(generators[mock_source.method]), 1)
+        end)
+
         it("should register additional generators for same method", function()
             c.register(mock_source)
             c.register(mock_source)

--- a/test/spec/helpers_spec.lua
+++ b/test/spec/helpers_spec.lua
@@ -513,6 +513,17 @@ describe("helpers", function()
                 assert.equals(builtin._opts.nested.nested_key, "new_val")
                 assert.equals(builtin._opts.nested.other_nested, "original_val")
             end)
+
+            it("should wrap builtin with condition", function()
+                local wrapped = builtin.with({
+                    condition = function()
+                        return true
+                    end,
+                })
+
+                assert.equals(type(wrapped), "function")
+                assert.equals(wrapped(), builtin)
+            end)
         end)
 
         describe("index metatable", function()


### PR DESCRIPTION
Will close #60 when done.

This is a basic implementation that handles the conditional formatting case described in #60 as follows:

```lua
local sources = {
    require("null-ls.helpers").conditional(function(utils)
        return utils.root_has_file(".eslintrc.js") and b.formatting.eslint_d or b.formatting.prettier
    end),
}
```

The above example shows a simple utility to check if a file exists in the current working directory. I mentioned in the linked issue that checking whether a command runs successfully is another option, and I'm open to adding more to handle common use cases. However, when it comes to handling more complicated cases (e.g. monorepos) or language-specific checks, I'd prefer to have users / integrations be responsible for writing the conditional logic. 

If registered unconditionally, the above example will run once whenever the user opens Neovim. A simple file existence check takes less than 1 millisecond, so I don't think it's a big deal, but for heavier conditional logic (or for users really obsessed with their startup time, an obsession I don't personally understand) it would be simple to call it conditionally on a `FileType` event:

```lua
_G.register_formatter = function()
    require("null-ls").register({ require("null-ls.helpers").conditional(function(utils)
        return utils.root_has_file(".eslintrc.js") and b.formatting.eslint_d or b.formatting.prettier
    end) })
end

vim.cmd("autocmd FileType javascript,typescript lua register_formatter()")
```

This is just a first pass, so I'm happy to hear feedback about the implementation and if there's any other common use cases we can handle for now. 