### PR TITLE
Fix rubocop formatter, add diagnostics, add standardrb for both

### DIFF
--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -947,6 +947,24 @@ local sources = { null_ls.builtins.formatting.shellharden }
 - `command = "shellharden"`
 - `args = { "--transform", "$FILENAME" }`
 
+#### [standardrb](https://github.com/testdouble/standard)
+
+##### About
+
+Ruby Style Guide, with linter & automatic code fixer. Based on Rubocop.
+
+##### Usage
+
+```lua
+local sources = { null_ls.builtins.formatting.standardrb }
+```
+
+##### Defaults
+
+- `filetypes = { "ruby" }`
+- `command = "standardrb"`
+- `args = { "--fix", "--format", "quiet", "--stderr", "--stdin", "$FILENAME" }`
+
 #### [styler](https://github.com/r-lib/styler)
 
 ##### About

--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -1449,6 +1449,24 @@ local sources = { null_ls.builtins.diagnostics.selene }
 - `command = "selene"`
 - `args = { "--display-style", "quiet", "-" }`
 
+#### [standardrb](https://github.com/testdouble/standard)
+
+##### About
+
+The Ruby Linter/Formatter that Serves and Protects.
+
+##### Usage
+
+```lua
+local sources = { null_ls.builtins.diagnostics.standardrb }
+```
+
+##### Defaults
+
+- `filetypes = { "ruby" }`
+- `command = "standardrb"`
+- `args = { "--no-fix", "-f", "json", "--stdin", "$FILENAME" }`
+
 #### [phpstan](https://github.com/phpstan/phpstan)
 
 ##### About
@@ -1512,6 +1530,23 @@ local sources = { null_ls.builtins.diagnostics.phpcs }
 - `command = "phpcs"`
 - `args = { "--report=json", "-s", "-" }`
 
+#### [Rubocop](https://rubocop.org/)
+
+##### About
+
+The Ruby Linter/Formatter that Serves and Protects.
+
+##### Usage
+
+```lua
+local sources = { null_ls.builtins.diagnostics.rubocop }
+```
+
+##### Defaults
+
+- `filetypes = { "ruby" }`
+- `command = "rubocop"`
+- `args = { "-f", "json", "--stdin", "$FILENAME" }`
 
 #### [Stylelint](https://github.com/stylelint/stylelint)
 

--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -806,7 +806,6 @@ local sources = { null_ls.builtins.formatting.format_r }
 ##### About
 
 Ruby static code analyzer and formatter, based on the community Ruby style guide.
-This formatter will need [awk](https://en.wikipedia.org/wiki/AWK) to be installed on the host system to work.
 
 ##### Usage
 
@@ -818,7 +817,7 @@ local sources = { null_ls.builtins.formatting.rubocop }
 
 - `filetypes = { "ruby" }`
 - `command = "rubocop"`
-- `args = { "--auto-correct", "--stdin", "$FILENAME", "2>/dev/null", "|", "awk 'f; /^====================$/{f=1}'" }`
+- `args = { "--auto-correct", "-f", "quiet", "--stderr", "--stdin", "$FILENAME" }`
 
 
 #### [rufo](https://github.com/ruby-formatter/rufo)

--- a/doc/HELPERS.md
+++ b/doc/HELPERS.md
@@ -29,6 +29,7 @@ helpers.generator_factory({
     args, -- table (optional)
     on_output, -- function
     format, -- "raw", "line", "json", or "json_raw" (optional)
+    ignore_stderr, -- boolean (optional)
     from_stderr, -- boolean (optional)
     to_stdin, -- boolean (optional)
     suppress_errors, -- boolean (optional)
@@ -104,12 +105,25 @@ Supports the following options:
   `stderr` or from `json_decode`. Instead, it'll pass errors to `on_output` via
   `params.err`.
 
+### ignore_stderr
+
+Usually when a command outputs anything on `stderr` it would cause the command
+to fail (unless `from_stderr` is set to `true`, see below).
+
+This option tells the runner that the command's `stderr` output is irrelevant
+and should be discarded. This is similar to running a command with a
+`2>/dev/null` redirect, but the error output will still be logged in `debug`
+mode before being rejected.
+
+Note that setting `ignore_stderr = true` will make `from_stderr` not do anything.
+
 ### from_stderr
 
 Captures a command's `stderr` output and assigns it to `params.output`. Useful
 for linters that output to `stderr`.
 
-Note that setting `from_stderr = true` will discard `stdin` output.
+Note that setting `from_stderr = true` will discard `stdin` output. Will not
+work with `ignore_stderr` set.
 
 ### to_stdin
 

--- a/lua/null-ls/builtins/diagnostics.lua
+++ b/lua/null-ls/builtins/diagnostics.lua
@@ -244,7 +244,7 @@ local handle_rubocop_output = function(params)
                     warning = h.diagnostics.severities.warning,
                     error = h.diagnostics.severities.error,
                     fatal = h.diagnostics.severities.fatal,
-                }
+                },
             })
             local offenses = {}
 

