### PR TITLE
feat(helpers): add from_temp_file option

### DIFF
--- a/doc/HELPERS.md
+++ b/doc/HELPERS.md
@@ -146,6 +146,12 @@ and linters that don't accept input via `stdin`.
 Setting `to_temp_file = true` will also assign the path to the temp file to
 `params.temp_path`.
 
+### from_temp_file
+
+Reads the contents of the temp file created by `to_temp_file` after running
+`command` and assigns it to `params.content`. Useful for formatters that don't
+output to `stdin` (see `formatter_factory`).
+
 ### use_cache
 
 Caches command output on run. When available, the generator will use cached
@@ -164,11 +170,14 @@ handler will always invalidate the buffer's cache before running generators.
 `formatter_factory` is a wrapper around `generator_factory` meant to streamline
 the process of capturing a formatter's output and replacing a buffer's entire
 content with that output. It supports the same options as `generator_factory`
-but will always override the following two options:
+with the following changes:
 
-- `suppress_errors`: will always be `true`.
+- `suppress_errors`: set to `true` unless specifically set to `false`.
 
-- `on_output`: will always return an edit object to replace the current buffer's
+- `from_temp_file`: always set to `true` if `to_temp_file` is `true` (since
+  formatting from a temp file won't work otherwise).
+
+- `on_output`: will always return an edit that will replace the current buffer's
   content with formatter output. As a result, other options that depend on
   `on_output`, such as `format`, will not have an effect.
 

--- a/test/spec/e2e_spec.lua
+++ b/test/spec/e2e_spec.lua
@@ -240,6 +240,29 @@ describe("e2e", function()
 
             assert.same(api.nvim_win_get_cursor(split_win), pos)
         end)
+
+        describe("from_temp_file", function()
+            local prettier = builtins.formatting.prettier
+            local original_args = prettier._opts.args
+            before_each(function()
+                c.reset()
+
+                prettier._opts.args = { "--write", "$FILENAME" }
+                prettier._opts.to_temp_file = true
+                c.register(prettier)
+            end)
+            after_each(function()
+                prettier._opts.args = original_args
+                prettier._opts.to_temp_file = false
+            end)
+
+            it("should format file", function()
+                lsp.buf.formatting()
+                lsp_wait()
+
+                assert.equals(u.buf.content(nil, true), formatted)
+            end)
+        end)
     end)
 
     describe("range formatting", function()


### PR DESCRIPTION
Closes #167. The primary motivation is to allow LSP-style formatting for sources that don't support writing to `stdin`, but I can see it being useful elsewhere, too. 

This is still missing unit test coverage, and I'd like to add a simple E2E test using `prettier --write`. 