### PR TITLE
fix(builtins): handle gitsigns returning nil

### DIFF
--- a/lua/null-ls/builtins/code-actions.lua
+++ b/lua/null-ls/builtins/code-actions.lua
@@ -17,7 +17,7 @@ M.gitsigns = h.make_builtin({
             end
 
             local ok, gitsigns_actions = pcall(require("gitsigns").get_actions)
-            if not ok then
+            if not ok or not gitsigns_actions then
                 return
             end
 


### PR DESCRIPTION
gitsign's [get_actions()](https://github.com/lewis6991/gitsigns.nvim/blob/main/lua/gitsigns/actions.lua#L720) may return `nil`, e.g., if the buffer is not version-controlled. Handle this case as well.