### PR TITLE
feat(markdownlint): add rule info

### DIFF
--- a/lua/null-ls/builtins/diagnostics.lua
+++ b/lua/null-ls/builtins/diagnostics.lua
@@ -107,12 +107,12 @@ M.markdownlint = h.make_builtin({
         end,
         on_output = h.diagnostics.from_patterns({
             {
-                pattern = [[:(%d+):(%d+) [%w-/]+ (.*)]],
-                groups = { "row", "col", "message" },
+                pattern = [[:(%d+):(%d+) ([%w-/]+) (.*)]],
+                groups = { "row", "col", "code", "message" },
             },
             {
-                pattern = [[:(%d+) [%w-/]+ (.*)]],
-                groups = { "row", "message" },
+                pattern = [[:(%d+) ([%w-/]+) (.*)]],
+                groups = { "row", "code", "message" },
             },
         }),
     },

--- a/test/spec/builtins/diagnostics_spec.lua
+++ b/test/spec/builtins/diagnostics_spec.lua
@@ -77,7 +77,8 @@ describe("diagnostics", function()
             local output = "rules.md:1:1 MD033/no-inline-html Inline HTML [Element: a]"
             local diagnostic = parser(output, { content = file })
             assert.are.same({
-                row = "1", --
+                code = "MD033/no-inline-html",
+                row = "1",
                 col = "1",
                 severity = 1,
                 message = "Inline HTML [Element: a]",
@@ -88,7 +89,8 @@ describe("diagnostics", function()
                 "rules.md:2 MD012/no-multiple-blanks Multiple consecutive blank lines [Expected: 1; Actual: 2]"
             local diagnostic = parser(output, { content = file })
             assert.are.same({
-                row = "2", --
+                row = "2",
+                code = "MD012/no-multiple-blanks",
                 severity = 1,
                 message = "Multiple consecutive blank lines [Expected: 1; Actual: 2]",
             }, diagnostic)


### PR DESCRIPTION
Add rules info like `MD012/no-multiple-blanks` as `diagnostics.code`. All rules are in [here](https://github.com/DavidAnson/markdownlint/#rules--aliases)

This is what it look in [trouble.nvim](https://github.com/folke/trouble.nvim).

Without `diagnostics.code`
![mdlint0](https://user-images.githubusercontent.com/45989017/135850714-eb74e4a3-3f37-4d89-8c59-fd883e9193fe.png)

With `diagnostics.code`
![mdlint2](https://user-images.githubusercontent.com/45989017/135850740-d29debc5-b308-4e9d-8986-cf1e560872f7.png)


