### PR TITLE
RFC - Dynamic source conditions

### DIFF
--- a/doc/HELPERS.md
+++ b/doc/HELPERS.md
@@ -36,6 +36,7 @@ helpers.generator_factory({
     timeout, -- number (optional)
     to_temp_file, -- boolean (optional)
     use_cache, -- boolean (optional)
+    runtime_condition, -- function (optional)
 })
 ```
 
@@ -166,6 +167,28 @@ Sources that rely on up-to-date buffer content should avoid using this option.
 
 Note that this option effectively does nothing for diagnostics, since the
 handler will always invalidate the buffer's cache before running generators.
+
+### runtime_condition
+
+Optional function that will be called when generating a list of sources to
+run for a given method. The calculations here must be conscious that this is
+called _every_ time a source is potentially run, and hence should avoid
+doing anything overly expensive.
+
+- Takes a single argument, `params`, which is a table of parameters containing
+  the following useful keys, amongst a few others (one can `print(vim.inspect(params))`
+  inside of the function to see more):
+    - `bufnr`: The buffer number being formatted
+    - `bufname`: The name of the above buffer number
+    - `client_id`: The ID of the attached client
+    - `content`: The contents of the buffer, potentially updated from formatters
+                 that have been run prior
+    - `ft`: The `filetype` of the aforementioned buffer
+- If the function returns `nil` or `false`, the associated source will be skipped,
+  otherwise it will be added to the set of valid sources to run upon meeting other
+  neccessary conditions (filetype, etc.) as well.
+- Defaults to `true`, hence any configured source will be run every time unless
+  this condition specifies otherwise.
 
 ## formatter_factory
 

--- a/doc/TESTING.md
+++ b/doc/TESTING.md
@@ -1,3 +1,39 @@
 # Testing
 
-WIP
+- The test suite includes unit and integration tests and depends on `plenary.nvim`
+- The default `test/minimal.vim` (passed to the instantiation of _Neovim_ with `-u`)
+  assumes that both `plenary.nvim` and `nvim-lspconfig` are installed one directory
+  above where this project lives. This is noted by:
+```
+...
+set rtp+=../plenary.nvim
+set rtp+=../nvim-lspconfig
+...
+```
+- From this, ensure that you have a directory structure that is something like the
+  following:
+```
+.
+├── plenary.nvim
+├── nvim-lspconfig
+└── null-ls
+```
+- As an additional note, the command used in the `Makefile` instantiates _Neovim_ with
+  `-u`, which does _not_ skip plugins in `start/` directories on `packpath`. We need
+  plugins to load in order for testing to work, so we can't use `--no-plugin` either.
+  If you have problems with _Neovim_ starting when running tests, try passing `--clean`
+  (by temporarily editing the commands in the `Makefile`), which allows us to not load
+  `start/` plugins by _default_, but still ensures that we can load plugins that are
+  manually added to our `:h runtimepath`.
+
+## Unit
+
+- Run `make test` in the root of the project to run the unit test suite
+
+## Functional
+
+- Run `FILE=test/spec/file_spec.lua make test-file` to run functional tests from a specific file
+- For example:
+```
+$ FILE=test/spec/e2e_spec.lua make test-file
+```

--- a/lua/null-ls/builtins/test.lua
+++ b/lua/null-ls/builtins/test.lua
@@ -127,4 +127,20 @@ M.second_formatter = {
     filetypes = { "text" },
 }
 
+M.runtime_skipped_formatter = {
+    method = methods.internal.FORMATTING,
+    generator = {
+        fn = function(_, done)
+            return done({ { text = "runtime" } })
+        end,
+        opts = {
+            runtime_condition = function(_)
+                return false
+            end,
+        },
+        async = true,
+    },
+    filetypes = { "text" },
+}
+
 return M

--- a/lua/null-ls/generators.lua
+++ b/lua/null-ls/generators.lua
@@ -18,6 +18,12 @@ M.run = function(generators, params, postprocess, callback)
         for _, generator in ipairs(generators) do
             table.insert(futures, function()
                 local copied_params = vim.deepcopy(params)
+
+                local runtime_condition = generator.opts and generator.opts.runtime_condition
+                if runtime_condition and not runtime_condition(copied_params) then
+                    return
+                end
+
                 local to_run = generator.async and a.wrap(generator.fn, 2) or generator.fn
                 local ok, results = pcall(to_run, copied_params)
                 a.util.scheduler()

--- a/lua/null-ls/helpers.lua
+++ b/lua/null-ls/helpers.lua
@@ -96,7 +96,7 @@ local line_output_wrapper = function(params, done, on_output)
 end
 
 M.generator_factory = function(opts)
-    local command, args, on_output, format, from_stderr, to_stdin, suppress_errors, check_exit_code, timeout, to_temp_file, from_temp_file, use_cache =
+    local command, args, on_output, format, from_stderr, to_stdin, suppress_errors, check_exit_code, timeout, to_temp_file, from_temp_file, use_cache, runtime_condition =
         opts.command,
         opts.args,
         opts.on_output,
@@ -108,7 +108,8 @@ M.generator_factory = function(opts)
         opts.timeout,
         opts.to_temp_file,
         opts.from_temp_file,
-        opts.use_cache
+        opts.use_cache,
+        opts.runtime_condition
 
     if type(check_exit_code) == "table" then
         local codes = vim.deepcopy(check_exit_code)
@@ -147,6 +148,7 @@ M.generator_factory = function(opts)
             to_temp_file = { to_temp_file, "boolean", true },
             from_temp_file = { from_temp_file, "boolean", true },
             use_cache = { use_cache, "boolean", true },
+            runtime_condition = { runtime_condition, "function", true },
         })
 
         assert(

--- a/test/spec/e2e_spec.lua
+++ b/test/spec/e2e_spec.lua
@@ -408,5 +408,17 @@ describe("e2e", function()
 
             assert.equals(u.buf.content(nil, true), "first\n")
         end)
+
+        it("should skip formatters that fail runtime conditions", function()
+            c.register(builtins._test.first_formatter)
+            c.register(builtins._test.runtime_skipped_formatter)
+            tu.edit_test_file("test-file.txt")
+            lsp_wait()
+
+            lsp.buf.formatting()
+            lsp_wait()
+
+            assert.equals(u.buf.content(nil, true), "first\n")
+        end)
     end)
 end)


### PR DESCRIPTION
Adds a `dynamic_condition` that is evaluated at "runtime" for all sources that discerns whether or not it will be run each time they have the potential to be run.

See associated discussion [here](https://github.com/jose-elias-alvarez/null-ls.nvim/discussions/202) as to why this might be useful.

Some things still to do, but curious on your thoughts @jose-elias-alvarez before messing with getting these going:

- [x] Add tests