### PR TITLE
fix: Ensure flake8 default format

### DIFF
--- a/lua/null-ls/builtins/diagnostics.lua
+++ b/lua/null-ls/builtins/diagnostics.lua
@@ -300,7 +300,7 @@ M.flake8 = h.make_builtin({
         command = "flake8",
         to_stdin = true,
         to_stderr = true,
-        args = { "--stdin-display-name", "$FILENAME", "-" },
+        args = { "--format", "default", "--stdin-display-name", "$FILENAME", "-" },
         format = "line",
         check_exit_code = function(code)
             return code == 0 or code == 255


### PR DESCRIPTION
It's relatively common to have one format specified in `setup.cfg` that's not's the default format. By setting this flag we ensure that the format is what we expect.

https://flake8.pycqa.org/en/latest/internal/formatters.html