### PR TITLE
chore(stylua): add --stdin-filepath $FILENAME

### DIFF
--- a/lua/null-ls/builtins/formatting.lua
+++ b/lua/null-ls/builtins/formatting.lua
@@ -479,7 +479,7 @@ M.stylua = h.make_builtin({
     filetypes = { "lua" },
     generator_opts = {
         command = "stylua",
-        args = h.range_formatting_args_factory({ "--search-parent-directories", "-" }),
+        args = h.range_formatting_args_factory({ "--search-parent-directories", "--stdin-filepath", "$FILENAME", "-" }),
         to_stdin = true,
     },
     factory = h.formatter_factory,


### PR DESCRIPTION
Since `--search-parent-directories` is added, maybe `--stdin-filepath` `$FILENAME` should be added to search the correct parent directories.