### PR TITLE
fix(builtins): let `fnlfmt` know which buffer to run on

### DIFF
--- a/lua/null-ls/builtins/formatting.lua
+++ b/lua/null-ls/builtins/formatting.lua
@@ -222,7 +222,7 @@ M.fnlfmt = h.make_builtin({
     filetypes = { "fennel", "fnl" },
     generator_opts = {
         command = "fnlfmt",
-        args = { "--fix" },
+        args = { "$FILENAME" },
         to_stdin = true,
     },
     factory = h.formatter_factory,


### PR DESCRIPTION
Omit `--fix` flag, which modifies file directly, but doesn't buffer.