### PR TITLE
feat: make formatting sequential

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,10 +229,12 @@ formatting.
 
 ### How do I format files?
 
-null-ls formatters run when you call `vim.lsp.buf.formatting()` or
-`vim.lsp.buf.formatting_sync()`. If a source supports it, you can run range
-formatting by visually selecting part of the buffer and calling
-`vim.lsp.buf.range_formatting()`.
+null-ls formatters run when you call `vim.lsp.buf.formatting()`. If a source
+supports it, you can run range formatting by visually selecting part of the
+buffer and calling `vim.lsp.buf.range_formatting()`.
+
+Note that `vim.lsp.buf.formatting_sync()` will not work properly when running
+more than one formatter on a single filetype.
 
 If you have other language servers running that can format the current buffer,
 Neovim will prompt you to choose a formatter. You can prevent actual LSP clients

--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ See the following snippet:
 -- or to a common on_attach callback to enable for all supported filetypes
 on_attach = function(client)
     if client.resolved_capabilities.document_formatting then
-        vim.cmd("autocmd BufWritePost <buffer> lua vim.lsp.buf.formatting()")
+        vim.cmd("autocmd BufWritePre <buffer> lua vim.lsp.buf.formatting_sync()")
     end
 end
 ```

--- a/README.md
+++ b/README.md
@@ -229,12 +229,10 @@ formatting.
 
 ### How do I format files?
 
-null-ls formatters run when you call `vim.lsp.buf.formatting()`. If a source
-supports it, you can run range formatting by visually selecting part of the
-buffer and calling `vim.lsp.buf.range_formatting()`.
-
-Note that `vim.lsp.buf.formatting_sync()` will not work properly when running
-more than one formatter on a single filetype.
+null-ls formatters run when you call `vim.lsp.buf.formatting()` or
+`vim.lsp.buf.formatting_sync()`. If a source supports it, you can run range
+formatting by visually selecting part of the buffer and calling
+`vim.lsp.buf.range_formatting()`.
 
 If you have other language servers running that can format the current buffer,
 Neovim will prompt you to choose a formatter. You can prevent actual LSP clients

--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -946,13 +946,11 @@ local sources = {
 - `command = "eslint"`
 - `args = { "-f", "json", "--stdin", "--stdin-filename", "$FILENAME" }`
 
-
 #### [flake8](https://github.com/PyCGA/flake8)
 
 ##### About
 
 flake8 is a python tool that glues together pycodestyle, pyflakes, mccabe, and third-party plugins to check the style and quality of some python code.
-
 
 ##### Usage
 
@@ -965,7 +963,6 @@ local sources = { null_ls.builtins.diagnostics.flake8 }
 - `filetypes = { "python" }`
 - `command = "flake8"`
 - `args = { "--stdin-display-name", "$FILENAME", "-" }`
-
 
 #### [hadolint](https://github.com/hadolint/hadolint)
 
@@ -1044,7 +1041,6 @@ local sources = { null_ls.builtins.diagnostics.markdownlint }
 ##### About
 
 Pylint is a Python static code analysis tool which looks for programming errors, helps enforcing a coding standard, sniffs for code smells and offers simple refactoring suggestions.
-
 
 ##### Usage
 

--- a/doc/CONFIG.md
+++ b/doc/CONFIG.md
@@ -1,3 +1,10 @@
+<!-- markdownlint-configure-file
+{
+  "line-length": false,
+  "no-duplicate-header": false
+}
+-->
+
 # Installing and configuring null-ls
 
 You can install null-ls using any package manager. Here is a simple example
@@ -42,7 +49,6 @@ The following code block shows the available options and their defaults.
 local defaults = {
     diagnostics_format = "#{m}",
     debounce = 250,
-    save_after_format = true,
     default_timeout = 5000,
     sources = nil,
 }
@@ -82,24 +88,6 @@ Lowering `debounce` will result in more frequent diagnostic refreshes at the
 cost of running diagnostic sources more frequently. The default value should be
 enough to provide near-instantaneous feedback from most sources without
 unnecessary resource usage.
-
-### save_after_format (boolean)
-
-By default, null-ls will save modified buffers after applying edits from
-formatting sources. This makes it simple to enable asynchronous formatting on
-save with the following snippet:
-
-```lua
--- add to your lspconfig on_attach function
-on_attach = function(client)
-    if client.resolved_capabilities.document_formatting then
-        vim.cmd("autocmd BufWritePost <buffer> lua vim.lsp.buf.formatting()")
-    end
-end
-```
-
-Setting `save_after_format = false` will leave the buffer in a modified state
-after formatting, which is consistent with default LSP behavior.
 
 ### default_timeout (number)
 

--- a/doc/MAIN.md
+++ b/doc/MAIN.md
@@ -273,6 +273,6 @@ return { {
 null-ls applies formatting results to the matching buffer and, depending on the
 user's settings, will optionally write the buffer.
 
-Note that although null-ls supports an arbitrary number of formatting sources
-for a single filetype, it cannot guarantee the order in which formatters will
-apply their edits to the current buffer, so it's not recommended.
+Users can register an arbitrary number of formatters for a single filetype. To
+match expected behavior, formatters run _sequentially_ in the order in which the
+user has registered them (manually or via an integration).

--- a/lua/null-ls/builtins/test.lua
+++ b/lua/null-ls/builtins/test.lua
@@ -122,4 +122,26 @@ M.mock_diagnostics = {
     filetypes = { "markdown" },
 }
 
+M.first_formatter = {
+    method = methods.internal.FORMATTING,
+    generator = {
+        fn = function(_, done)
+            return done({ { text = "first" } })
+        end,
+        async = true,
+    },
+    filetypes = { "text" },
+}
+
+M.second_formatter = {
+    method = methods.internal.FORMATTING,
+    generator = {
+        fn = function(params, done)
+            return done({ { text = params.content[1] == "first" and "sequential" or "second" } })
+        end,
+        async = true,
+    },
+    filetypes = { "text" },
+}
+
 return M

--- a/lua/null-ls/builtins/test.lua
+++ b/lua/null-ls/builtins/test.lua
@@ -88,7 +88,7 @@ M.slow_code_action = h.make_builtin({
 
 M.cached_code_action = h.make_builtin({
     method = methods.internal.CODE_ACTION,
-    filetypes = { "lua" },
+    filetypes = { "text" },
     generator_opts = {
         command = "ls",
         on_output = function(params, done)

--- a/lua/null-ls/code-actions.lua
+++ b/lua/null-ls/code-actions.lua
@@ -21,15 +21,14 @@ M.handler = function(method, original_params, handler)
             return
         end
 
-        local uri = original_params.textDocument.uri
-        local bufnr = vim.uri_to_bufnr(uri)
-        original_params.bufnr = bufnr
-
         s.clear_actions()
-        generators.run_registered(
-            u.make_params(original_params, methods.internal.CODE_ACTION),
-            postprocess,
-            function(actions)
+        local params = u.make_params(original_params, methods.map[method])
+        generators.run_registered({
+            filetype = params.ft,
+            method = methods.map[method],
+            params = params,
+            postprocess = postprocess,
+            callback = function(actions)
                 u.debug_log("received code actions from generators")
                 u.debug_log(actions)
 
@@ -38,8 +37,8 @@ M.handler = function(method, original_params, handler)
                     return a.title < b.title
                 end)
                 handler(actions)
-            end
-        )
+            end,
+        })
         original_params._null_ls_handled = true
     end
 

--- a/lua/null-ls/config.lua
+++ b/lua/null-ls/config.lua
@@ -3,7 +3,6 @@ local validate = vim.validate
 local defaults = {
     diagnostics_format = "#{m}",
     debounce = 250,
-    save_after_format = true,
     default_timeout = 5000,
     debug = false,
     _generators = {},

--- a/lua/null-ls/config.lua
+++ b/lua/null-ls/config.lua
@@ -153,10 +153,6 @@ M.reset_sources = function()
     config._filetypes = {}
 end
 
-M.generators = function(method)
-    return method and config._generators[method] or config._generators
-end
-
 local validate_config = function(user_config)
     local to_validate, validated = {}, {}
 

--- a/lua/null-ls/diagnostics.lua
+++ b/lua/null-ls/diagnostics.lua
@@ -40,6 +40,7 @@ M.handler = function(original_params)
     end
     local method, uri = original_params.method, original_params.textDocument.uri
     if method == methods.lsp.DID_CLOSE then
+        s.clear_cache(uri)
         return
     end
 

--- a/lua/null-ls/diagnostics.lua
+++ b/lua/null-ls/diagnostics.lua
@@ -39,28 +39,31 @@ M.handler = function(original_params)
         return
     end
     local method, uri = original_params.method, original_params.textDocument.uri
-    if method == methods.lsp.DID_CHANGE then
-        s.clear_cache(uri)
-    end
-
     if method == methods.lsp.DID_CLOSE then
         return
     end
 
-    original_params.bufnr = vim.uri_to_bufnr(uri)
-    generators.run_registered(
-        u.make_params(original_params, methods.internal.DIAGNOSTICS),
-        postprocess,
-        function(diagnostics)
+    if method == methods.lsp.DID_CHANGE then
+        s.clear_cache(uri)
+    end
+
+    local params = u.make_params(original_params, methods.map[method])
+    generators.run_registered({
+        filetype = params.ft,
+        method = methods.map[method],
+        params = params,
+        postprocess = postprocess,
+        callback = function(diagnostics)
             u.debug_log("received diagnostics from generators")
             u.debug_log(diagnostics)
 
             vim.lsp.handlers[methods.lsp.PUBLISH_DIAGNOSTICS](nil, nil, {
                 diagnostics = diagnostics,
                 uri = uri,
+                ---@diagnostic disable-next-line: redundant-parameter
             }, original_params.client_id, nil, {})
-        end
-    )
+        end,
+    })
 end
 
 return M

--- a/lua/null-ls/formatting.lua
+++ b/lua/null-ls/formatting.lua
@@ -79,9 +79,6 @@ M.apply_edits = function(edits, params)
 
     vim.schedule(function()
         restore_win_data(marks, views, bufnr)
-        if c.get().save_after_format and not _G._TEST then
-            vim.cmd(bufnr .. "bufdo! silent keepjumps noautocmd update")
-        end
     end)
 
     u.debug_log("successfully applied edits")

--- a/lua/null-ls/generators.lua
+++ b/lua/null-ls/generators.lua
@@ -9,40 +9,38 @@ M.run = function(generators, params, postprocess, callback)
     local runner = a.async(function()
         u.debug_log("running generators for method " .. params.method)
 
-        if not generators then
-            u.debug_log("no generators registered")
+        if not generators or vim.tbl_isempty(generators) then
+            u.debug_log("no generators available")
             return {}
         end
 
         local futures, all_results = {}, {}
         for _, generator in ipairs(generators) do
-            if u.filetype_matches(generator.filetypes, params.ft) then
-                table.insert(
-                    futures,
-                    a.future(function()
-                        local ok, results
-                        if generator.async then
-                            local wrapped = a.wrap(generator.fn, 2)
-                            ok, results = a.await(a.util.protected(wrapped(params)))
-                        else
-                            ok, results = pcall(generator.fn, params)
-                        end
-                        a.await(a.scheduler())
+            table.insert(
+                futures,
+                a.future(function()
+                    local ok, results
+                    if generator.async then
+                        local wrapped = a.wrap(generator.fn, 2)
+                        ok, results = a.await(a.util.protected(wrapped(params)))
+                    else
+                        ok, results = pcall(generator.fn, params)
+                    end
+                    a.await(a.scheduler())
 
-                        if not ok then
-                            u.echo("WarningMsg", "failed to run generator: " .. results)
-                        elseif type(results) == "table" then
-                            for _, result in ipairs(results) do
-                                if postprocess then
-                                    postprocess(result, params, generator)
-                                end
-
-                                table.insert(all_results, result)
+                    if not ok then
+                        u.echo("WarningMsg", "failed to run generator: " .. results)
+                    elseif type(results) == "table" then
+                        for _, result in ipairs(results) do
+                            if postprocess then
+                                postprocess(result, params, generator)
                             end
+
+                            table.insert(all_results, result)
                         end
-                    end)
-                )
-            end
+                    end
+                end)
+            )
         end
 
         a.await_all(futures)
@@ -54,22 +52,22 @@ M.run = function(generators, params, postprocess, callback)
     end)
 end
 
-M.run_registered = function(params, postprocess, callback)
-    local generators = c.generators(params.method)
+M.run_registered = function(opts)
+    local filetype, method, params, postprocess, callback =
+        opts.filetype, opts.method, opts.params, opts.postprocess, opts.callback
+    local generators = M.get_available(filetype, method)
+
     M.run(generators, params, postprocess, callback)
 end
 
+M.get_available = function(filetype, method)
+    return vim.tbl_filter(function(generator)
+        return u.filetype_matches(generator.filetypes, filetype)
+    end, c.get()._generators[method] or {})
+end
+
 M.can_run = function(filetype, method)
-    local generators = c.generators(method)
-    if not generators then
-        return false
-    end
-    for _, generator in ipairs(generators) do
-        if u.filetype_matches(generator.filetypes, filetype) then
-            return true
-        end
-    end
-    return false
+    return #M.get_available(filetype, method) > 0
 end
 
 return M

--- a/lua/null-ls/generators.lua
+++ b/lua/null-ls/generators.lua
@@ -30,6 +30,7 @@ M.run = function(generators, params, postprocess, callback)
 
                     if not ok then
                         u.echo("WarningMsg", "failed to run generator: " .. results)
+                        generator._failed = true
                     elseif type(results) == "table" then
                         for _, result in ipairs(results) do
                             if postprocess then
@@ -90,7 +91,7 @@ end
 
 M.get_available = function(filetype, method)
     return vim.tbl_filter(function(generator)
-        return u.filetype_matches(generator.filetypes, filetype)
+        return not generator._failed and u.filetype_matches(generator.filetypes, filetype)
     end, c.get()._generators[method] or {})
 end
 

--- a/lua/null-ls/generators.lua
+++ b/lua/null-ls/generators.lua
@@ -58,11 +58,14 @@ M.run = function(generators, params, postprocess, callback)
     end)
 end
 
-M.run_sequentially = function(generators, make_params, postprocess, callback)
+M.run_sequentially = function(generators, make_params, postprocess, callback, after_all)
     local generator_index, wrapped_callback = 1, nil
     local run_next = function()
         local next_generator = generators[generator_index]
         if not next_generator then
+            if after_all then
+                after_all()
+            end
             return
         end
         -- schedule to make sure params reflect current buffer state
@@ -89,11 +92,11 @@ M.run_registered = function(opts)
 end
 
 M.run_registered_sequentially = function(opts)
-    local filetype, method, make_params, postprocess, callback =
-        opts.filetype, opts.method, opts.make_params, opts.postprocess, opts.callback
+    local filetype, method, make_params, postprocess, callback, after_all =
+        opts.filetype, opts.method, opts.make_params, opts.postprocess, opts.callback, opts.after_all
     local generators = M.get_available(filetype, method)
 
-    M.run_sequentially(generators, make_params, postprocess, callback)
+    M.run_sequentially(generators, make_params, postprocess, callback, after_all)
 end
 
 M.get_available = function(filetype, method)

--- a/lua/null-ls/helpers.lua
+++ b/lua/null-ls/helpers.lua
@@ -93,7 +93,13 @@ M.generator_factory = function(opts)
     local _validated
     local validate_opts = function()
         validate({
-            command = { command, "string" },
+            command = {
+                command,
+                function(v)
+                    return type(v) == "string" and vim.fn.executable(command) > 0
+                end,
+                "string (executable)",
+            },
             args = {
                 args,
                 function(v)

--- a/lua/null-ls/methods.lua
+++ b/lua/null-ls/methods.lua
@@ -23,6 +23,8 @@ local lsp_to_internal_map = {
     [lsp_methods.CODE_ACTION] = internal_methods.CODE_ACTION,
     [lsp_methods.FORMATTING] = internal_methods.FORMATTING,
     [lsp_methods.RANGE_FORMATTING] = internal_methods.RANGE_FORMATTING,
+    [lsp_methods.DID_OPEN] = internal_methods.DIAGNOSTICS,
+    [lsp_methods.DID_CHANGE] = internal_methods.DIAGNOSTICS,
 }
 
 return { lsp = lsp_methods, internal = internal_methods, map = lsp_to_internal_map }

--- a/test/files/test-file.txt
+++ b/test/files/test-file.txt
@@ -1,0 +1,1 @@
+intentionally left blank

--- a/test/spec/code-actions_spec.lua
+++ b/test/spec/code-actions_spec.lua
@@ -12,11 +12,14 @@ describe("code_actions", function()
     stub(s, "get")
     stub(s, "run_action")
     local mock_uri = "file:///mock-file"
-    local mock_bufnr, mock_client_id = vim.uri_to_bufnr(mock_uri), 999
+    local mock_client_id = 999
     local mock_params
     before_each(function()
-        s.get.returns({ client_id = 99 })
-        mock_params = { textDocument = { uri = mock_uri }, client_id = mock_client_id }
+        mock_params = {
+            textDocument = { uri = mock_uri },
+            client_id = mock_client_id,
+        }
+        u.make_params.returns(mock_params)
     end)
 
     after_each(function()
@@ -51,13 +54,12 @@ describe("code_actions", function()
             it("should call make_params with original params and internal method", function()
                 code_actions.handler(method, mock_params, handler)
 
-                mock_params.bufnr = mock_bufnr
                 mock_params._null_ls_handled = nil
                 assert.stub(u.make_params).was_called_with(mock_params, methods.internal.CODE_ACTION)
             end)
 
             it("should set handled flag on params", function()
-                code_actions.handler(method, mock_params, handler, 1)
+                code_actions.handler(method, mock_params, handler)
 
                 assert.equals(mock_params._null_ls_handled, true)
             end)
@@ -65,7 +67,7 @@ describe("code_actions", function()
             it("should call handler with arguments", function()
                 code_actions.handler(method, mock_params, handler)
 
-                local callback = generators.run_registered.calls[1].refs[3]
+                local callback = generators.run_registered.calls[1].refs[1].callback
                 callback({ { title = "actions" } })
 
                 -- wait for schedule_wrap
@@ -91,7 +93,7 @@ describe("code_actions", function()
                         end,
                     }
                     code_actions.handler(method, mock_params, handler)
-                    postprocess = generators.run_registered.calls[1].refs[2]
+                    postprocess = generators.run_registered.calls[1].refs[1].postprocess
                 end)
 
                 it("should register action in state", function()

--- a/test/spec/config_spec.lua
+++ b/test/spec/config_spec.lua
@@ -39,7 +39,7 @@ describe("config", function()
         it("should register single source", function()
             c.register(mock_source)
 
-            local generators = c.generators()
+            local generators = c.get()._generators
 
             assert.equals(vim.tbl_count(generators), 1)
             assert.equals(vim.tbl_count(generators[mock_source.method]), 1)
@@ -51,7 +51,7 @@ describe("config", function()
                 return mock_source
             end)
 
-            local generators = c.generators()
+            local generators = c.get()._generators
 
             assert.equals(vim.tbl_count(generators), 1)
             assert.equals(vim.tbl_count(generators[mock_source.method]), 1)
@@ -61,7 +61,7 @@ describe("config", function()
             c.register(mock_source)
             c.register(mock_source)
 
-            local generators = c.generators()
+            local generators = c.get()._generators
 
             assert.equals(vim.tbl_count(generators), 1)
             assert.equals(vim.tbl_count(generators[mock_source.method]), 2)
@@ -71,7 +71,7 @@ describe("config", function()
         it("should register multiple sources from simple list", function()
             c.register({ mock_source, mock_source })
 
-            local generators = c.generators()
+            local generators = c.get()._generators
 
             assert.equals(vim.tbl_count(generators), 1)
             assert.equals(vim.tbl_count(generators[mock_source.method]), 2)
@@ -84,7 +84,7 @@ describe("config", function()
                 sources = { mock_source, mock_source },
             })
 
-            local generators = c.generators()
+            local generators = c.get()._generators
 
             assert.equals(vim.tbl_count(generators), 1)
             assert.equals(vim.tbl_count(generators[mock_source.method]), 2)
@@ -98,27 +98,8 @@ describe("config", function()
 
             c.reset_sources()
 
-            assert.equals(vim.tbl_count(c.generators()), 0)
+            assert.equals(vim.tbl_count(c.get()._generators), 0)
             assert.equals(c.get().debounce, 500)
-        end)
-    end)
-
-    describe("generators", function()
-        before_each(function()
-            c.register(mock_source)
-        end)
-
-        it("should get generators matching method", function()
-            local generators = c.generators(mock_source.method)
-
-            assert.equals(vim.tbl_count(generators), 1)
-        end)
-
-        it("should get all generators", function()
-            local all_generators = c.generators()
-
-            assert.equals(vim.tbl_count(all_generators), 1)
-            assert.equals(vim.tbl_count(all_generators[mock_source.method]), 1)
         end)
     end)
 
@@ -181,7 +162,7 @@ describe("config", function()
         it("should register sources", function()
             c.setup({ sources = { mock_source } })
 
-            local generators = c.generators()
+            local generators = c.get()._generators
 
             assert.equals(vim.tbl_count(generators), 1)
             assert.equals(vim.tbl_count(generators[mock_source.method]), 1)

--- a/test/spec/e2e_spec.lua
+++ b/test/spec/e2e_spec.lua
@@ -22,6 +22,15 @@ require("lspconfig")["null-ls"].setup({
     },
 })
 
+local get_code_actions = function()
+    local current_bufnr = api.nvim_get_current_buf()
+    return lsp.buf_request_sync(
+        current_bufnr,
+        methods.lsp.CODE_ACTION,
+        { textDocument = { uri = vim.uri_from_bufnr(current_bufnr) } }
+    )
+end
+
 describe("e2e", function()
     _G._TEST = true
     after_each(function()
@@ -30,16 +39,14 @@ describe("e2e", function()
     end)
 
     describe("code actions", function()
-        local actions, null_ls_action, mock_params
+        local actions, null_ls_action
         before_each(function()
             c.register(builtins._test.toggle_line_comment)
 
             tu.edit_test_file("test-file.lua")
             lsp_wait()
-            mock_params = { textDocument = { uri = vim.uri_from_bufnr() } }
-            require("null-ls.state").clear_cache(vim.uri_from_bufnr())
-            actions = lsp.buf_request_sync(api.nvim_get_current_buf(), methods.lsp.CODE_ACTION, mock_params)
 
+            actions = get_code_actions()
             null_ls_action = actions[1].result[1]
         end)
 
@@ -52,7 +59,7 @@ describe("e2e", function()
             assert.equals(vim.tbl_count(actions[1].result), 1)
 
             assert.equals(null_ls_action.title, "Comment line")
-            assert.equals(null_ls_action.command, methods.internal.CODE_ACTION, mock_params)
+            assert.equals(null_ls_action.command, methods.internal.CODE_ACTION)
         end)
 
         it("should apply code action", function()
@@ -64,7 +71,7 @@ describe("e2e", function()
         it("should adapt code action based on params", function()
             vim.lsp.buf.execute_command(null_ls_action)
 
-            actions = lsp.buf_request_sync(api.nvim_get_current_buf(), methods.lsp.CODE_ACTION, mock_params)
+            actions = get_code_actions()
             null_ls_action = actions[1].result[1]
             assert.equals(null_ls_action.title, "Uncomment line")
 
@@ -75,7 +82,7 @@ describe("e2e", function()
         it("should combine actions from multiple sources", function()
             c.register(builtins._test.mock_code_action)
 
-            actions = lsp.buf_request_sync(api.nvim_get_current_buf(), methods.lsp.CODE_ACTION, mock_params)
+            actions = get_code_actions()
 
             assert.equals(vim.tbl_count(actions[1].result), 2)
         end)
@@ -85,7 +92,7 @@ describe("e2e", function()
             -- but action timeout is 100 ms
             c.register(builtins._test.slow_code_action)
 
-            actions = lsp.buf_request_sync(api.nvim_get_current_buf(), methods.lsp.CODE_ACTION, mock_params)
+            actions = get_code_actions()
 
             assert.equals(vim.tbl_count(actions[1].result), 1)
         end)
@@ -265,39 +272,38 @@ describe("e2e", function()
 
     describe("cached generator", function()
         local actions, null_ls_action
-        local mock_params
-        -- local mock_bufnr
         before_each(function()
             c.register(builtins._test.cached_code_action)
-            tu.edit_test_file("test-file.lua")
+            tu.edit_test_file("test-file.txt")
             lsp_wait()
-            -- mock_bufnr = vim.api.nvim_get_current_buf()
-            mock_params = { textDocument = { uri = vim.uri_from_bufnr() } }
-            require("null-ls.state").clear_cache(vim.uri_from_bufnr())
-            actions = lsp.buf_request_sync(api.nvim_get_current_buf(), methods.lsp.CODE_ACTION, mock_params)
+
+            actions = get_code_actions()
             null_ls_action = actions[1].result[1]
+        end)
+        after_each(function()
+            actions = nil
+            null_ls_action = nil
         end)
 
         it("should cache results after running action once", function()
             assert.equals(null_ls_action.title, "Not cached")
 
-            actions = lsp.buf_request_sync(api.nvim_get_current_buf(), methods.lsp.CODE_ACTION, mock_params)
+            actions = get_code_actions()
             null_ls_action = actions[1].result[1]
 
             assert.equals(null_ls_action.title, "Cached")
         end)
 
-        -- temporarily disabled, but the functionality works
+        it("should reset cache when file is edited", function()
+            assert.equals(null_ls_action.title, "Not cached")
 
-        -- it("should reset cache when file is edited", function()
-        --     assert.equals(null_ls_action.title, "Not cached")
-        --     api.nvim_buf_set_lines(mock_bufnr, 0, 1, false, { "print('new content')" })
-        --     lsp_wait()
-        --     actions = lsp.buf_request_sync(mock_bufnr, methods.lsp.CODE_ACTION, mock_params)
-        --     null_ls_action = actions[1].result[1]
+            api.nvim_buf_set_lines(0, 0, 1, false, { "print('new content')" })
+            lsp_wait()
 
-        --     assert.equals(null_ls_action.title, "Not cached")
-        -- end)
+            actions = get_code_actions()
+            null_ls_action = actions[1].result[1]
+            assert.equals(null_ls_action.title, "Not cached")
+        end)
     end)
 
     describe("sequential formatting", function()

--- a/test/spec/e2e_spec.lua
+++ b/test/spec/e2e_spec.lua
@@ -299,4 +299,30 @@ describe("e2e", function()
         --     assert.equals(null_ls_action.title, "Not cached")
         -- end)
     end)
+
+    describe("sequential formatting", function()
+        it("should format file sequentially", function()
+            c.register(builtins._test.first_formatter)
+            c.register(builtins._test.second_formatter)
+            tu.edit_test_file("test-file.txt")
+            lsp_wait()
+
+            lsp.buf.formatting()
+            lsp_wait()
+
+            assert.equals(u.buf.content(nil, true), "sequential\n")
+        end)
+
+        it("should format file according to source order", function()
+            c.register(builtins._test.second_formatter)
+            c.register(builtins._test.first_formatter)
+            tu.edit_test_file("test-file.txt")
+            lsp_wait()
+
+            lsp.buf.formatting()
+            lsp_wait()
+
+            assert.equals(u.buf.content(nil, true), "first\n")
+        end)
+    end)
 end)

--- a/test/spec/formatting_spec.lua
+++ b/test/spec/formatting_spec.lua
@@ -3,7 +3,6 @@ local mock = require("luassert.mock")
 
 local u = require("null-ls.utils")
 local c = require("null-ls.config")
-local s = require("null-ls.state")
 local methods = require("null-ls.methods")
 local generators = require("null-ls.generators")
 
@@ -26,7 +25,12 @@ describe("formatting", function()
         api = mock(vim.api, true)
 
         c._set({ save_after_format = false })
-        mock_params = { textDocument = { uri = mock_uri }, client_id = mock_client_id, bufnr = mock_bufnr }
+        mock_params = {
+            textDocument = { uri = mock_uri },
+            client_id = mock_client_id,
+            bufnr = mock_bufnr,
+            lsp_method = method,
+        }
     end)
 
     after_each(function()
@@ -51,32 +55,32 @@ describe("formatting", function()
             assert.equals(mock_params._null_ls_handled, nil)
         end)
 
-        it("should set handled flag if method matches", function()
+        it("should set handled flag if method is lsp.FORMATTING", function()
             formatting.handler(method, mock_params, handler)
 
             assert.equals(mock_params._null_ls_handled, true)
         end)
+
+        it("should set handled flag if method is lsp.RANGE_FORMATTING", function()
+            formatting.handler(methods.lsp.RANGE_FORMATTING, mock_params, handler)
+
+            assert.equals(mock_params._null_ls_handled, true)
+        end)
+
+        it("should call run_registered_sequentially with opts", function()
+            formatting.handler(methods.lsp.FORMATTING, mock_params, handler)
+
+            local opts = generators.run_registered_sequentially.calls[1].refs[1]
+
+            assert.equals(opts.filetype, vim.api.nvim_buf_get_option(mock_params.bufnr, "filetype"))
+            assert.equals(opts.method, methods.map[method])
+            assert.equals(type(opts.make_params), "function")
+            assert.equals(type(opts.callback), "function")
+            assert.equals(type(opts.after_all), "function")
+        end)
     end)
 
-    describe("apply_edits", function()
-        stub(s, "get")
-
-        local mock_edits = { { text = "new text" } }
-        local mock_diffed = {
-            text = "diffed text",
-            range = {
-                start = { line = 0, character = 10 },
-                ["end"] = { line = 35, character = 1 },
-            },
-        }
-        before_each(function()
-            s.get.returns({ client_id = mock_client_id })
-            lsp.util.compute_diff.returns(mock_diffed)
-        end)
-        after_each(function()
-            s.get:clear()
-        end)
-
+    describe("make_params", function()
         it("should call make_params with params and internal method", function()
             formatting.handler(methods.lsp.FORMATTING, mock_params, handler)
 
@@ -86,14 +90,41 @@ describe("formatting", function()
             assert.same(u.make_params.calls[1].refs[1], mock_params)
             assert.equals(u.make_params.calls[1].refs[2], methods.internal.FORMATTING)
         end)
+    end)
 
-        it("should call handler with text edits", function()
+    describe("callback", function()
+        local mock_edits = { { text = "new text" } }
+        local mock_diffed = {
+            text = "diffed text",
+            range = {
+                start = { line = 0, character = 10 },
+                ["end"] = { line = 35, character = 1 },
+            },
+        }
+        local lsp_handler = stub.new()
+        local original_handler = vim.lsp.handlers[method]
+        before_each(function()
+            vim.lsp.handlers[method] = lsp_handler
+            lsp.util.compute_diff.returns(mock_diffed)
+        end)
+        after_each(function()
+            lsp_handler:clear()
+            vim.lsp.handlers[method] = original_handler
+        end)
+
+        it("should call lsp_handler with text edit response", function()
             formatting.handler(methods.lsp.FORMATTING, mock_params, handler)
 
             local callback = generators.run_registered_sequentially.calls[1].refs[1].callback
             callback(mock_edits, mock_params)
 
-            assert.stub(handler).was_called_with({ { newText = mock_diffed.text, range = mock_diffed.range } })
+            assert.stub(lsp_handler).was_called_with(
+                nil,
+                mock_params.lsp_method,
+                { { newText = mock_diffed.text, range = mock_diffed.range } },
+                mock_params.client_id,
+                mock_params.bufnr
+            )
         end)
 
         it("should not save buffer if config option is not set", function()
@@ -101,6 +132,8 @@ describe("formatting", function()
 
             local callback = generators.run_registered_sequentially.calls[1].refs[1].callback
             callback(mock_edits, mock_params)
+            -- wait for schedule
+            vim.wait(0)
 
             assert.stub(vim.cmd).was_not_called_with(mock_bufnr .. "bufdo! silent keepjumps noautocmd update")
         end)
@@ -114,6 +147,17 @@ describe("formatting", function()
             vim.wait(0)
 
             assert.stub(vim.cmd).was_called_with(mock_bufnr .. "bufdo! silent keepjumps noautocmd update")
+        end)
+    end)
+
+    describe("after_all", function()
+        it("should call original handler with empty response", function()
+            formatting.handler(methods.lsp.FORMATTING, mock_params, handler)
+
+            local after_all = generators.run_registered_sequentially.calls[1].refs[1].after_all
+            after_all()
+
+            assert.stub(handler).was_called_with(nil, method, nil, mock_params.client_id, mock_params.bufnr)
         end)
     end)
 end)

--- a/test/spec/generators_spec.lua
+++ b/test/spec/generators_spec.lua
@@ -180,6 +180,19 @@ describe("generators", function()
             assert.equals(count, 2)
         end)
 
+        it("should call after_all after running all generators", function()
+            local after_all = stub.new()
+            generators.run_sequentially({ first_generator, second_generator }, function()
+                return mock_params
+            end, postprocess, callback, after_all)
+
+            vim.wait(50, function()
+                return #results == 2
+            end)
+
+            assert.stub(after_all).was_called(1)
+        end)
+
         it("should return no results when generators is empty", function()
             generators.run_sequentially({}, function()
                 return mock_params
@@ -226,6 +239,7 @@ describe("generators", function()
 
     describe("run_registered_sequentially", function()
         local callback = stub.new()
+        local after_all = stub.new()
 
         local run_sequentially
         before_each(function()
@@ -233,6 +247,7 @@ describe("generators", function()
         end)
         after_each(function()
             callback:clear()
+            after_all:clear()
             run_sequentially:revert()
         end)
 
@@ -246,6 +261,7 @@ describe("generators", function()
                 end,
                 postprocess = postprocess,
                 callback = callback,
+                after_all = after_all,
             }
 
             generators.run_registered_sequentially(mock_opts)
@@ -254,7 +270,8 @@ describe("generators", function()
                 { sync_generator },
                 mock_opts.make_params,
                 mock_opts.postprocess,
-                mock_opts.callback
+                mock_opts.callback,
+                mock_opts.after_all
             )
         end)
     end)


### PR DESCRIPTION
Closes #56. Also includes a bunch of changes to generator methods that should not affect anyone and a few changes to debug logs to make them less useless. 

Previously, formatters ran simultaneously, which meant that registering more than one formatter was useless (or worse). This PR makes formatting sequential, meaning that users can register multiple formatters for a given filetype and have them run in the order in which they've been registered.

At the moment, I imagine that most null-ls users are defining built-in formatters in their own configurations, so this won't cause any surprises, but integrations that register formatters should be aware of this change, since spawning processes back-to-back will inevitably slow down formatting.

I work primarily with TypeScript and Lua, where multiple formatters are (mostly) unnecessary, so I'd appreciate feedback from users of languages like Python where multiple formatters seem to be more common (cc @nghialm269, who opened the issue in the first place). 