### PR TITLE
Allow phpcbf builtin to consider exit codes 1 or 2 as success

### DIFF
--- a/lua/null-ls/builtins/formatting.lua
+++ b/lua/null-ls/builtins/formatting.lua
@@ -381,8 +381,17 @@ M.phpcbf = h.make_builtin({
     filetypes = { "php" },
     generator_opts = {
         command = "phpcbf",
-        args = { "-" },
+        args = {
+            -- silence status messages during processing
+            "-q",
+            -- process stdin
+            "-",
+        },
         to_stdin = true,
+        check_exit_code = function(code)
+            -- phpcbf return a 1 or 2 exit code if it detects warnings or errors
+            return code <= 2
+        end,
     },
     factory = h.formatter_factory,
 })


### PR DESCRIPTION
Related to https://github.com/jose-elias-alvarez/null-ls.nvim/pull/185

Like `phpcs`, `phpcbf` returns a 1 or 2 exit code if it detects issues that need to be changed. The downside is that this exit code can be interpreted as meaning that the command failed, when in fact it did not (the result is that the stdout output ends up being moved to stderr by the formatter and not used).

This PR alters the phpcbf formatting builtin so that it will treat a 1 or 2 error code as a success, allowing formatting to proceed.