### PR TITLE
feat(builtins): create copies from with() method

### DIFF
--- a/lua/null-ls/config.lua
+++ b/lua/null-ls/config.lua
@@ -65,11 +65,11 @@ local should_register = function(source, filetypes, source_methods)
 
     for _, method in ipairs(source_methods) do
         config._methods[method] = config._methods[method] or {}
-        if config._methods[method][name] then
+        if config._methods[method][name] and not source._is_copy then
             return false
         end
 
-        config._methods[method][name] = filetypes
+        config._methods[method][name] = vim.list_extend(config._methods[method][name] or {}, filetypes)
     end
 
     return true

--- a/test/spec/config_spec.lua
+++ b/test/spec/config_spec.lua
@@ -77,7 +77,7 @@ describe("config", function()
             local source_methods = c.get()._methods
             assert.truthy(source_methods[mock_source.method])
             assert.truthy(source_methods[mock_source.method][mock_source.name])
-            assert.equals(source_methods[mock_source.method][mock_source.name], mock_source.filetypes)
+            assert.same(source_methods[mock_source.method][mock_source.name], mock_source.filetypes)
         end)
 
         it("should not register source with same name twice", function()
@@ -88,6 +88,21 @@ describe("config", function()
 
             local generators = c.get()._generators
             assert.equals(vim.tbl_count(generators[mock_source.method]), 1)
+        end)
+
+        it("should register sources with same name if they are copies", function()
+            mock_source.name = "mock-source"
+            mock_source._is_copy = true
+
+            local copy = vim.deepcopy(mock_source)
+            mock_source.filetypes = { "lua" }
+
+            c.register(mock_source)
+            c.register(copy)
+
+            local generators = c.get()._generators
+            assert.equals(vim.tbl_count(generators[mock_source.method]), 2)
+            assert.same(c.get()._methods[mock_source.method][mock_source.name], { "lua", "txt", "markdown" })
         end)
 
         it("should register function source", function()

--- a/test/spec/helpers_spec.lua
+++ b/test/spec/helpers_spec.lua
@@ -690,45 +690,51 @@ describe("helpers", function()
         end)
 
         describe("with", function()
-            it("should override filetypes and return", function()
-                local result = builtin.with({ filetypes = { "txt" } })
+            it("should create copy", function()
+                local copy = builtin.with({ filetypes = { "txt" } })
 
-                assert.same(builtin.filetypes, { "txt" })
-                assert.equals(result, builtin)
+                assert.not_same(builtin, copy)
+                assert.equals(copy._is_copy, true)
+            end)
+
+            it("should override filetypes", function()
+                local copy = builtin.with({ filetypes = { "txt" } })
+
+                assert.same(copy.filetypes, { "txt" })
             end)
 
             it("should override values on opts", function()
-                builtin.with({ timeout = 5000 })
+                local copy = builtin.with({ timeout = 5000 })
 
-                assert.equals(builtin._opts.timeout, 5000)
+                assert.equals(copy._opts.timeout, 5000)
             end)
 
             it("should override single nested value", function()
-                builtin.with({ nested = { nested_key = "new_val" } })
+                local copy = builtin.with({ nested = { nested_key = "new_val" } })
 
-                assert.equals(builtin._opts.nested.nested_key, "new_val")
-                assert.equals(builtin._opts.nested.other_nested, "original_val")
+                assert.equals(copy._opts.nested.nested_key, "new_val")
+                assert.equals(copy._opts.nested.other_nested, "original_val")
             end)
 
             it("should extend args with extra_args table", function()
-                builtin.with({ extra_args = { "user_first", "user_second" } })
+                local copy = builtin.with({ extra_args = { "user_first", "user_second" } })
 
-                assert.equals(type(builtin._opts.args), "function")
-                assert.are.same(builtin._opts.args(), { "first", "second", "user_first", "user_second" })
+                assert.equals(type(copy._opts.args), "function")
+                assert.are.same(copy._opts.args(), { "first", "second", "user_first", "user_second" })
                 -- Multiple calls should yield the same results
-                assert.are.same(builtin._opts.args(), { "first", "second", "user_first", "user_second" })
+                assert.are.same(copy._opts.args(), { "first", "second", "user_first", "user_second" })
             end)
 
             it("should extend args with extra_args function", function()
-                builtin.with({
+                local copy = builtin.with({
                     extra_args = function()
                         return { "user_first", "user_second" }
                     end,
                 })
 
-                assert.equals(type(builtin._opts.args), "function")
-                assert.are.same(builtin._opts.args(), { "first", "second", "user_first", "user_second" })
-                assert.are.same(builtin._opts.args(), { "first", "second", "user_first", "user_second" })
+                assert.equals(type(copy._opts.args), "function")
+                assert.are.same(copy._opts.args(), { "first", "second", "user_first", "user_second" })
+                assert.are.same(copy._opts.args(), { "first", "second", "user_first", "user_second" })
             end)
 
             it("should set args to extra_args if args is nil", function()
@@ -741,10 +747,10 @@ describe("helpers", function()
                     },
                 }
                 builtin = helpers.make_builtin(test_opts)
-                builtin.with({ extra_args = { "user_first", "user_second" } })
+                local copy = builtin.with({ extra_args = { "user_first", "user_second" } })
 
-                assert.equals(type(builtin._opts.args), "function")
-                assert.are.same(builtin._opts.args(), { "user_first", "user_second" })
+                assert.equals(type(copy._opts.args), "function")
+                assert.are.same(copy._opts.args(), { "user_first", "user_second" })
             end)
 
             it("should extend args with extra_args, but keep '-' arg last", function()
@@ -758,23 +764,22 @@ describe("helpers", function()
                     },
                 }
                 builtin = helpers.make_builtin(test_opts)
-                builtin.with({ extra_args = { "user_first", "user_second" } })
+                local copy = builtin.with({ extra_args = { "user_first", "user_second" } })
 
-                assert.equals(type(builtin._opts.args), "function")
-                assert.are.same(builtin._opts.args(), { "first", "second", "user_first", "user_second", "-" })
+                assert.equals(type(copy._opts.args), "function")
+                assert.are.same(copy._opts.args(), { "first", "second", "user_first", "user_second", "-" })
                 -- Multiple calls should yield the same results
-                assert.are.same(builtin._opts.args(), { "first", "second", "user_first", "user_second", "-" })
+                assert.are.same(copy._opts.args(), { "first", "second", "user_first", "user_second", "-" })
             end)
 
             it("should wrap builtin with condition", function()
-                local wrapped = builtin.with({
+                local wrapped_copy = builtin.with({
                     condition = function()
                         return true
                     end,
                 })
 
-                assert.equals(type(wrapped), "function")
-                assert.equals(wrapped(), builtin)
+                assert.equals(type(wrapped_copy), "function")
             end)
         end)
 


### PR DESCRIPTION
Closes #247.

As discussed in the linked issue, this PR makes it so that the `with` method for built-ins automatically returns a copy of the built-in, making it possible to register the same built-in multiple times with different config options. I also changed how the registration check works to allow registering multiple copies with the same name, which avoids the need to change the name when making a copy.

One pitfall is that if a user registers the same built-in multiple times with, say, an overlapping condition, the source will naturally be registered multiple times, and that fact won't be immediately obvious (since it will only show up once in `:NullLsInfo`). For example, this config will cause `stylua` to run twice if Neovim is opened in a working directory containing both `stylua.toml` and `other-project-marker`:

```lua
local null_ls = require("null-ls")
local b = null_ls.builtins

local sources = {
    b.formatting.stylua.with({
        condition = function(utils)
            return utils.root_has_file("stylua.toml")
        end,
    }),
    b.formatting.stylua.with({
        condition = function(utils)
            return utils.root_has_file("other-project-marker")
        end,
    }),
}
```

That's arguably just an issue with the user's configuration, though, and I think avoiding the need to set a unique name is convenient (and matches user expectations), but if this is a problem, we could require unique names and warn the user in this situation. 

@Nargonath Let me know what you think. 