### PR TITLE
Taplo as TOML formatter

### DIFF
--- a/lua/null-ls/builtins/formatting.lua
+++ b/lua/null-ls/builtins/formatting.lua
@@ -434,7 +434,6 @@ M.prettier = h.make_builtin({
         "less",
         "html",
         "json",
-        "toml",
         "yaml",
         "markdown",
         "graphql",


### PR DESCRIPTION
This PR adds a built-in formatter of [Taplo](https://github.com/tamasfe/taplo) for TOML.

It also removes TOML from Prettier's target based on feedback in #291.