### PR TITLE
hotfix(builtins.cppcheck): Remove missingInclude,information option

### DIFF
--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -1401,7 +1401,7 @@ local sources = { null_ls.builtins.diagnostics.cppcheck }
 
 - `filetypes = { "cpp" , "c" }`
 - `command = "cppcheck"`
-- `args = { "--enable=warning,style,performance,portability,information,missingInclude", "--template=gcc", "$FILENAME" }`
+- `args = { "--enable=warning,style,performance,portability", "--template=gcc", "$FILENAME" }`
 
 #### [write-good](https://github.com/btford/write-good)
 

--- a/lua/null-ls/builtins/diagnostics.lua
+++ b/lua/null-ls/builtins/diagnostics.lua
@@ -749,7 +749,7 @@ M.cppcheck = h.make_builtin({
     generator_opts = {
         command = "cppcheck",
         args = {
-            "--enable=warning,style,performance,portability,information,missingInclude",
+            "--enable=warning,style,performance,portability",
             "--template=gcc",
             "$FILENAME",
         },


### PR DESCRIPTION
missingInclude causes Cppcheck to generate nagging warnings in all
header files unless -I <dir> or --includes-file=<file> or --include=<file>
are specified as arguments which isn't practical or feasible.
cppcheck does not need standard library headers to get proper results.

Remove information because it enables missingInclude