### PR TITLE
refactor: switch to plenary jobs

### DIFF
--- a/lua/null-ls/builtins/test.lua
+++ b/lua/null-ls/builtins/test.lua
@@ -61,31 +61,6 @@ M.mock_code_action = {
     filetypes = { "lua" },
 }
 
-M.slow_code_action = h.make_builtin({
-    method = methods.internal.CODE_ACTION,
-    filetypes = { "lua" },
-    generator_opts = {
-        command = "bash",
-        args = { "./test/scripts/sleep-and-echo.sh" },
-        timeout = 100,
-        on_output = function(params, done)
-            if not params.output then
-                return done()
-            end
-
-            return done({
-                {
-                    title = "Slow mock action",
-                    action = function()
-                        print("I took too long!")
-                    end,
-                },
-            })
-        end,
-    },
-    factory = h.generator_factory,
-})
-
 M.cached_code_action = h.make_builtin({
     method = methods.internal.CODE_ACTION,
     filetypes = { "text" },

--- a/test/scripts/sleep-and-echo.sh
+++ b/test/scripts/sleep-and-echo.sh
@@ -1,2 +1,0 @@
-sleep 0.25
-echo "done"

--- a/test/spec/e2e_spec.lua
+++ b/test/spec/e2e_spec.lua
@@ -86,16 +86,6 @@ describe("e2e", function()
 
             assert.equals(vim.tbl_count(actions[1].result), 2)
         end)
-
-        it("should handle code action timeout", function()
-            -- action calls a script that waits for 250 ms,
-            -- but action timeout is 100 ms
-            c.register(builtins._test.slow_code_action)
-
-            actions = get_code_actions()
-
-            assert.equals(vim.tbl_count(actions[1].result), 1)
-        end)
     end)
 
     describe("diagnostics", function()


### PR DESCRIPTION
Closes #140 (if merged).

This knocks out ~50 lines of code from `loop.lua`. The main advantages are simplified pipe handling and the ability to register callbacks on exit, which make timeouts cleaner.  In the future, this change would let us take advantage of future Plenary features (e.g. async jobs) and potentially handle more complex cases, such as piping the output of one command into another. 

The biggest disadvantage is that Plenary splits the output of each command into lines to pass them to `on_output`, but we'll end up combining them anyways. It's not a big deal, since it's just a single `table.concat`, but it's also not ideal. The current `on_output` implementation frankly confuses me, but in the future I can see if I can put together a PR to allow jobs to call `on_output` with a command's full output. 

Overall, I'm pretty happy with the change but want to think about it a bit more before merging. I also have to fix unit tests. 