### PR TITLE
[rustfmt] change edition to `2018`

### DIFF
--- a/lua/null-ls/builtins/formatting.lua
+++ b/lua/null-ls/builtins/formatting.lua
@@ -507,7 +507,7 @@ M.rustfmt = h.make_builtin({
     filetypes = { "rust" },
     generator_opts = {
         command = "rustfmt",
-        args = { "--emit=stdout" },
+        args = { "--emit=stdout", "--edition=2018" },
         to_stdin = true,
     },
     factory = h.formatter_factory,


### PR DESCRIPTION
Fixes #208 

I also think this is a mistake, as the builtins docs clearly say that `edition=2018` is the default