### PR TITLE
perf: don't update diagnostics in insert mode

### DIFF
--- a/lua/null-ls/diagnostics.lua
+++ b/lua/null-ls/diagnostics.lua
@@ -4,6 +4,58 @@ local c = require("null-ls.config")
 local methods = require("null-ls.methods")
 local generators = require("null-ls.generators")
 
+local api = vim.api
+
+local get_augroup_name = function(bufnr)
+    return string.format("NullLsInsertLeave%s", bufnr)
+end
+
+local tracked_buffers = {}
+
+local init_tracking = function(uri)
+    local bufnr = vim.uri_to_bufnr(uri)
+    api.nvim_exec(
+        string.format(
+            [[
+        augroup %s
+            autocmd!
+            autocmd InsertLeave <buffer=%s> lua require("null-ls.diagnostics").run()
+        augroup END
+            ]],
+            get_augroup_name(bufnr),
+            bufnr
+        ),
+        false
+    )
+
+    tracked_buffers[uri] = {}
+end
+
+local clear_tracking = function(uri)
+    local bufnr = vim.uri_to_bufnr(uri)
+    api.nvim_exec(
+        string.format(
+            [[
+        augroup %s
+            autocmd!
+        augroup END
+            ]],
+            get_augroup_name(bufnr)
+        ),
+        false
+    )
+
+    tracked_buffers[uri] = nil
+end
+
+local handle_tracked_change = function(uri, params)
+    if not tracked_buffers[uri] then
+        return
+    end
+
+    tracked_buffers[uri].params = params
+end
+
 local M = {}
 
 -- assume 1-indexed ranges
@@ -34,21 +86,42 @@ local postprocess = function(diagnostic, _, generator)
     diagnostic.message = formatted
 end
 
-M.handler = function(original_params)
-    if not original_params.textDocument then
+M.handler = function(params)
+    if not params.textDocument then
         return
     end
-    local method, uri = original_params.method, original_params.textDocument.uri
+
+    local method, uri = params.method, params.textDocument.uri
     if method == methods.lsp.DID_CLOSE then
         s.clear_cache(uri)
+        clear_tracking(uri)
         return
+    end
+
+    if method == methods.lsp.DID_OPEN then
+        init_tracking(uri)
     end
 
     if method == methods.lsp.DID_CHANGE then
         s.clear_cache(uri)
     end
 
-    local params = u.make_params(original_params, methods.map[method])
+    handle_tracked_change(uri, params)
+
+    if api.nvim_get_mode().mode ~= "i" then
+        M.run(uri)
+    end
+end
+
+M.run = function(uri)
+    uri = uri or vim.uri_from_bufnr(0)
+    local tracked = tracked_buffers[uri]
+    if not tracked or tracked.params.textDocument.version == tracked.version then
+        return
+    end
+
+    local method = tracked.params.method
+    local params = u.make_params(tracked.params, methods.map[method])
     generators.run_registered({
         filetype = params.ft,
         method = methods.map[method],
@@ -62,9 +135,13 @@ M.handler = function(original_params)
                 diagnostics = diagnostics,
                 uri = uri,
                 ---@diagnostic disable-next-line: redundant-parameter
-            }, original_params.client_id, nil, {})
+            }, tracked.params.client_id, nil, {})
         end,
     })
+
+    tracked.version = tracked.params.textDocument.version
 end
+
+M._tracked_buffers = tracked_buffers
 
 return M


### PR DESCRIPTION
Closes #111. 

This is working as expected (at least on my end), but to be honest I'm not thrilled with it, mostly because I feel that we're straying too far from LSP behavior here. I wonder if this would be better as a change / extension to Neovim itself, since I think the current behavior of the `update_in_insert` flag doesn't really match user expectations. 

Also, from what I understand, this is fundamentally not a null-ls issue but rather with slow linters, and it seems that other solutions like efm also suffer from [the same issue](https://github.com/mattn/efm-langserver/issues/98). Having users of problematic linters raise the value of `debounce` in their configuration is another potential solution (and one that's built-in to Neovim already). 

Finally, as I mentioned in the issue, I haven't personally experienced lag with any source on my (modest) setup, so I have no idea if this actually solves anything. If all we're doing is delaying lag until after the user exits insert mode, I don't know if this change is worth the increase in complexity. 

cc @abzcoding (since it seems like you've dealt with related issues in LunarVim)

Edit: also, yet another reason I'm lukewarm about this is that diagnostics won't immediately update / show when exiting insert mode, since that's when generators will actually run. That's probably an acceptable trade-off if it does solve the issue, though. 
