### PR TITLE
Add `$ROOT` substitution arg for LSP workspace root

### DIFF
--- a/doc/HELPERS.md
+++ b/doc/HELPERS.md
@@ -59,6 +59,8 @@ null-ls will transform the following special arguments before spawning:
 - `$FILEEXT`: replaced with the current buffer's file extension (e.g.
   `my-file.lua` produces `"lua"`)
 
+- `$ROOT`: replaced with the project root path detected by the LSP
+
 ### on_output
 
 A callback function that receives a `params` object, which contains information

--- a/doc/HELPERS.md
+++ b/doc/HELPERS.md
@@ -59,7 +59,7 @@ null-ls will transform the following special arguments before spawning:
 - `$FILEEXT`: replaced with the current buffer's file extension (e.g.
   `my-file.lua` produces `"lua"`)
 
-- `$ROOT`: replaced with the project root path detected by the LSP
+- `$ROOT`: replaced with the LSP workspace root path
 
 ### on_output
 

--- a/lua/null-ls/helpers.lua
+++ b/lua/null-ls/helpers.lua
@@ -37,6 +37,9 @@ local parse_args = function(args, params)
         if string.find(arg, "$FILEEXT") then
             arg = u.string.replace(arg, "$FILEEXT", vim.fn.fnamemodify(params.bufname, ":e"))
         end
+        if string.find(arg, "$ROOT") then
+            arg = u.string.replace(arg, "$ROOT", vim.lsp.get_client_by_id(params.client_id).config.root_dir)
+        end
 
         table.insert(parsed, arg)
     end

--- a/lua/null-ls/helpers.lua
+++ b/lua/null-ls/helpers.lua
@@ -38,7 +38,9 @@ local parse_args = function(args, params)
             arg = u.string.replace(arg, "$FILEEXT", vim.fn.fnamemodify(params.bufname, ":e"))
         end
         if string.find(arg, "$ROOT") then
-            arg = u.string.replace(arg, "$ROOT", vim.lsp.get_client_by_id(params.client_id).config.root_dir)
+            local client = vim.lsp.get_client_by_id(params.client_id)
+            local cwd = client and client.config.root_dir or vim.fn.getcwd()
+            arg = u.string.replace(arg, "$ROOT", cwd)
         end
 
         table.insert(parsed, arg)

--- a/test/spec/helpers_spec.lua
+++ b/test/spec/helpers_spec.lua
@@ -46,6 +46,28 @@ describe("helpers", function()
             assert.equals(parsed[1], "lua")
         end)
 
+        it("should replace $ROOT with LSP workspace", function()
+            local args = { "$ROOT" }
+
+            stub(vim.lsp, "get_client_by_id")
+            local cwd = "/test-dir/"
+            vim.lsp.get_client_by_id.returns({ config = { root_dir = cwd } })
+
+            local parsed = helpers._parse_args(args, { client_id = 1 })
+
+            assert.equals(parsed[1], cwd)
+        end)
+
+        it("should replace $ROOT with cwd", function()
+            local args = { "$ROOT" }
+
+            vim.lsp.get_client_by_id.returns(nil)
+
+            local parsed = helpers._parse_args(args, { client_id = nil })
+
+            assert.equals(parsed[1], vim.fn.getcwd())
+        end)
+
         it("should return unmodified argument", function()
             local args = { "--mock-flag", "mock-value" }
 


### PR DESCRIPTION
Closes #151

This adds a new substitution argument `$ROOT` for the LSP workspace root path.
