### PR TITLE
feat(hadolint): add Dockerfile to filetypes

### DIFF
--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -1363,7 +1363,7 @@ local sources = { null_ls.builtins.diagnostics.hadolint }
 
 ##### Defaults
 
-- `filetypes = { "dockerfile" }`
+- `filetypes = { "Dockerfile", "dockerfile" }`
 - `command = "hadolint"`
 - `args = { "--no-fail", "--format=json", "$FILENAME" }`
 

--- a/lua/null-ls/builtins/diagnostics.lua
+++ b/lua/null-ls/builtins/diagnostics.lua
@@ -419,7 +419,7 @@ M.eslint_d = h.make_builtin({
 
 M.hadolint = h.make_builtin({
     method = DIAGNOSTICS,
-    filetypes = { "dockerfile" },
+    filetypes = { "Dockerfile", "dockerfile" },
     generator_opts = {
         command = "hadolint",
         format = "json",


### PR DESCRIPTION
ekalinin/Dockerfile.vim uses Dockerfile as a filetype, causing hadolint not to be activated when editing Dockerfile files.

nvim-lspconfig also uses both filetypes for activating dockerls, so I think it makes sense to have them both for hadolint too until this is eventually changed in Dockerfile.vim. (see linked issue)

See:

- https://github.com/neovim/nvim-lspconfig/blob/cd1ccf0/lua/lspconfig/dockerls.lua#L10
- https://github.com/ekalinin/Dockerfile.vim/issues/67