### PR TITLE
feat: Initial implementation for completion support

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ null-ls sources are able to hook into the following LSP features:
 
 - Hover
 
+- Completion
+
 null-ls includes built-in sources for each of these features to provide
 out-of-the-box functionality. See [BUILTINS](doc/BUILTINS.md) for instructions on
 how to set up sources and a list of available sources.
@@ -69,12 +71,14 @@ integration with nvim-lspconfig, as in this example:
 ```lua
 -- example configuration! (see CONFIG above to make your own)
 require("null-ls").config({
-    sources = { require("null-ls").builtins.formatting.stylua }
+	sources = {
+		require("null-ls").builtins.formatting.stylua,
+		require("null-ls").builtins.completion.spell,
+	},
 })
 require("lspconfig")["null-ls"].setup({
-    on_attach = my_custom_on_attach
+	on_attach = my_custom_on_attach,
 })
-
 ```
 
 ## Documentation

--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -1903,6 +1903,11 @@ If you are using a completion plugin, they can also leverage these custom comple
 local sources = { null_ls.builtins.completion.spell }
 ```
 
-##### Defaults
+If you want to disable spell suggestions when `spell` options is not set, you can use the
+following snippet:
 
-- `null_ls.builtins.completion.spell` requires `spell` option to be set.
+```lua
+runtime_condition = function(_)
+    return vim.opt_local.spell:get()
+end
+```

--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -1887,23 +1887,29 @@ local sources = { null_ls.builtins.hover.dictionary }
 
 ### Completion
 
+#### Tags
+
 ##### About
 
-Completion sources provide an easy way for you to add custom completion to your project. When
-Neovim runs `omnifunc`, the null-ls will return completion item from registered sources.
+Tags source for completion. Only works if you have `tags` options set.
 
-If you are using a completion plugin, they can also leverage these custom completion sources.
-
-##### Usage
-
-- Proof-of-concept for completion functionality.
-- See the completion section of [the documentation](MAIN.md) for details.
+###### Usage
 
 ```lua
-local sources = { null_ls.builtins.completion.spell, null_ls.builtins.completion.tags }
+local sources = { null_ls.builtins.completion.tags }
 ```
 
-Tags source won't be available if you don't have the `tags` option set for Neovim,
+#### Spell
+
+##### About
+
+Spell suggestions completion source.
+
+###### Usage
+
+```lua
+local sources = { null_ls.builtins.completion.spell }
+```
 
 If you want to disable spell suggestions when `spell` options is not set, you can use the
 following snippet:

--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -1884,3 +1884,26 @@ local sources = { null_ls.builtins.hover.dictionary }
 ##### Defaults
 
 - `filetypes = { "txt", "markdown" }`
+
+### Completion
+
+##### About
+
+Completion sources provide an easy way for you to add custom completion to your project. When
+Neovim runs `omnifunc`, the null-ls will return completion item from registered sources.
+
+If you are using a completion plugin, they can also leverage these custom completion sources.
+
+##### Usage
+
+- Proof-of-concept for completion functionality.
+- See the completion section of [the documentation](MAIN.md) for details.
+
+```lua
+local sources = { null_ls.builtins.completion.tags, null_ls.builtins.completion.spell }
+```
+
+##### Defaults
+
+- `null_ls.builtins.completion.tags` requires `tags` option to be set.
+- `null_ls.builtins.completion.spell` requires `spell` option to be set.

--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -1900,10 +1900,9 @@ If you are using a completion plugin, they can also leverage these custom comple
 - See the completion section of [the documentation](MAIN.md) for details.
 
 ```lua
-local sources = { null_ls.builtins.completion.tags, null_ls.builtins.completion.spell }
+local sources = { null_ls.builtins.completion.spell }
 ```
 
 ##### Defaults
 
-- `null_ls.builtins.completion.tags` requires `tags` option to be set.
 - `null_ls.builtins.completion.spell` requires `spell` option to be set.

--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -1900,8 +1900,10 @@ If you are using a completion plugin, they can also leverage these custom comple
 - See the completion section of [the documentation](MAIN.md) for details.
 
 ```lua
