### PR TITLE
Add stylua range formatting.

### DIFF
--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -769,7 +769,8 @@ local sources = { null_ls.builtins.formatting.shfmt }
 
 ##### About
 
-A fast and opinionated Lua formatter written in Rust. Highly recommended!
+- A fast and opinionated Lua formatter written in Rust. Highly recommended!
+- Supports both `textDocument/formatting` and `textDocument/rangeFormatting`
 
 ##### Usage
 
@@ -781,7 +782,7 @@ local sources = { null_ls.builtins.formatting.stylua }
 
 - `filetypes = { "lua" }`
 - `command = "stylua"`
-- `args = { "-" }`
+- `args = { "-s", "-" }`
 
 #### [swfitformat](https://github.com/nicklockwood/SwiftFormat)
 
@@ -932,7 +933,7 @@ local sources = {
 
 ##### About
 
-flake8 is a python tool that glues together pycodestyle, pyflakes, mccabe, and third-party plugins to check the style and quality of some python code. 
+flake8 is a python tool that glues together pycodestyle, pyflakes, mccabe, and third-party plugins to check the style and quality of some python code.
 
 
 ##### Usage

--- a/lua/null-ls/builtins/formatting.lua
+++ b/lua/null-ls/builtins/formatting.lua
@@ -35,6 +35,31 @@ local get_prettier_generator_args = function(common_args)
     end
 end
 
+local get_stylua_args = function(common_args)
+    return function(params)
+        local args = vim.deepcopy(common_args)
+
+        if params.method == FORMATTING then
+            return args
+        end
+
+        local range = params.range
+
+        local row, col = range.row, range.col
+        local end_row, end_col = range.end_row, range.end_col
+
+        local range_start = row <= 1 and 0 or vim.api.nvim_buf_get_offset(0, row - 1) + col - 1
+        local range_end = end_row <= 1 and 0 or vim.api.nvim_buf_get_offset(0, end_row - 1) + end_col
+
+        table.insert(args, "--range-start")
+        table.insert(args, range_start)
+        table.insert(args, "--range-end")
+        table.insert(args, range_end)
+
+        return args
+    end
+end
+
 local function get_uncrustify_args()
     local format_type = "-l " .. vim.bo.filetype:upper()
     return { "-q", format_type }
@@ -504,9 +529,13 @@ M.shfmt = h.make_builtin({
 })
 
 M.stylua = h.make_builtin({
-    method = FORMATTING,
+    method = { FORMATTING, RANGE_FORMATTING },
     filetypes = { "lua" },
-    generator_opts = { command = "stylua", args = { "-s", "-" }, to_stdin = true },
+    generator_opts = {
+        command = "stylua",
+        args = get_stylua_args({ "-s", "-" }),
+        to_stdin = true,
+    },
     factory = h.formatter_factory,
 })
 


### PR DESCRIPTION
NOTE: keymap setting
```vim
" It doesn't work.
<cmd>lua vim.lsp.buf.range_formatting()<CR>

" It works
:lua vim.lsp.buf.range_formatting()<CR>
```