### PR TITLE
Add standardrb formatter

### DIFF
--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -948,6 +948,24 @@ local sources = { null_ls.builtins.formatting.shellharden }
 - `command = "shellharden"`
 - `args = { "--transform", "$FILENAME" }`
 
+#### [standardrb](https://github.com/testdouble/standard)
+
+##### About
+
+Ruby Style Guide, with linter & automatic code fixer. Based on Rubocop.
+
+##### Usage
+
+```lua
+local sources = { null_ls.builtins.formatting.standardrb }
+```
+
+##### Defaults
+
+- `filetypes = { "ruby" }`
+- `command = "standardrb"`
+- `args = { "--fix", "--quiet", "--stdin", "$FILENAME", "2>/dev/null", "|", "awk 'f; /^====================$/{f=1}'" }`
+
 #### [styler](https://github.com/r-lib/styler)
 
 ##### About

--- a/lua/null-ls/builtins/formatting.lua
+++ b/lua/null-ls/builtins/formatting.lua
@@ -580,7 +580,6 @@ M.standardrb = h.make_builtin({
     factory = h.formatter_factory,
 })
 
-
 M.styler = h.make_builtin({
     method = FORMATTING,
     filetypes = { "r", "rmd" },

--- a/lua/null-ls/builtins/formatting.lua
+++ b/lua/null-ls/builtins/formatting.lua
@@ -561,6 +561,26 @@ M.shellharden = h.make_builtin({
     factory = h.formatter_factory,
 })
 
+M.standardrb = h.make_builtin({
+    method = FORMATTING,
+    filetypes = { "ruby" },
+    generator_opts = {
+        command = "standardrb",
+        args = {
+            "--fix",
+            "--quiet",
+            "--stdin",
+            "$FILENAME",
+            "2>/dev/null",
+            "|",
+            "awk 'f; /^====================$/{f=1}'",
+        },
+        to_stdin = true,
+    },
+    factory = h.formatter_factory,
+})
+
+
 M.styler = h.make_builtin({
     method = FORMATTING,
     filetypes = { "r", "rmd" },


### PR DESCRIPTION
[Standardrb](https://github.com/testdouble/standard) is a Ruby style guide, formatter and fixer based on Rubocop.