### PR TITLE
Add trim_newlines formatter

### DIFF
--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -1039,7 +1039,7 @@ A simple wrapper around `awk` to remove trailing newlines.
 local sources = { null_ls.builtins.formatting.trim_newlines }
 ```
 
-##### Usage
+##### Defaults
 - `filetypes = { }`
 - `command = "awk"`
 - `args = { 'NF{print s $0; s=""; next} {s=s ORS}' }`

--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -1027,6 +1027,31 @@ local sources = { null_ls.builtins.formatting.terraform_fmt }
 - `command = "terraform"`
 - `args = { "fmt", "-" }`
 
+#### trim_newlines
+
+##### About
+
+A simple wrapper around `awk` to remove trailing newlines.
+
+##### Usage
+
+```lua
+local sources = { null_ls.builtins.formatting.trim_newlines }
+```
+
+##### Usage
+- `filetypes = { }`
+- `command = "awk"`
+- `args = { 'NF{print s $0; s=""; next} {s=s ORS}' }`
+
+if you want to use this with specific filetypes you can set using `with`
+
+```lua
+local sources = { null_ls.builtins.formatting.trim_newlines.with({
+    filetypes = { "lua", "c", "cpp }
+}) }
+```
+
 #### trim_whitespace
 
 ##### About

--- a/lua/null-ls/builtins/formatting.lua
+++ b/lua/null-ls/builtins/formatting.lua
@@ -624,6 +624,17 @@ M.trim_whitespace = h.make_builtin({
     factory = h.formatter_factory,
 })
 
+M.trim_newlines = h.make_builtin({
+    method = FORMATTING,
+    filetypes = {},
+    generator_opts = {
+        command = "awk",
+        args = { 'NF{print s $0; s=""; next} {s=s ORS}' },
+        to_stdin = true,
+    },
+    factory = h.formatter_factory,
+})
+
 M.uncrustify = h.make_builtin({
     method = FORMATTING,
     filetypes = { "c", "cpp", "cs", "java" },


### PR DESCRIPTION
This PR follows a very similar structure to how `trim_whitespace` has been implemented to add a trailing newlines formatter.

* Adds new `trim_newlines` formatter
* Updates docs for usage information