### PR TITLE
Update 'codespell' docs

### DIFF
--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -1084,7 +1084,7 @@ local sources = { null_ls.builtins.diagnostics.codespell }
 
 - `filetypes = { "*" }`
 - `command = "codespell"`
-- `args = { "$FILENAME" }`
+- `args = { "-" }`
 
 #### [ESLint](https://github.com/eslint/eslint)
 


### PR DESCRIPTION
Update 'codespell' docs to reflect actual default arguments.