-local sources = { null_ls.builtins.completion.spell }
+local sources = { null_ls.builtins.completion.spell, null_ls.builtins.completion.tags }
 ```
+
+Tags source won't be available if you don't have the `tags` option set for Neovim,
 
 If you want to disable spell suggestions when `spell` options is not set, you can use the
 following snippet:

--- a/doc/MAIN.md
+++ b/doc/MAIN.md
@@ -313,3 +313,16 @@ null-ls will combine the results of each of its hover sources when calling the
 handler, so 2+ _null-ls_ hover sources are okay, but note that running more than
 one LSP server with hover capabilities **is not well-supported** (by default,
 the second popup will wipe out the first).
+
+
+#### Completion
+
+```lua
+return { { label = "Item #1", insertText = "Item #1", documentation = "A test completion item" } }
+```
+
+Completion sources must return a list of
+[CompletionItems](https://microsoft.github.io/language-server-protocol/specifications/specification-3-17/#completionItem).
+You can leverage the full attributes of `CompletionItem` from LSP specification. They can be used
+by other plugins (e.g completion plugins) to provide additional context about the highlighted
+completion item.

--- a/doc/MAIN.md
+++ b/doc/MAIN.md
@@ -319,12 +319,14 @@ the second popup will wipe out the first).
 
 ```lua
 return {
-    items = { label = "Item #1", insertText = "Item #1", documentation = "A test completion item" },
-    isIncomplete = true,
+    {
+        items = { label = "Item #1", insertText = "Item #1", documentation = "A test completion item" },
+        isIncomplete = true,
+    },
 }
 ```
 
-Completion sources must return a
+Completion sources must return a list of
 [CompletionList](https://microsoft.github.io/language-server-protocol/specifications/specification-3-17/#completionList).
 You can leverage the full attributes of `CompletionItem` from LSP specification. They can be used
 by other plugins (e.g completion plugins) to provide additional context about the highlighted

--- a/doc/MAIN.md
+++ b/doc/MAIN.md
@@ -318,11 +318,14 @@ the second popup will wipe out the first).
 #### Completion
 
 ```lua
