### PR TITLE
feat: add deno fmt

### DIFF
--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -259,6 +259,29 @@ local sources = { null_ls.builtins.formatting.dart_format }
 - `command = "dart"`
 - `args = { "format" }`
 
+#### [deno formatter](https://deno.land/manual/tools/formatter)
+
+##### About
+
+Use [deno](https://deno.land) to format TypeScript and JavaScript code
+
+##### Usage
+
+```lua
+local sources = { null_ls.builtins.formatting.deno_fmt }
+```
+
+##### Defaults
+
+- `filetypes = {
+    "javascript",
+    "javascriptreact",
+    "typescript",
+    "typescriptreact",
+}`
+- `command = "deno"`
+- `args = { "fmt", "-"}`
+
 #### [elm-format](https://github.com/avh4/elm-format)
 
 ##### About

--- a/lua/null-ls/builtins/formatting.lua
+++ b/lua/null-ls/builtins/formatting.lua
@@ -132,6 +132,22 @@ M.dart_format = h.make_builtin({
     factory = h.formatter_factory,
 })
 
+M.deno_fmt = h.make_builtin({
+    method = FORMATTING,
+    filetypes = {
+        "javascript",
+        "javascriptreact",
+        "typescript",
+        "typescriptreact",
+    },
+    generator_opts = {
+        command = "deno",
+        args = { "fmt", "-" },
+        to_stdin = true,
+    },
+    factory = h.formatter_factory,
+})
+
 M.elm_format = h.make_builtin({
     method = FORMATTING,
     filetypes = { "elm" },


### PR DESCRIPTION
Adds the [deno formatter](https://deno.land/manual/tools/formatter) to `builtins`.