### PR TITLE
fix: ignore stderr output when running rustfmt

### DIFF
--- a/lua/null-ls/builtins/formatting.lua
+++ b/lua/null-ls/builtins/formatting.lua
@@ -557,6 +557,7 @@ M.rustfmt = h.make_builtin({
         command = "rustfmt",
         args = { "--emit=stdout", "--edition=2018" },
         to_stdin = true,
+        ignore_stderr = true,
     },
     factory = h.formatter_factory,
 })


### PR DESCRIPTION
when rust logging is active globally ( via setting `RUST_LOG=trace` )
`rustfmt` will print debug output to stderr.

I manually tested this with a new, custom source so I assume this will also work. 

I'm happy to add any needed documentation or tests if I need to. 