### PR TITLE
fix(builtins): Make finding credo cwd smarter

### DIFF
--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -257,7 +257,8 @@ local sources = { null_ls.builtins.formatting.cmake_format }
 
 Static analysis for `elixir` files for enforcing code consistency.
 
-- Searches _downward_ from the project root, so it should work for most projects, including umbrella projects with a single credo config. The `cwd` parameter may be overwritten for other project structures such as to search upwards for umbrella projects with per-application configurations.
+- Searches upwards from the buffer to the project root and tries to find the first `.credo.exs` file in case nested credo configs are used.
+- When not using a global credo install, the diagnostic can be disable with a conditional checking for the config file with `utils.root_has_file('.credo.exs')`
 
 ##### Usage
 
@@ -269,7 +270,7 @@ local sources = { null_ls.builtins.diagnostics.credo }
 
 - `filetypes = { "elixir" }`
 - `command = "mix"`
-- `args = { "credo", "suggest", "--format", "json", "$FILENAME" }`
+- `args = { "credo", "suggest", "--format", "json", "--read-from-stdin", "$FILENAME" }`
 
 #### [crystal-format](https://crystal-lang.org/2015/10/16/crystal-0.9.0-released.html)
 

--- a/lua/null-ls/builtins/diagnostics.lua
+++ b/lua/null-ls/builtins/diagnostics.lua
@@ -44,46 +44,63 @@ M.credo = h.make_builtin({
     filetypes = { "elixir" },
     generator_opts = {
         command = "mix",
+        --NOTE: search upwards to look for the credo config file
         cwd = function(params)
-            mix_file = vim.fn.findfile("mix.exs", params.root .. "/**")
-            if mix_file then
-                return vim.fn.fnamemodify(mix_file, ":p:h")
+            local match = vim.fn.findfile(".credo.exs", vim.fn.fnamemodify(params.bufname, ":h") .. ";" .. params.root)
+
+            if match then
+                return vim.fn.fnamemodify(match, ":h")
+            else
+                return params.root
             end
         end,
-        args = { "credo", "suggest", "--format", "json", "$FILENAME" },
-        format = "json",
+        args = { "credo", "suggest", "--format", "json", "--read-from-stdin", "$FILENAME" },
+        format = "json_raw",
+        to_stdin = true,
         from_stderr = true,
         on_output = function(params)
             issues = {}
 
-            for _, issue in ipairs(params.output.issues) do
-                err = {
-                    message = issue.message,
-                    row = issue.line_no,
+            if params.output and params.output.issues then
+                for _, issue in ipairs(params.output.issues) do
+                    err = {
+                        message = issue.message,
+                        row = issue.line_no,
+                        source = "credo",
+                    }
+
+                    --NOTE: priority is dynamic, ranges are from credo source
+                    --could use `from_json` helper if mapped to same severity
+                    if issue.priority >= 10 then
+                        err.severity = h.diagnostics.severities.error
+                    elseif issue.priority >= 0 then
+                        err.severity = h.diagnostics.severities.warning
+                    elseif issue.priority >= -10 then
+                        err.severity = h.diagnostics.severities.information
+                    else
+                        err.severity = h.diagnostics.severities.hint
+                    end
+
+                    if issue.column and issue.column ~= vim.NIL then
+                        err.col = issue.column
+                    end
+
+                    if issue.column_end and issue.column_end ~= vim.NIL then
+                        err.end_col = issue.column_end
+                    end
+
+                    table.insert(issues, err)
+                end
+            end
+
+            --NOTE: by using stdin, partial files get sent that won't compile but
+            --it can be reported for feedback in case any other errors occur as well
+            if params.err then
+                table.insert(issues, {
+                    message = params.err,
+                    row = 1,
                     source = "credo",
-                }
-
-                --NOTE: priority is dynamic, ranges are from credo source
-                --could use `from_json` helper if mapped to same severity
-                if issue.priority >= 10 then
-                    err.severity = h.diagnostics.severities.error
-                elseif issue.priority >= 0 then
-                    err.severity = h.diagnostics.severities.warning
-                elseif issue.priority >= -10 then
-                    err.severity = h.diagnostics.severities.information
-                else
-                    err.severity = h.diagnostics.severities.hint
-                end
-
-                if issue.column and issue.column ~= vim.NIL then
-                    err.col = issue.column
-                end
-
-                if issue.column_end and issue.column_end ~= vim.NIL then
-                    err.end_col = issue.column_end
-                end
-
-                table.insert(issues, err)
+                })
             end
 
             return issues

--- a/test/spec/builtins/diagnostics_spec.lua
+++ b/test/spec/builtins/diagnostics_spec.lua
@@ -142,6 +142,18 @@ describe("diagnostics", function()
                 },
             }, diagnostic)
         end)
+        it("returns errors as diagnostics", function()
+            local error =
+                [[** (Mix) The task "credo" could not be found\nNote no mix.exs was found in the current directory]]
+            local diagnostic = parser({ err = error })
+            assert.are.same({
+                {
+                    source = "credo",
+                    message = error,
+                    row = 1,
+                },
+            }, diagnostic)
+        end)
     end)
 
     describe("luacheck", function()


### PR DESCRIPTION
Make the cwd smarter by searching upwards from the buffer but limited to
the project root and then trying to find the most specific match. It
should prevent excessive searches and erroneous other matches like
adjacent projects.

Switching to `json_raw` allows for silencing errors in projects that
do not use creo, but any other errors should still be reported.

Also use stdin to get more rapid feedback when changing files.