### PR TITLE
Do not exit early when `suppress_errors = true`

### DIFF
--- a/lua/null-ls/helpers.lua
+++ b/lua/null-ls/helpers.lua
@@ -173,7 +173,10 @@ M.generator_factory = function(opts)
                     error_output = nil
                 end
 
-                if error_output and not (suppress_errors or format == output_formats.raw or format == output_formats.json_raw) then
+                if
+                    error_output
+                    and not (suppress_errors or format == output_formats.raw or format == output_formats.json_raw)
+                then
                     error("error in generator output: " .. error_output)
                     done()
                     return

--- a/lua/null-ls/helpers.lua
+++ b/lua/null-ls/helpers.lua
@@ -173,10 +173,8 @@ M.generator_factory = function(opts)
                     error_output = nil
                 end
 
-                if error_output and not (format == output_formats.raw or format == output_formats.json_raw) then
-                    if not suppress_errors then
-                        error("error in generator output: " .. error_output)
-                    end
+                if error_output and not (suppress_errors or format == output_formats.raw or format == output_formats.json_raw) then
+                    error("error in generator output: " .. error_output)
                     done()
                     return
                 end


### PR DESCRIPTION
The previous behavior was to return from the generator early if
there is any `error_output` from stderr even if
`suppress_errors = true` (given the default `from_stderr = false`).

This didn't really make sense, because aborting on an error was
already covered by `check_exit_code`, which returns an error
before the generator even starts processing output.

In the case that a command doesn't use exit codes (always returns 0),
the `raw` output method could be used to check the error output.