### PR TITLE
Missing filetype in formatting.trim_whitespace

### DIFF
--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -1036,16 +1036,21 @@ A simple wrapper around `awk` to remove trailing whitespace.
 ##### Usage
 
 ```lua
-local sources = { null_ls.builtins.formatting.trim_whitespace.with({
-    filetypes = { ... }
-}) }
+local sources = { null_ls.builtins.formatting.trim_whitespace }
 ```
 
 ##### Usage
-
-- `filetypes = one (must specify in with(), as above)`
+- `filetypes = { }`
 - `command = "awk"`
 - `args = { '{ sub(/[ \t]+$/, ""); print }' }`
+
+if you want to use this with specific filetypes you can set using `with`
+
+```lua
+local sources = { null_ls.builtins.formatting.trim_whitespace.with({
+    filetypes = { "lua", "c", "cpp }
+}) }
+```
 
 #### [uncrustify](https://github.com/uncrustify/uncrustify)
 

--- a/lua/null-ls/builtins/formatting.lua
+++ b/lua/null-ls/builtins/formatting.lua
@@ -598,6 +598,7 @@ M.terraform_fmt = h.make_builtin({
 
 M.trim_whitespace = h.make_builtin({
     method = FORMATTING,
+    filetypes = {},
     generator_opts = {
         command = "awk",
         args = { '{ sub(/[ \t]+$/, ""); print }' },


### PR DESCRIPTION
Hi, I tracked down a problem when I tried to load with `formatting.trim_whitespace` and I noticed that `filetype` was missing, so I inserted one empty not sure if this is the right answer. At least this addressed the problem and since at [lines](https://github.com/jose-elias-alvarez/null-ls.nvim/blob/main/lua/null-ls/config.lua#L89-L93) you validate they, I think it's necessary.

Regards,
Lucas