### PR TITLE
Feat: add Surface formatter

### DIFF
--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -532,6 +532,24 @@ local sources = { null_ls.builtins.formatting.mix }
 - `command = "mix"`
 - `args = { "format", "-" }`
 
+#### [Surface](https://hexdocs.pm/surface_formatter/readme.html)
+
+##### About
+
+A code formatter for Surface, the server-side rendering component library for Phoenix.
+
+##### Usage
+
+```lua
+local sources = { null_ls.builtins.formatting.surface }
+```
+
+##### Defaults
+
+- `filetypes = { "elixir", "surface" }`
+- `command = "mix"`
+- `args = { "surface.format", "-" }`
+
 #### [nginxbeautifier](https://github.com/vasilevich/nginxbeautifier)
 
 ##### About

--- a/lua/null-ls/builtins/formatting.lua
+++ b/lua/null-ls/builtins/formatting.lua
@@ -298,6 +298,18 @@ M.mix = h.make_builtin({
     factory = h.formatter_factory,
 })
 
+M.surface = h.make_builtin({
+    method = FORMATTING,
+    filetypes = { "elixir", "surface" },
+    generator_opts = {
+        command = "mix",
+        args = { "surface.format", "-" },
+        format = "raw",
+        to_stdin = true,
+    },
+    factory = h.formatter_factory,
+})
+
 M.nginx_beautifier = h.make_builtin({
     method = FORMATTING,
     filetypes = { "nginx" },


### PR DESCRIPTION
~~Blocked by https://github.com/surface-ui/surface_formatter/pull/37~~

This PR adds a new builtin formatter, [Surface Formatter](https://github.com/surface-ui/surface_formatter), that can format Surface template files.