### PR TITLE
Allow phpcs builtin messages to always reach output

### DIFF
--- a/lua/null-ls/builtins/diagnostics.lua
+++ b/lua/null-ls/builtins/diagnostics.lua
@@ -511,7 +511,7 @@ M.phpcs = h.make_builtin({
             "ignore_errors_on_exit",
             "1",
             -- process stdin
-            "-"
+            "-",
         },
         format = "json_raw",
         to_stdin = true,

--- a/lua/null-ls/builtins/diagnostics.lua
+++ b/lua/null-ls/builtins/diagnostics.lua
@@ -497,7 +497,22 @@ M.phpcs = h.make_builtin({
     filetypes = { "php" },
     generator_opts = {
         command = "phpcs",
-        args = { "--report=json", "-q", "-s", "-" },
+        args = {
+            "--report=json",
+            -- silence status messages during processing as they are invalid JSON
+            "-q",
+            -- always report codes
+            "-s",
+            -- phpcs exits with a non-0 exit code when messages are reported but we only want to know if the command fails
+            "--runtime-set",
+            "ignore_warnings_on_exit",
+            "1",
+            "--runtime-set",
+            "ignore_errors_on_exit",
+            "1",
+            -- process stdin
+            "-"
+        },
         format = "json_raw",
         to_stdin = true,
         from_stderr = false,

--- a/lua/null-ls/builtins/diagnostics.lua
+++ b/lua/null-ls/builtins/diagnostics.lua
@@ -497,7 +497,7 @@ M.phpcs = h.make_builtin({
     filetypes = { "php" },
     generator_opts = {
         command = "phpcs",
-        args = { "--report=json", "-s", "-" },
+        args = { "--report=json", "-q", "-s", "-" },
         format = "json_raw",
         to_stdin = true,
         from_stderr = false,

--- a/lua/null-ls/builtins/diagnostics.lua
+++ b/lua/null-ls/builtins/diagnostics.lua
@@ -505,7 +505,16 @@ M.phpcs = h.make_builtin({
             return code <= 1
         end,
         on_output = function(params)
-            local parser = h.diagnostics.from_json({})
+            local parser = h.diagnostics.from_json({
+                attributes = {
+                    severity = "type",
+                    code = "source",
+                },
+                severities = {
+                    ERROR = h.diagnostics.severities["error"],
+                    WARNING = h.diagnostics.severities["warning"],
+                }
+            })
             params.messages = params.output
                     and params.output.files
                     and params.output.files["STDIN"]

--- a/lua/null-ls/builtins/diagnostics.lua
+++ b/lua/null-ls/builtins/diagnostics.lua
@@ -500,7 +500,7 @@ M.phpcs = h.make_builtin({
         args = { "--report=json", "-s", "-" },
         format = "json_raw",
         to_stdin = true,
-        from_stderr = true,
+        from_stderr = false,
         check_exit_code = function(code)
             return code <= 1
         end,

--- a/lua/null-ls/builtins/diagnostics.lua
+++ b/lua/null-ls/builtins/diagnostics.lua
@@ -513,7 +513,7 @@ M.phpcs = h.make_builtin({
                 severities = {
                     ERROR = h.diagnostics.severities["error"],
                     WARNING = h.diagnostics.severities["warning"],
-                }
+                },
             })
             params.messages = params.output
                     and params.output.files


### PR DESCRIPTION
Support for phpcs as a diagnostic tool was added to the builtins in https://github.com/jose-elias-alvarez/null-ls.nvim/pull/178, but (unless I'm doing something incorrectly) there were a few issues. 

Firstly, this adds some overrides to the JSON parsing of the phpcs output so that its properties are correctly mapped. In particular, the `severity` was probably not correct as phpcs's message `severity` property does not map directly to the ones used by `null-ls`.

Secondly, the output from phpcs is to STDOUT, not STDERR, and so this PR changes the builtin's `from_stderr` to `false` (this sometimes worked anyway because of a separate issue, see below).

Sometimes, additional status messages are included in the phpcs output even when reporting in JSON mode, creating invalid JSON. This PR also adds the `-q` option to the phpcs call to silence the status reporting output to prevent the possibility of creating unparsable JSON.

Finally, because phpcs returns a 1 or 2 error code depending on the severity of the messages it reports, it was possible for the builtin's `check_error_code` to consider a successful run with errors to be reported as a failed run, directing its output to stderr. This meant that the builtin would work or not work depending on the type of errors being reported. To resolve this we also pass config options to phpcs to cause it to only return an error code if there is an actual error with the command.

Before this PR, the phpcs diagnostic builtin would sometimes not report any warnings or errors. After this PR it should always report correctly.

Fixes https://github.com/jose-elias-alvarez/null-ls.nvim/issues/170