--- a/lua/null-ls/builtins/diagnostics.lua
+++ b/lua/null-ls/builtins/diagnostics.lua
@@ -225,6 +225,64 @@ M.selene = h.make_builtin({
     factory = h.generator_factory,
 })
 
+local handle_rubocop_output = function(params)
+    if params.output and params.output.files then
+        local file
+        for _, file_output in ipairs(params.output.files) do
+            if file_output.path == vim.fn.fnamemodify(params.bufname, ":.") then
+                file = file_output
+                break
+            end
+        end
+
+        if file and file.offenses then
+            local parser = h.diagnostics.from_json({
+                severities = {
+                    info = h.diagnostics.severities.information,
+                    refactor = h.diagnostics.severities.hint,
+                    convention = h.diagnostics.severities.warning,
+                    warning = h.diagnostics.severities.warning,
+                    error = h.diagnostics.severities.error,
+                    fatal = h.diagnostics.severities.fatal,
+                }
+            })
+            local offenses = {}
+
+            for _, offense in ipairs(file.offenses) do
+                table.insert(offenses, {
+                    message = offense.message,
+                    ruleId = offense.cop_name,
+                    level = offense.severity,
+                    line = offense.location.start_line,
+                    column = offense.start_column,
+                    endLine = offense.location.last_line,
+                    endColumn = offense.last_column,
+                })
+            end
+
+            return parser({ output = offenses })
+        end
+    end
+
+    return {}
+end
+
+M.standardrb = h.make_builtin({
+    method = DIAGNOSTICS,
+    filetypes = { "ruby" },
+    generator_opts = {
+        command = "standardrb",
+        args = { "--no-fix", "-f", "json", "--stdin", "$FILENAME" },
+        to_stdin = true,
+        format = "json",
+        check_exit_code = function(code)
+            return code <= 1
+        end,
+        on_output = handle_rubocop_output,
+    },
+    factory = h.generator_factory,
+})
+
 local handle_eslint_output = function(params)
     params.messages = params.output and params.output[1] and params.output[1].messages or {}
     if params.err then
@@ -540,6 +598,22 @@ M.phpcs = h.make_builtin({
 
             return parser({ output = params.messages })
         end,
+    },
+    factory = h.generator_factory,
+})
+
+M.rubocop = h.make_builtin({
+    method = DIAGNOSTICS,
+    filetypes = { "ruby" },
+    generator_opts = {
+        command = "rubocop",
+        args = { "-f", "json", "--stdin", "$FILENAME" },
+        to_stdin = true,
+        format = "json",
+        check_exit_code = function(code)
+            return code <= 1
+        end,
+        on_output = handle_rubocop_output,
     },
     factory = h.generator_factory,
 })

--- a/lua/null-ls/builtins/formatting.lua
+++ b/lua/null-ls/builtins/formatting.lua
@@ -491,13 +491,14 @@ M.rubocop = h.make_builtin({
         command = "rubocop",
         args = {
             "--auto-correct",
+            "-f",
+            "quiet",
+            "--stderr",
             "--stdin",
             "$FILENAME",
-            "2>/dev/null",
-            "|",
-            "awk 'f; /^====================$/{f=1}'",
         },
         to_stdin = true,
+        ignore_stderr = true,
     },
     factory = h.formatter_factory,
 })

--- a/lua/null-ls/builtins/formatting.lua
+++ b/lua/null-ls/builtins/formatting.lua
@@ -562,6 +562,25 @@ M.shellharden = h.make_builtin({
     factory = h.formatter_factory,
 })
 
