### PR TITLE
Fix: set end column in vale properly

### DIFF
--- a/lua/null-ls/builtins/diagnostics.lua
+++ b/lua/null-ls/builtins/diagnostics.lua
@@ -255,15 +255,18 @@ M.vale = h.make_builtin({
     generator_opts = {
         command = "vale",
         format = "json",
-        args = { "--no-exit", "--output=JSON", "$FILENAME" },
+        to_stdin = true,
+        args = function(params)
+			      return { "--no-exit", "--output", "JSON", "--ext", "." .. vim.fn.fnamemodify(params.bufname, ":e") }
+        end,
         on_output = function(params)
             local diagnostics = {}
             local severities = { error = 1, warning = 2, suggestion = 4 }
-            for _, diagnostic in ipairs(params.output[params.bufname]) do
+            for _, diagnostic in ipairs(params.output["stdin." .. vim.fn.fnamemodify(params.bufname, ":e")]) do
                 table.insert(diagnostics, {
                     row = diagnostic.Line,
                     col = diagnostic.Span[1],
-                    end_col = diagnostic.Span[2] + 1, 
+                    end_col = diagnostic.Span[2] + 1,
                     code = diagnostic.Check,
                     message = diagnostic.Message,
                     severity = severities[diagnostic.Severity],

--- a/lua/null-ls/builtins/diagnostics.lua
+++ b/lua/null-ls/builtins/diagnostics.lua
@@ -263,7 +263,7 @@ M.vale = h.make_builtin({
                 table.insert(diagnostics, {
                     row = diagnostic.Line,
                     col = diagnostic.Span[1],
-                    end_col = diagnostic.Span[2],
+                    end_col = diagnostic.Span[2] + 1, 
                     code = diagnostic.Check,
                     message = diagnostic.Message,
                     severity = severities[diagnostic.Severity],


### PR DESCRIPTION
### Description

It seems like the way of handling the column position in null-ls changed, so this needs to be updated in the [vale](https://github.com/errata-ai/vale) diagnostics plug-in.

### Implementation

It only required to sum one to the end column position to be correct.