### PR TITLE
Follow shellcheck external sources

### DIFF
--- a/lua/null-ls/builtins/diagnostics.lua
+++ b/lua/null-ls/builtins/diagnostics.lua
@@ -184,7 +184,7 @@ M.shellcheck = h.make_builtin({
     filetypes = { "sh" },
     generator_opts = {
         command = "shellcheck",
-        args = { "--format", "json1", "-" },
+        args = { "--format", "json1", "--source-path=$DIRNAME", "--external-sources", "-" },
         to_stdin = true,
         format = "json",
         check_exit_code = function(code)

--- a/lua/null-ls/helpers.lua
+++ b/lua/null-ls/helpers.lua
@@ -31,6 +31,9 @@ local parse_args = function(args, params)
         if string.find(arg, "$FILENAME") then
             arg = u.string.replace(arg, "$FILENAME", params.bufname)
         end
+        if string.find(arg, "$DIRNAME") then
+            arg = u.string.replace(arg, "$DIRNAME", vim.fn.fnamemodify(params.bufname, ":h"))
+        end
         if string.find(arg, "$TEXT") then
             arg = u.string.replace(arg, "$TEXT", get_content(params))
         end

--- a/test/spec/helpers_spec.lua
+++ b/test/spec/helpers_spec.lua
@@ -30,6 +30,14 @@ describe("helpers", function()
             assert.equals(parsed[2], "/files/test-file.lua")
         end)
 
+        it("should replace $DIRNAME with buffer's directory name", function()
+            local args = { "--stdin-filename", "$DIRNAME" }
+
+            local parsed = helpers._parse_args(args, { bufname = "/files/test-file.lua" })
+
+            assert.equals(parsed[2], "/files")
+        end)
+
         it("should replace $TEXT with buffer content", function()
             local args = { "--stdin", "text=$TEXT" }
 


### PR DESCRIPTION
This PR adds support for following external sources for [shellcheck](https://www.mankier.com/1/shellcheck).

I have added expanding `$DIRNAME` to the parent directory of the buffer. I could not find another way to make it work.

The newly added test passes. The only tests that do not pass also did not pass on `main`, so I don't think my changes are the root cause.

## Before

![2021-09-15_11-23](https://user-images.githubusercontent.com/889383/133407522-7b99377a-7bc0-4788-9fc4-604b44ddc0d2.png)

## After 

![2021-09-15_11-24](https://user-images.githubusercontent.com/889383/133407520-b5d2297e-bc61-4a44-a819-beb5b34d51f6.png)