### PR TITLE
fix: pass filename to shfmt

### DIFF
--- a/lua/null-ls/builtins/formatting.lua
+++ b/lua/null-ls/builtins/formatting.lua
@@ -526,6 +526,7 @@ M.shfmt = h.make_builtin({
     },
     generator_opts = {
         command = "shfmt",
+        args = { "-filename", "$FILENAME" },
         to_stdin = true,
     },
     factory = h.formatter_factory,


### PR DESCRIPTION
Helps shfmt respect .editorconfig

Reference: https://github.com/mvdan/sh/blob/master/cmd/shfmt/shfmt.1.scd#parser-flags