### PR TITLE
Ignore statix failed parsing

### DIFF
--- a/lua/null-ls/builtins/code-actions.lua
+++ b/lua/null-ls/builtins/code-actions.lua
@@ -78,6 +78,7 @@ M.statix = h.make_builtin({
         args = { "check", "--format=json", "--", "$FILENAME" },
         format = "json",
         to_temp_file = true,
+        ignore_stderr = true,
         on_output = function(params)
             local actions = {}
             for _, r in ipairs(params.output.report) do

--- a/lua/null-ls/builtins/diagnostics.lua
+++ b/lua/null-ls/builtins/diagnostics.lua
@@ -724,6 +724,7 @@ M.statix = h.make_builtin({
         args = { "check", "--format=errfmt", "--", "$FILENAME" },
         format = "line",
         to_temp_file = true,
+        ignore_stderr = true,
         on_output = h.diagnostics.from_pattern(
             [[>(%d+):(%d+):(.):(%d+):(.*)]],
             { "row", "col", "severity", "code", "message" },


### PR DESCRIPTION
I missed this earlier...  Parsing errors is output on stderr