### PR TITLE
feat: allow specifically disabling filetypes

### DIFF
--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -72,8 +72,26 @@ local sources = {
 See the descriptions below or the relevant `builtins` source file to see the
 default options passed to each built-in source.
 
-Note that setting `filetypes = {}` will enable the source for all filetypes,
-which isn't recommended for most sources.
+### Filetypes
+
+If you see `filetypes = {}` in a source's description, that means the source is
+active for all filetypes by default. In this case, you can specifically disable
+a filetype by setting its value to `false`, e.g.:
+
+```lua
+local sources = {
+    null_ls.builtins.code_actions.gitsigns.with({
+        -- active for all filetypes except Lua
+        filetypes = { lua = false },
+    }),
+}
+```
+
+Note that mixing these two structures is not allowed; a source is either active
+for a specified list of filetypes, or active for all filetypes except those
+disabled.
+
+### Arguments
 
 You can override `args` using `with({ args = your_args })`, but if you want to
 add more flags, you should use `extra_args` instead:
@@ -86,6 +104,8 @@ local sources = {
   }
 ```
 
+### Expansion
+
 Note that environment variables and `~` aren't expanded in arguments. As a
 workaround, you can use `vim.fn.expand`:
 
@@ -96,6 +116,8 @@ local sources = {
     }),
 }
 ```
+
+### Diagnostics Format
 
 For diagnostics sources, you can change the format of diagnostic messages by
 setting `diagnostics_format`:

--- a/lua/null-ls/config.lua
+++ b/lua/null-ls/config.lua
@@ -43,7 +43,10 @@ end
 local config = vim.deepcopy(defaults)
 
 local register_filetypes = function(filetypes)
-    if vim.tbl_isempty(filetypes) then
+    if
+        vim.tbl_isempty(filetypes) -- empty list
+        or not vim.tbl_islist(filetypes) -- disabled filetypes, e.g. { lua = false }
+    then
         config._all_filetypes = true
         return
     end
@@ -69,7 +72,9 @@ local should_register = function(source, filetypes, source_methods)
             return false
         end
 
-        config._methods[method][name] = vim.list_extend(config._methods[method][name] or {}, filetypes)
+        config._methods[method][name] = vim.tbl_islist(filetypes)
+                and vim.list_extend(config._methods[method][name] or {}, filetypes)
+            or vim.tbl_extend("force", config._methods[method][name] or {}, filetypes)
     end
 
     return true

--- a/lua/null-ls/lspconfig.lua
+++ b/lua/null-ls/lspconfig.lua
@@ -7,22 +7,20 @@ local api = vim.api
 local M = {}
 
 function M.setup()
-    local configs = require("lspconfig/configs")
-    local util = require("lspconfig/util")
-
-    local config_def = {
+    local lsputil = require("lspconfig.util")
+    local default_config = {
         cmd = { "nvim" },
         name = "null-ls",
         root_dir = function(fname)
-            return util.root_pattern("Makefile", ".git")(fname) or util.path.dirname(fname)
+            return lsputil.root_pattern("Makefile", ".git")(fname) or lsputil.path.dirname(fname)
         end,
         flags = { debounce_text_changes = c.get().debounce },
         filetypes = c.get()._filetypes,
         autostart = false,
     }
 
-    configs["null-ls"] = {
-        default_config = config_def,
+    require("lspconfig/configs")["null-ls"] = {
+        default_config = default_config,
     }
 
     -- listen on FileType and try attaching

--- a/lua/null-ls/utils.lua
+++ b/lua/null-ls/utils.lua
@@ -52,7 +52,19 @@ M.debug_log = function(...)
 end
 
 M.filetype_matches = function(filetypes, ft)
-    return vim.tbl_isempty(filetypes) or vim.tbl_contains(filetypes, ft)
+    -- simple list of enabled filetypes, e.g. { "lua", "tl" }
+    if vim.tbl_islist(filetypes) then
+        return vim.tbl_isempty(filetypes) or vim.tbl_contains(filetypes, ft)
+    end
+
+    -- allow specifically disabling filetypes with a table, e.g. { lua = "false" }
+    for key, val in pairs(filetypes) do
+        if key == ft and val == false then
+            return false
+        end
+    end
+
+    return true
 end
 
 M.get_client = function()

--- a/test/spec/config_spec.lua
+++ b/test/spec/config_spec.lua
@@ -60,6 +60,24 @@ describe("config", function()
             assert.equals(c.get()._all_filetypes, true)
         end)
 
+        it("should set all_filetypes if filetypes only contains disabled filetypes", function()
+            mock_source.filetypes = { lua = false }
+
+            c.register(mock_source)
+
+            assert.equals(vim.tbl_count(c.get()._filetypes), 0)
+            assert.equals(c.get()._all_filetypes, true)
+        end)
+
+        it("should handle mixed table", function()
+            mock_source.filetypes = { lua = false, "tl" }
+
+            c.register(mock_source)
+
+            assert.equals(vim.tbl_count(c.get()._filetypes), 0)
+            assert.equals(c.get()._all_filetypes, true)
+        end)
+
         it("should throw if source method is invalid", function()
             mock_source.method = "badMethod"
 
@@ -78,6 +96,26 @@ describe("config", function()
             assert.truthy(source_methods[mock_source.method])
             assert.truthy(source_methods[mock_source.method][mock_source.name])
             assert.same(source_methods[mock_source.method][mock_source.name], mock_source.filetypes)
+        end)
+
+        it("should register table of disabled filetypes under methods", function()
+            mock_source.name = "mock-source"
+            mock_source.filetypes = { lua = false }
+
+            c.register(mock_source)
+
+            local source_methods = c.get()._methods
+            assert.same(source_methods[mock_source.method][mock_source.name], { lua = false })
+        end)
+
+        it("should register mixed table of filetypes under methods", function()
+            mock_source.name = "mock-source"
+            mock_source.filetypes = { lua = false, "tl" }
+
+            c.register(mock_source)
+
+            local source_methods = c.get()._methods
+            assert.same(source_methods[mock_source.method][mock_source.name], { lua = false, "tl" })
         end)
 
         it("should not register source with same name twice", function()

--- a/test/spec/utils_spec.lua
+++ b/test/spec/utils_spec.lua
@@ -25,31 +25,71 @@ describe("utils", function()
     end)
 
     describe("filetype_matches", function()
-        it("should return true when filetypes is empty", function()
-            local filetypes = {}
-            local ft = "lua"
+        describe("list", function()
+            it("should return true when filetypes is empty", function()
+                local filetypes = {}
+                local ft = "lua"
 
-            local matches = u.filetype_matches(filetypes, ft)
+                local matches = u.filetype_matches(filetypes, ft)
 
-            assert.equals(matches, true)
+                assert.equals(matches, true)
+            end)
+
+            it("should return true when filetypes includes ft", function()
+                local filetypes = { "lua" }
+                local ft = "lua"
+
+                local matches = u.filetype_matches(filetypes, ft)
+
+                assert.equals(matches, true)
+            end)
+
+            it("should return false when filetypes is not empty and does not include ft", function()
+                local filetypes = { "javascript" }
+                local ft = "lua"
+
+                local matches = u.filetype_matches(filetypes, ft)
+
+                assert.equals(matches, false)
+            end)
         end)
 
-        it("should return true when filetypes includes ft", function()
-            local filetypes = { "lua" }
-            local ft = "lua"
+        describe("table", function()
+            it("should return false when filetype is specifically disabled", function()
+                local filetypes = { lua = false }
+                local ft = "lua"
 
-            local matches = u.filetype_matches(filetypes, ft)
+                local matches = u.filetype_matches(filetypes, ft)
 
-            assert.equals(matches, true)
-        end)
+                assert.equals(matches, false)
+            end)
 
-        it("should return false when filetypes is not empty and does not include ft", function()
-            local filetypes = { "javascript" }
-            local ft = "lua"
+            it("should handle mixed table", function()
+                local filetypes = { tl = false, "lua" }
+                local ft = "tl"
 
-            local matches = u.filetype_matches(filetypes, ft)
+                local matches = u.filetype_matches(filetypes, ft)
 
-            assert.equals(matches, false)
+                assert.equals(matches, false)
+            end)
+
+            it("should return true when mixed table doesn't specifically disable filetype", function()
+                local filetypes = { tl = false, "lua" }
+                local ft = "other_ft"
+
+                local matches = u.filetype_matches(filetypes, ft)
+
+                assert.equals(matches, true)
+            end)
+
+            it("should return true when filetype is not specifically disabled", function()
+                local filetypes = { tl = false }
+                local ft = "lua"
+
+                local matches = u.filetype_matches(filetypes, ft)
+
+                assert.equals(matches, true)
+            end)
         end)
     end)
 


### PR DESCRIPTION
We now have a number of built-ins that are enabled for all filetypes, and users have asked about the possibility of specifically disabling filetypes for these sources (#222, #49). As I mentioned in the first discussion, it's now possible to work around this by using `runtime_condition`, but it's not the cleanest solution. 

This PR makes it possible to disable filetypes by setting `filetypes` to a table where the key contains the filetype and the value is `false`, e.g.:

```lua
local sources = {
    null_ls.builtins.code_actions.gitsigns.with({
        -- active for all filetypes except Lua
        filetypes = { lua = false },
    }),
}
```

This is the cleanest approach I can think of, since we can reuse the existing config key. However, there is a drawback, which I mentioned in the documentation:

> Note that mixing these two structures is not allowed; a source is either active for a specified list of filetypes, or active for all filetypes except those disabled.

That means that the following attempts to configure `filetypes` will not work as expected (though they won't break anything):

```lua
local sources = {
    null_ls.builtins.code_actions.gitsigns.with({
        -- active for all filetypes, not just tl
        -- doing this doesn't really make sense in the first place, 
        -- since just { "tl" } will achieve the desired result
        filetypes = { lua = false, tl = true },
    }),
    null_ls.builtins.code_actions.gitsigns.with({
        -- same result as above
        filetypes = { lua = false, "tl" },
    }),
}
```

Other solutions like adding a new config key (e.g. `disabled_filetypes`) would also create weird interactions and add complexity, so I'm pretty happy with this. Since it's not an option that I'll personally use, I'd be happy to hear from anyone who is interested in this feature (cc @gegoune and @briandipalma from the discussion). 