### PR TITLE
Format toml with prettier

### DIFF
--- a/lua/null-ls/builtins/formatting.lua
+++ b/lua/null-ls/builtins/formatting.lua
@@ -434,6 +434,7 @@ M.prettier = h.make_builtin({
         "less",
         "html",
         "json",
+        "toml",
         "yaml",
         "markdown",
         "graphql",


### PR DESCRIPTION
This PR adds a `toml` file type to a target of a `prettier` formatter.
