### PR TITLE
Added support for D messages in flake8

### DIFF
--- a/lua/null-ls/builtins/diagnostics.lua
+++ b/lua/null-ls/builtins/diagnostics.lua
@@ -288,13 +288,14 @@ M.flake8 = h.make_builtin({
             return code == 0 or code == 255
         end,
         on_output = h.diagnostics.from_pattern(
-            [[:(%d+):(%d+): (([EFW])%w+) (.*)]], --
+            [[:(%d+):(%d+): (([DEFW])%w+) (.*)]], --
             { "row", "col", "code", "severity", "message" },
             {
                 severities = {
                     E = h.diagnostics.severities["error"],
                     W = h.diagnostics.severities["warning"],
                     F = h.diagnostics.severities["information"],
+                    D = h.diagnostics.severities["information"],
                 },
             }
         ),


### PR DESCRIPTION
I have added the possibility of showing D messages in flake8. I have found this usefull when I combine flake8 with the [flake8-docstrings](https://pypi.org/project/flake8-docstrings/) pluggin.