+M.standardrb = h.make_builtin({
+    method = FORMATTING,
+    filetypes = { "ruby" },
+    generator_opts = {
+        command = "standardrb",
+        args = {
+            "--fix",
+            "--format",
+            "quiet",
+            "--stderr",
+            "--stdin",
+            "$FILENAME",
+        },
+        to_stdin = true,
+        ignore_stderr = true,
+    },
+    factory = h.formatter_factory,
+})
+
 M.styler = h.make_builtin({
     method = FORMATTING,
     filetypes = { "r", "rmd" },

--- a/lua/null-ls/helpers.lua
+++ b/lua/null-ls/helpers.lua
@@ -96,11 +96,12 @@ local line_output_wrapper = function(params, done, on_output)
 end
 
 M.generator_factory = function(opts)
-    local command, args, on_output, format, from_stderr, to_stdin, suppress_errors, check_exit_code, timeout, to_temp_file, from_temp_file, use_cache, runtime_condition =
+    local command, args, on_output, format, ignore_stderr, from_stderr, to_stdin, suppress_errors, check_exit_code, timeout, to_temp_file, from_temp_file, use_cache, runtime_condition =
         opts.command,
         opts.args,
         opts.on_output,
         opts.format,
+        opts.ignore_stderr,
         opts.from_stderr,
         opts.to_stdin,
         opts.suppress_errors,
@@ -141,6 +142,7 @@ M.generator_factory = function(opts)
                 "raw, line, json, or json_raw",
             },
             from_stderr = { from_stderr, "boolean", true },
+            ignore_stderr = { ignore_stderr, "boolean", true },
             to_stdin = { to_stdin, "boolean", true },
             suppress_errors = { suppress_errors, "boolean", true },
             check_exit_code = { check_exit_code, "function", true },
@@ -172,7 +174,9 @@ M.generator_factory = function(opts)
                 u.debug_log("error output: " .. (error_output or "nil"))
                 u.debug_log("output: " .. (output or "nil"))
 
-                if from_stderr then
+                if ignore_stderr then
+                    error_output = nil
+                elseif from_stderr then
                     output = error_output
                     error_output = nil
                 end

--- a/test/spec/helpers_spec.lua
+++ b/test/spec/helpers_spec.lua
@@ -473,6 +473,17 @@ describe("helpers", function()
                 assert.stub(on_output).was_called_with({ output = "error output" }, done)
             end)
 
+            it("should ignore error output if ignore_stderr = true", function()
+                generator_args.ignore_stderr = true
+                local generator = helpers.generator_factory(generator_args)
+                generator.fn({}, done)
+
+                local wrapper = loop.spawn.calls[1].refs[3].handler
+                wrapper("error output", "normal output")
+
+                assert.stub(on_output).was_called_with({ output = "normal output" }, done)
+            end)
+
             it("should not override params.output if already set", function()
                 local params = { output = "original output" }
                 local generator = helpers.generator_factory(generator_args)


### PR DESCRIPTION
Retrying #210.

# Fixing `rubocop`

Rubocop outputs both the violations it detected and the file contents to STDOUT. The command tried to pipe this to awk in order to cut off the first half and only output the formatted file contents.

This did not work as the command wasn't run in a shell and the pipes and shell constructs were passed as real command line arguments, which Rubocop confused to be other files to check. The `--stdin` option is not allowed together with filenames, and so Rubocop exited with an error.
Adding the `--stderr` option to Rubocop makes it output only the file contents to STDOUT and the violations to STDERR.

Added a new option called `ignore_stderr` that resets STDERR after running the command so the command doesn't fail because of operator output.

Now the formatter works correctly.

# Adding `standardrb` formatter

[`standardrb` is another Ruby formatter, based on Rubocop](https://github.com/testdouble/standard), but with a slightly more modern take on the style guide, as well as fewer rules enabled.

# Adding diagnostics for both

Adds both a `rubocop` and a `standardrb` diagnostics builtin. They output their "offenses" as JSON, which is then picked up and emitted.

**Rubocop diagnostics**

![Screenshot_2021-09-29_22-54-49](https://user-images.githubusercontent.com/1599/135348348-73239640-9b13-4edc-8848-d9b260ec3417.png)

**standardrb diagnostics**

![Screenshot_2021-09-29_22-54-16](https://user-images.githubusercontent.com/1599/135348353-c78130e4-01cf-43f1-b15d-6b0e91f8cf9a.png)
