### PR TITLE
Pass `--stdin-filename` for black

### DIFF
--- a/lua/null-ls/builtins/formatting.lua
+++ b/lua/null-ls/builtins/formatting.lua
@@ -32,6 +32,8 @@ M.black = h.make_builtin({
     generator_opts = {
         command = "black",
         args = {
+            "--stdin-filename",
+            "$FILENAME",
             "--quiet",
             "-",
         },


### PR DESCRIPTION
Black accepts --stdin-filename since its 21.5b0 release: https://github.com/psf/black/releases/tag/21.5b0