### PR TITLE
statix: output change from stdout to stderr

### DIFF
--- a/lua/null-ls/builtins/code-actions.lua
+++ b/lua/null-ls/builtins/code-actions.lua
@@ -105,7 +105,7 @@ M.statix = h.make_builtin({
         args = { "check", "--format=json", "--", "$FILENAME" },
         format = "json",
         to_temp_file = true,
-        ignore_stderr = true,
+        from_stderr = true,
         on_output = function(params)
             local actions = {}
             for _, r in ipairs(params.output.report) do

--- a/lua/null-ls/builtins/diagnostics.lua
+++ b/lua/null-ls/builtins/diagnostics.lua
@@ -724,7 +724,7 @@ M.statix = h.make_builtin({
         args = { "check", "--format=errfmt", "--", "$FILENAME" },
         format = "line",
         to_temp_file = true,
-        ignore_stderr = true,
+        from_stderr = true,
         on_output = h.diagnostics.from_pattern(
             [[>(%d+):(%d+):(.):(%d+):(.*)]],
             { "row", "col", "severity", "code", "message" },


### PR DESCRIPTION
Statix changed default diagnostics output in https://github.com/nerdypepper/statix/commit/1a97cce01f8e49b33bf28cbcdfeb3c8aefd809a5