### PR TITLE
introduce phpcs diagnostic

### DIFF
--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -1447,8 +1447,28 @@ local sources = { null_ls.builtins.diagnostics.psalm }
 
 - `filetypes = { "php" }`
 - `command = "psalm"`
-- `args = { "--output-format=json", "--no-progress", "$FILENAME" },`
+- `args = { "--output-format=json", "--no-progress", "$FILENAME" }`
 
 ##### Requirements
 
 A valid `psalm.xml` at root.
+
+
+#### [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer)
+
+##### About
+
+PHP_CodeSniffer is a script that tokenizes PHP, JavaScript and CSS files to detect violations of a defined coding standard.
+
+##### Usage
+
+```lua
+local sources = { null_ls.builtins.diagnostics.phpcs }
+```
+
+##### Defaults
+
+- `filetypes = { "php" }`
+- `command = "phpcs"`
+- `args = { "--report=json", "-s", "-" }`
+

--- a/lua/null-ls/builtins/diagnostics.lua
+++ b/lua/null-ls/builtins/diagnostics.lua
@@ -492,4 +492,30 @@ M.psalm = h.make_builtin({
     factory = h.generator_factory,
 })
 
+M.phpcs = h.make_builtin({
+    method = DIAGNOSTICS,
+    filetypes = { "php" },
+    generator_opts = {
+        command = "phpcs",
+        args = { "--report=json", "-s", "-" },
+        format = "json_raw",
+        to_stdin = true,
+        from_stderr = true,
+        check_exit_code = function(code)
+            return code <= 1
+        end,
+        on_output = function(params)
+            local parser = h.diagnostics.from_json({})
+            params.messages = params.output
+                    and params.output.files
+                    and params.output.files["STDIN"]
+                    and params.output.files["STDIN"].messages
+                or {}
+
+            return parser({ output = params.messages })
+        end,
+    },
+    factory = h.generator_factory,
+})
+
 return M


### PR DESCRIPTION
This commit adds [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) analyser.

Related to #170 