### PR TITLE
refactor: copy params per generator

### DIFF
--- a/lua/null-ls/builtins/test.lua
+++ b/lua/null-ls/builtins/test.lua
@@ -105,24 +105,6 @@ M.cached_code_action = h.make_builtin({
     factory = h.generator_factory,
 })
 
-M.mock_diagnostics = {
-    method = methods.internal.DIAGNOSTICS,
-    generator = {
-        fn = function()
-            return {
-                {
-                    col = 1,
-                    row = 1,
-                    message = "There is something wrong with this file!",
-                    severity = 1,
-                    source = "mock-diagnostics",
-                },
-            }
-        end,
-    },
-    filetypes = { "markdown" },
-}
-
 M.first_formatter = {
     method = methods.internal.FORMATTING,
     generator = {

--- a/lua/null-ls/generators.lua
+++ b/lua/null-ls/generators.lua
@@ -17,8 +17,9 @@ M.run = function(generators, params, postprocess, callback)
         local futures, all_results = {}, {}
         for _, generator in ipairs(generators) do
             table.insert(futures, function()
+                local copied_params = vim.deepcopy(params)
                 local to_run = generator.async and a.wrap(generator.fn, 2) or generator.fn
-                local ok, results = pcall(to_run, params)
+                local ok, results = pcall(to_run, copied_params)
                 a.util.scheduler()
 
                 if not ok then
@@ -33,7 +34,7 @@ M.run = function(generators, params, postprocess, callback)
 
                 for _, result in ipairs(results) do
                     if postprocess then
-                        postprocess(result, params, generator)
+                        postprocess(result, copied_params, generator)
                     end
 
                     table.insert(all_results, result)

--- a/lua/null-ls/helpers.lua
+++ b/lua/null-ls/helpers.lua
@@ -157,7 +157,6 @@ M.generator_factory = function(opts)
 
     return {
         fn = function(params, done)
-            params = vim.deepcopy(params)
             local loop = require("null-ls.loop")
 
             if not _validated then


### PR DESCRIPTION
As discussed in #179 and the related issues, I suspected this was a regression, and in fact it was caused by cc612849a68c1eeb40986d6be50f11a5a9442acc. However, although multiple diagnostics were working well before this commit, there was still a risk of leaking, since the same `params` object was passed between generators. 

This PR moves the place where we copy params to the `generators` module, which makes more sense and simplifies testing, and also adds test coverage for this case to prevent future regressions. 

Thanks to everyone who reported issues and to @gbprod for putting in a fix. 