-return { { label = "Item #1", insertText = "Item #1", documentation = "A test completion item" } }
+return {
+    items = { label = "Item #1", insertText = "Item #1", documentation = "A test completion item" },
+    isIncomplete = true,
+}
 ```
 
-Completion sources must return a list of
-[CompletionItems](https://microsoft.github.io/language-server-protocol/specifications/specification-3-17/#completionItem).
+Completion sources must return a
+[CompletionList](https://microsoft.github.io/language-server-protocol/specifications/specification-3-17/#completionList).
 You can leverage the full attributes of `CompletionItem` from LSP specification. They can be used
 by other plugins (e.g completion plugins) to provide additional context about the highlighted
 completion item.

--- a/lua/null-ls/builtins/completion.lua
+++ b/lua/null-ls/builtins/completion.lua
@@ -27,7 +27,8 @@ M.tags = h.make_builtin({
             for _, tag in ipairs(tags) do
                 table.insert(words, tag.name)
             end
-            words = table.uniq(words)
+
+            words = utils.table.uniq(words)
             for _, word in ipairs(words) do
                 table.insert(items, {
                     label = word,

--- a/lua/null-ls/builtins/completion.lua
+++ b/lua/null-ls/builtins/completion.lua
@@ -21,7 +21,7 @@ M.spell = h.make_builtin({
                 return items
             end
 
-            done({ items = candidates(vim.fn.spellsuggest(params.word_to_complete)), isIncomplete = true })
+            done({ items = candidates(vim.fn.spellsuggest(params.word_to_complete)), isIncomplete = false })
         end,
         async = true,
     },

--- a/lua/null-ls/builtins/completion.lua
+++ b/lua/null-ls/builtins/completion.lua
@@ -1,0 +1,36 @@
+local h = require("null-ls.helpers")
+local methods = require("null-ls.methods")
+local utils = require("null-ls.utils")
+
+local COMPLETION = methods.internal.COMPLETION
+
+local M = {}
+
+M.tags = h.make_builtin({
+    method = COMPLETION,
+    filetypes = {},
+    name = "tags",
+    generator = {
+        fn = function(params, done)
+            local tags = vim.fn.taglist(params.word_to_complete)
+            local words = {}
+            local items = {}
+            for _, tag in ipairs(tags) do
+                table.insert(words, tag.name)
+            end
+            words = utils.tbl_uniq(words)
+            for _, word in ipairs(words) do
+                table.insert(items, {
+                    label = word,
+                    insertText = word,
+                })
+            end
+
+            done(items)
+        end,
+        async = true,
+        use_cache = true,
+    },
+})
+
+return M

--- a/lua/null-ls/builtins/completion.lua
+++ b/lua/null-ls/builtins/completion.lua
@@ -6,36 +6,6 @@ local COMPLETION = methods.internal.COMPLETION
 
 local M = {}
 
-M.tags = h.make_builtin({
-    method = COMPLETION,
-    filetypes = {},
-    name = "tags",
-    runtime_condition = function(_)
-        return #vim.fn.tagfiles() > 0
-    end,
-    generator = {
-        fn = function(params, done)
-            local tags = vim.fn.taglist(params.word_to_complete)
-            local words = {}
-            local items = {}
-            for _, tag in ipairs(tags) do
-                table.insert(words, tag.name)
-            end
-            words = utils.tbl_uniq(words)
-            for _, word in ipairs(words) do
-                table.insert(items, {
-                    label = word,
-                    insertText = word,
-                })
-            end
-
-            done(items)
-        end,
-        async = true,
-        use_cache = true,
-    },
-})
-
 M.spell = h.make_builtin({
     method = COMPLETION,
     filetypes = {},

--- a/lua/null-ls/builtins/completion.lua
+++ b/lua/null-ls/builtins/completion.lua
@@ -27,7 +27,6 @@ M.spell = h.make_builtin({
             done({ items = candidates(vim.fn.spellsuggest(params.word_to_complete)), isIncomplete = true })
         end,
         async = true,
-        use_cache = true,
     },
 })
 

--- a/lua/null-ls/builtins/completion.lua
+++ b/lua/null-ls/builtins/completion.lua
@@ -1,10 +1,45 @@
 local h = require("null-ls.helpers")
 local methods = require("null-ls.methods")
-local utils = require("null-ls.utils")
 
 local COMPLETION = methods.internal.COMPLETION
 
 local M = {}
+
+M.tags = h.make_builtin({
+    method = COMPLETION,
+    filetypes = {},
+    name = "tags",
+    generator_opts = {
+        runtime_condition = function(_)
+            return #vim.fn.tagfiles() > 0
+        end,
+    },
+    generator = {
+        fn = function(params, done)
+            local tags = vim.fn.taglist(params.word_to_complete)
+            if tags == 0 then
+                done({ items = {}, isIncomplete = false })
+                return
+            end
+
+            local words = {}
+            local items = {}
+            for _, tag in ipairs(tags) do
+                table.insert(words, tag.name)
+            end
+            words = table.uniq(words)
+            for _, word in ipairs(words) do
+                table.insert(items, {
+                    label = word,
+                    insertText = word,
+                })
+            end
+
+            done({ items = items, isIncomplete = false })
+        end,
+        async = true,
+    },
+})
 
 M.spell = h.make_builtin({
     method = COMPLETION,

--- a/lua/null-ls/builtins/completion.lua
+++ b/lua/null-ls/builtins/completion.lua
@@ -10,6 +10,9 @@ M.tags = h.make_builtin({
     method = COMPLETION,
     filetypes = {},
     name = "tags",
+    runtime_condition = function(_)
+        return #vim.fn.tagfiles() > 0
+    end,
     generator = {
         fn = function(params, done)
             local tags = vim.fn.taglist(params.word_to_complete)

--- a/lua/null-ls/builtins/completion.lua
+++ b/lua/null-ls/builtins/completion.lua
@@ -24,7 +24,7 @@ M.spell = h.make_builtin({
                 return items
             end
 
-            done(candidates(vim.fn.spellsuggest(params.word_to_complete)))
+            done({ items = candidates(vim.fn.spellsuggest(params.word_to_complete)), isIncomplete = true })
         end,
         async = true,
         use_cache = true,

--- a/lua/null-ls/builtins/completion.lua
+++ b/lua/null-ls/builtins/completion.lua
@@ -10,9 +10,6 @@ M.spell = h.make_builtin({
     method = COMPLETION,
     filetypes = {},
     name = "spell",
-    runtime_condition = function(_)
-        return vim.opt_local.spell:get()
-    end,
     generator = {
         fn = function(params, done)
             local candidates = function(entries)

--- a/lua/null-ls/builtins/completion.lua
+++ b/lua/null-ls/builtins/completion.lua
@@ -64,8 +64,8 @@ M.spell = h.make_builtin({
                 return items
             end
 
-            local canditates = get_candidates(vim.fn.spellsuggest(params.word_to_complete))
-            done({ { items = canditates, isIncomplete = #canditates } })
+            local candidates = get_candidates(vim.fn.spellsuggest(params.word_to_complete))
+            done({ { items = candidates, isIncomplete = #candidates } })
         end,
         async = true,
     },

--- a/lua/null-ls/builtins/completion.lua
+++ b/lua/null-ls/builtins/completion.lua
@@ -33,4 +33,29 @@ M.tags = h.make_builtin({
     },
 })
 
+M.spell = h.make_builtin({
+    method = COMPLETION,
+    filetypes = {},
+    name = "spell",
+    runtime_condition = function(_)
+        return vim.opt_local.spell:get()
+    end,
+    generator = {
+        fn = function(params, done)
+            local candidates = function(entries)
+                local items = {}
+                for k, v in ipairs(entries) do
+                    items[k] = { label = v, kind = vim.lsp.protocol.CompletionItemKind["Text"] }
+                end
+
+                return items
+            end
+
+            done(candidates(vim.fn.spellsuggest(params.word_to_complete)))
+        end,
+        async = true,
+        use_cache = true,
+    },
+})
+
 return M

--- a/lua/null-ls/builtins/init.lua
+++ b/lua/null-ls/builtins/init.lua
@@ -3,6 +3,7 @@ local paths = {
     formatting = "null-ls.builtins.formatting",
     code_actions = "null-ls.builtins.code-actions",
     hover = "null-ls.builtins.hover",
+    completion = "null-ls.builtins.completion",
     _test = "null-ls.builtins.test",
 }
 

--- a/lua/null-ls/completion.lua
+++ b/lua/null-ls/completion.lua
@@ -1,0 +1,33 @@
+local u = require("null-ls.utils")
+local methods = require("null-ls.methods")
+
+local M = {}
+
+M.handler = function(method, original_params, handler)
+    local params = u.make_params(original_params, methods.map[method])
+    if method == methods.lsp.COMPLETION then
+        require("null-ls.generators").run_registered({
+            filetype = params.ft,
+            method = methods.map[method],
+            params = params,
+            callback = function(results)
+                u.debug_log("received completion results from generators")
+                u.debug_log(results)
+                if #results == 0 then
+                    handler({})
+                else
+                    for index, item in ipairs(results) do
+                        if type(item) == "string" then
+                            results[index] = { label = item, insertText = item }
+                        end
+                    end
+
+                    handler({ isIncomplete = false, items = results })
+                end
+            end,
+        })
+        original_params._null_ls_handled = true
+    end
+end
+
+return M

--- a/lua/null-ls/completion.lua
+++ b/lua/null-ls/completion.lua
@@ -16,15 +16,30 @@ M.handler = function(method, original_params, handler)
                 if #results == 0 then
                     handler({})
                 else
-                    for index, item in ipairs(results) do
-                        if type(item) == "string" then
-                            results[index] = { label = item, insertText = item }
-                        else
-                            break
+                    local items = {}
+                    local isIncomplete = false
+                    for _, result in ipairs(results) do
+                        isIncomplete = isIncomplete or result.isIncomplete
+
+                        vim.validate({
+                            items = { result.items, "table" },
+                            isIncomplete = { result.isIncomplete, "boolean" },
+                        })
+                        for index, item in ipairs(result.items) do
+                            if type(item) == "string" then
+                                result.items[index] = { label = item, insertText = item }
+                            else
+                                vim.validate({
+                                    item = { item, "table" },
+                                })
+                                break
+                            end
                         end
+
+                        u.table.extend(items, result.items)
                     end
 
-                    handler({ isIncomplete = false, items = results })
+                    handler({ isIncomplete = isIncomplete, items = items })
                 end
             end,
         })

--- a/lua/null-ls/completion.lua
+++ b/lua/null-ls/completion.lua
@@ -1,5 +1,6 @@
 local u = require("null-ls.utils")
 local methods = require("null-ls.methods")
+local config = require("null-ls.config").get()
 
 local M = {}
 
@@ -21,22 +22,18 @@ M.handler = function(method, original_params, handler)
                     for _, result in ipairs(results) do
                         isIncomplete = isIncomplete or result.isIncomplete
 
-                        vim.validate({
-                            items = { result.items, "table" },
-                            isIncomplete = { result.isIncomplete, "boolean" },
-                        })
-                        for index, item in ipairs(result.items) do
-                            if type(item) == "string" then
-                                result.items[index] = { label = item, insertText = item }
-                            else
-                                vim.validate({
-                                    item = { item, "table" },
-                                })
-                                break
-                            end
+                        if config.debug then
+                            vim.validate({
+                                items = { result.items, "table" },
+                                isIncomplete = { result.isIncomplete, "boolean" },
+                            })
+
+                            vim.validate({
+                                item = { result.items[1], "table" },
+                            })
                         end
 
-                        u.table.extend(items, result.items)
+                        vim.list_extend(items, result.items)
                     end
 
                     handler({ isIncomplete = isIncomplete, items = items })

--- a/lua/null-ls/completion.lua
+++ b/lua/null-ls/completion.lua
@@ -19,6 +19,8 @@ M.handler = function(method, original_params, handler)
                     for index, item in ipairs(results) do
                         if type(item) == "string" then
                             results[index] = { label = item, insertText = item }
+                        else
+                            break
                         end
                     end
 

--- a/lua/null-ls/generators.lua
+++ b/lua/null-ls/generators.lua
@@ -39,20 +39,12 @@ M.run = function(generators, params, postprocess, callback)
                     return
                 end
 
-                if params.method == methods.internal.COMPLETION then
+                for _, result in ipairs(results) do
                     if postprocess then
-                        postprocess(results, copied_params, generator)
+                        postprocess(result, copied_params, generator)
                     end
 
-                    table.insert(all_results, results)
-                else
-                    for _, result in ipairs(results) do
-                        if postprocess then
-                            postprocess(result, copied_params, generator)
-                        end
-
-                        table.insert(all_results, result)
-                    end
+                    table.insert(all_results, result)
                 end
             end)
         end

--- a/lua/null-ls/generators.lua
+++ b/lua/null-ls/generators.lua
@@ -1,5 +1,6 @@
 local c = require("null-ls.config")
 local u = require("null-ls.utils")
+local methods = require("null-ls.methods")
 
 local M = {}
 
@@ -38,12 +39,20 @@ M.run = function(generators, params, postprocess, callback)
                     return
                 end
 
-                for _, result in ipairs(results) do
+                if params.method == methods.internal.COMPLETION then
                     if postprocess then
-                        postprocess(result, copied_params, generator)
+                        postprocess(results, copied_params, generator)
                     end
 
-                    table.insert(all_results, result)
+                    table.insert(all_results, results)
+                else
+                    for _, result in ipairs(results) do
+                        if postprocess then
+                            postprocess(result, copied_params, generator)
+                        end
+
+                        table.insert(all_results, result)
+                    end
                 end
             end)
         end

--- a/lua/null-ls/methods.lua
+++ b/lua/null-ls/methods.lua
@@ -11,6 +11,7 @@ local lsp_methods = {
     DID_OPEN = "textDocument/didOpen",
     DID_CLOSE = "textDocument/didClose",
     HOVER = "textDocument/hover",
+    COMPLETION = "textDocument/completion",
 }
 vim.tbl_add_reverse_lookup(lsp_methods)
 
@@ -20,6 +21,7 @@ local internal_methods = {
     FORMATTING = "NULL_LS_FORMATTING",
     RANGE_FORMATTING = "NULL_LS_RANGE_FORMATTING",
     HOVER = "NULL_LS_HOVER",
+    COMPLETION = "NULL_LS_COMPLETION",
 }
 vim.tbl_add_reverse_lookup(internal_methods)
 
@@ -30,6 +32,7 @@ local lsp_to_internal_map = {
     [lsp_methods.DID_OPEN] = internal_methods.DIAGNOSTICS,
     [lsp_methods.DID_CHANGE] = internal_methods.DIAGNOSTICS,
     [lsp_methods.HOVER] = internal_methods.HOVER,
+    [lsp_methods.COMPLETION] = internal_methods.COMPLETION,
 }
 
 local readable_map = {
@@ -38,6 +41,7 @@ local readable_map = {
     [internal_methods.FORMATTING] = "Formatting",
     [internal_methods.RANGE_FORMATTING] = "Range formatting",
     [internal_methods.HOVER] = "Hover",
+    [internal_methods.COMPLETION] = "Completion",
 }
 
 local M = {}

--- a/lua/null-ls/rpc.lua
+++ b/lua/null-ls/rpc.lua
@@ -8,7 +8,15 @@ local capabilities = {
     executeCommandProvider = true,
     documentFormattingProvider = true,
     documentRangeFormattingProvider = true,
-    completionProvider = true,
+    completionProvider = {
+        -- FIXME: How do we decide what trigger characters are?
+        triggerCharacters = { ".", ":", "-" },
+        allCommitCharacters = {},
+        resolveProvider = false,
+        completionItem = {
+            labelDetailsSupport = true,
+        },
+    },
     textDocumentSync = {
         change = 1, -- prompt LSP client to send full document text on didOpen and didChange
         openClose = true,

--- a/lua/null-ls/rpc.lua
+++ b/lua/null-ls/rpc.lua
@@ -8,6 +8,7 @@ local capabilities = {
     executeCommandProvider = true,
     documentFormattingProvider = true,
     documentRangeFormattingProvider = true,
+    completionProvider = true,
     textDocumentSync = {
         change = 1, -- prompt LSP client to send full document text on didOpen and didChange
         openClose = true,
@@ -82,6 +83,7 @@ function M.start(dispatchers)
             require("null-ls.code-actions").handler(method, params, send)
             require("null-ls.formatting").handler(method, params, send)
             require("null-ls.hover").handler(method, params, send)
+            require("null-ls.completion").handler(method, params, send)
             if not params._null_ls_handled then
                 send()
             end

--- a/lua/null-ls/utils.lua
+++ b/lua/null-ls/utils.lua
@@ -170,6 +170,13 @@ M.table = {
         end
         return replaced
     end,
+    extend = function(source, target)
+        for _, v in ipairs(target) do
+            table.insert(source, v)
+        end
+
+        return source
+    end,
 }
 
 M.resolve_handler = function(method)

--- a/lua/null-ls/utils.lua
+++ b/lua/null-ls/utils.lua
@@ -119,6 +119,13 @@ M.make_params = function(original_params, method)
         params.range = M.range.from_lsp(original_params.range)
     end
 
+    if params.lsp_method == methods.lsp.COMPLETION then
+        local pos = vim.api.nvim_win_get_cursor(0)
+        local line = vim.api.nvim_get_current_line()
+        local line_to_cursor = line:sub(1, pos[2])
+        params.word_to_complete = line:sub(vim.fn.match(line_to_cursor, "\\k*$") + 1, params.col)
+    end
+
     return params
 end
 
@@ -197,6 +204,19 @@ function M.throttle(ms, fn)
             running = true
         end
     end
+end
+
+function M.tbl_uniq(t)
+    local new_table = {}
+    local hash = {}
+    for _, v in pairs(t) do
+        if not hash[v] then
+            table.insert(new_table, v)
+            hash[v] = true
+        end
+    end
+
+    return new_table
 end
 
 return M

--- a/lua/null-ls/utils.lua
+++ b/lua/null-ls/utils.lua
@@ -120,7 +120,6 @@ M.make_params = function(original_params, method)
     end
 
     if params.lsp_method == methods.lsp.COMPLETION then
-        local pos = vim.api.nvim_win_get_cursor(0)
         local line = vim.api.nvim_get_current_line()
         local line_to_cursor = line:sub(1, pos[2])
         params.word_to_complete = line:sub(vim.fn.match(line_to_cursor, "\\k*$") + 1, params.col)

--- a/lua/null-ls/utils.lua
+++ b/lua/null-ls/utils.lua
@@ -122,7 +122,9 @@ M.make_params = function(original_params, method)
     if params.lsp_method == methods.lsp.COMPLETION then
         local line = vim.api.nvim_get_current_line()
         local line_to_cursor = line:sub(1, pos[2])
-        params.word_to_complete = line:sub(vim.fn.match(line_to_cursor, "\\k*$") + 1, params.col)
+        local regex = vim.regex("\\k*$")
+
+        params.word_to_complete = line:sub(regex:match_str(line_to_cursor) + 1, params.col)
     end
 
     return params

--- a/lua/null-ls/utils.lua
+++ b/lua/null-ls/utils.lua
@@ -170,12 +170,17 @@ M.table = {
         end
         return replaced
     end,
-    extend = function(source, target)
-        for _, v in ipairs(target) do
-            table.insert(source, v)
+    uniq = function(t)
+        local new_table = {}
+        local hash = {}
+        for _, v in pairs(t) do
+            if not hash[v] then
+                table.insert(new_table, v)
+                hash[v] = true
+            end
         end
 
-        return source
+        return new_table
     end,
 }
 
@@ -210,19 +215,6 @@ function M.throttle(ms, fn)
             running = true
         end
     end
-end
-
-function M.tbl_uniq(t)
-    local new_table = {}
-    local hash = {}
-    for _, v in pairs(t) do
-        if not hash[v] then
-            table.insert(new_table, v)
-            hash[v] = true
-        end
-    end
-
-    return new_table
 end
 
 return M

--- a/test/spec/completion_spec.lua
+++ b/test/spec/completion_spec.lua
@@ -1,0 +1,55 @@
+local stub = require("luassert.stub")
+
+local u = require("null-ls.utils")
+local generators = require("null-ls.generators")
+local methods = require("null-ls.methods")
+local completion = require("null-ls.completion")
+
+describe("completion", function()
+    local mock_uri = "file:///mock-file"
+    local mock_params
+    before_each(function()
+        mock_params = {
+            textDocument = { uri = mock_uri },
+        }
+        u.make_params.returns(mock_params)
+    end)
+
+    describe("handler", function()
+        local handler = stub.new()
+        stub(generators, "run_registered")
+        stub(u, "make_params")
+
+        after_each(function()
+            generators.run_registered:clear()
+            u.make_params:clear()
+            handler:clear()
+        end)
+
+        describe("method == COMPLETION", function()
+            local method = methods.lsp.COMPLETION
+
+            it("should call make_params with original params and internal method", function()
+                completion.handler(method, mock_params, handler)
+
+                mock_params._null_ls_handled = nil
+                assert.stub(u.make_params).was_called_with(mock_params, methods.internal.COMPLETION)
+            end)
+
+            it("should set handled flag on params", function()
+                completion.handler(method, mock_params, handler)
+
+                assert.equals(mock_params._null_ls_handled, true)
+            end)
+
+            it("should call handler with results", function()
+                completion.handler(method, mock_params, handler)
+
+                local callback = generators.run_registered.calls[1].refs[1].callback
+                callback({ { items = {}, isIncomplete = false } })
+
+                assert.stub(handler).was_called_with({ items = {}, isIncomplete = false })
+            end)
+        end)
+    end)
+end)


### PR DESCRIPTION
Just creating a PR to get some early feedback. I thought I could base the completion feature on the way hover works.
I'm not yet so sure about extending the `generator_opts` to support external processes for completion yet. I want to understand your point of view on this feature before investing too much time in the wrong direction.

I started testing it with my own config [here](https://github.com/Furkanzmc/dotfiles/blob/master/vim/lua/vimrc/null_ls_sources.lua#L158).

I want to express my appreciation for this plug-in again. It's awesome work! I'm looking forward to pushing it to the limits.

Let me know what you think of my changes and the direction you want to take.

-----

I didn't add any tests yet. I'll do that once I get your feedback.

-----

**Q_1**: Is there a way to report the results as they become available instead of waiting for all the generators to finish running?
**Q_2**: I'm thinking of adding the ability to support external sources for completion from nvim-cmp. I tried the buffer sources by just copying it to my config and it works well without any changes. The only trouble is when cmp-buffer repository is added to the plugins, it'll look for `cmp` module and it is possible it doesn't exist. Do you have any ideas about this? Do you think it makes sense?