### PR TITLE
Update formatting for R language

### DIFF
--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -754,7 +754,8 @@ local sources = { null_ls.builtins.formatting.prismaFmt }
 
 ##### About
 
-Format R code automatically.
+- Format R code automatically.
+- Supports both `textDocument/formatting` and `textDocument/rangeFormatting`.
 
 ##### Usage
 
@@ -766,7 +767,7 @@ local sources = { null_ls.builtins.formatting.format_r }
 
 - `filetypes = { "r", "rmd" }`
 - `command = "R"`
-- `args = { "--slave", "--no-restore", "--no-save", '-e "formatR::tidy_source(text=readr::read_file(file(\\"stdin\\")), arrow=FALSE)"' }`
+- `args = { "--slave", "--no-restore", "--no-save", "-e", 'formatR::tidy_source(source="stdin")' }`
 
 #### [rufo](https://github.com/ruby-formatter/rufo)
 
@@ -894,6 +895,25 @@ local sources = { null_ls.builtins.formatting.shellharden }
 - `filetypes = { "sh" }`
 - `command = "shellharden"`
 - `args = { "--transform", "$FILENAME" }`
+
+#### [styler](https://github.com/r-lib/styler)
+
+##### About
+
+- Non-invasive pretty printing of R code.
+- Supports both `textDocument/formatting` and `textDocument/rangeFormatting`.
+
+##### Usage
+
+```lua
+local sources = { null_ls.builtins.formatting.styler }
+```
+
+##### Defaults
+
+- `filetypes = { "r", "rmd" }`
+- `command = "R"`
+- `args = { "--slave", "--no-restore", "--no-save", "-e", 'con=file("stdin");output=styler::style_text(readLines(con));close(con);print(output, colored=FALSE)' }`
 
 #### [StyLua](https://github.com/JohnnyMorganz/StyLua)
 

--- a/lua/null-ls/builtins/formatting.lua
+++ b/lua/null-ls/builtins/formatting.lua
@@ -209,12 +209,13 @@ M.format_r = h.make_builtin({
     filetypes = { "r", "rmd" },
     generator_opts = {
         command = "R",
-        args = {
+        args = h.range_formatting_args_factory({
             "--slave",
             "--no-restore",
             "--no-save",
-            '-e "formatR::tidy_source(text=readr::read_file(file(\\"stdin\\")), arrow=FALSE)"',
-        },
+            "-e",
+            'formatR::tidy_source(source="stdin")',
+        }),
         to_stdin = true,
     },
     factory = h.formatter_factory,
@@ -518,6 +519,23 @@ M.shellharden = h.make_builtin({
         command = "shellharden",
         args = { "--transform", "$FILENAME" },
         to_stdin = false,
+    },
+    factory = h.formatter_factory,
+})
+
+M.styler = h.make_builtin({
+    method = FORMATTING,
+    filetypes = { "r", "rmd" },
+    generator_opts = {
+        command = "R",
+        args = h.range_formatting_args_factory({
+            "--slave",
+            "--no-restore",
+            "--no-save",
+            "-e",
+            'con=file("stdin");output=styler::style_text(readLines(con));close(con);print(output, colored=FALSE)',
+        }),
+        to_stdin = true,
     },
     factory = h.formatter_factory,
 })


### PR DESCRIPTION
Details:
- Make 'format_r' actually work by moving executable code to separate argument (this seems to be needed with `loop.spawn`). And also simplify code a bit.
- Remove opinionated `arrow = FALSE` parameter (as it seems preferable to be as less opinionated in builtins as possible).
- Use `range_formatting_args_factory` as this supports range formatting.
- Add 'styler' builtin. It has rather convoluted code to ensure there are no warnings (they are written to `stderr` and confuse this plugin).

If these changes are good enough, I'll update 'BUILTINS.md'.