### PR TITLE
feat(builtins): add mypy built-in

### DIFF
--- a/lua/null-ls/builtins/diagnostics/mypy.lua
+++ b/lua/null-ls/builtins/diagnostics/mypy.lua
@@ -1,0 +1,47 @@
+local h = require("null-ls.helpers")
+local methods = require("null-ls.methods")
+
+local DIAGNOSTICS = methods.internal.DIAGNOSTICS
+
+return h.make_builtin({
+    method = DIAGNOSTICS,
+    filetypes = { "python" },
+    generator_opts = {
+        command = "mypy",
+        args = {
+            "--hide-error-codes",
+            "--hide-error-context",
+            "--no-color-output",
+            "--show-column-numbers",
+            "--show-error-codes",
+            "--no-error-summary",
+            "--no-pretty",
+            "--command",
+            "$TEXT",
+        },
+        format = "line",
+        check_exit_code = function(code)
+            return code <= 2
+        end,
+        on_output = function(...)
+            local parser_result = h.diagnostics.from_pattern(
+                "<string>:(%d+):(%d+): (%a+): (.*)  %[([%a-]+)%]", --
+                { "row", "col", "severity", "message", "code" },
+                {
+                    severities = {
+                        error = h.diagnostics.severities["error"],
+                        warning = h.diagnostics.severities["warning"],
+                        note = h.diagnostics.severities["information"],
+                    },
+                }
+            )(...)
+
+            if parser_result.code == "syntax" then
+                return nil
+            end
+
+            return parser_result
+        end,
+    },
+    factory = h.generator_factory,
+})

--- a/lua/null-ls/builtins/diagnostics/mypy.lua
+++ b/lua/null-ls/builtins/diagnostics/mypy.lua
@@ -23,25 +23,17 @@ return h.make_builtin({
         check_exit_code = function(code)
             return code <= 2
         end,
-        on_output = function(...)
-            local parser_result = h.diagnostics.from_pattern(
-                "<string>:(%d+):(%d+): (%a+): (.*)  %[([%a-]+)%]", --
-                { "row", "col", "severity", "message", "code" },
-                {
-                    severities = {
-                        error = h.diagnostics.severities["error"],
-                        warning = h.diagnostics.severities["warning"],
-                        note = h.diagnostics.severities["information"],
-                    },
-                }
-            )(...)
-
-            if parser_result.code == "syntax" then
-                return nil
-            end
-
-            return parser_result
-        end,
+        on_output = h.diagnostics.from_pattern(
+            "<string>:(%d+):(%d+): (%a+): (.*)  %[([%a-]+)%]", --
+            { "row", "col", "severity", "message", "code" },
+            {
+                severities = {
+                    error = h.diagnostics.severities["error"],
+                    warning = h.diagnostics.severities["warning"],
+                    note = h.diagnostics.severities["information"],
+                },
+            }
+        ),
     },
     factory = h.generator_factory,
 })


### PR DESCRIPTION
Closes #139.

Here is my attempt to add the mypy built-in. It differs from #155 in these ways:

- instead of using a temporary file, it uses a `--command` parameter with a file content,
- it includes exit code 2 as a positive result,
- it also parses diagnostic codes.

As for the exit code, I will ask upstream if they could add a separate exit code for syntax errors.

**EDIT:** I've just noticed that the spawn `mypy` processes don't close, so they fill up the whole CPU