### PR TITLE
Handle compile warnings preceeding credo output

### DIFF
--- a/lua/null-ls/builtins/diagnostics/credo.lua
+++ b/lua/null-ls/builtins/diagnostics/credo.lua
@@ -25,6 +25,19 @@ return h.make_builtin({
         from_stderr = true,
         on_output = function(params)
             local issues = {}
+
+            if params.err and params.err:find("{") then
+                i, _ = params.err:find("{")
+                maybe_json_string = params.err:sub(i)
+
+                local ok, decoded = pcall(vim.fn.json_decode, maybe_json_string)
+
+                if ok then
+                    params.output = decoded
+                    params.err = nil
+                end
+            end
+
             if params.output and params.output.issues then
                 for _, issue in ipairs(params.output.issues) do
                     local err = {

--- a/test/spec/builtins/diagnostics_spec.lua
+++ b/test/spec/builtins/diagnostics_spec.lua
@@ -154,6 +154,38 @@ describe("diagnostics", function()
                 },
             }, diagnostic)
         end)
+        it("should handle compile warnings preceeding output", function()
+            local error = [[
+            [warn] IMPORTING DEV.SECRET
+
+            {
+              "issues": [
+                {
+                  "category": "consistency",
+                  "check": "Credo.Check.Consistency.SpaceInParentheses",
+                  "column": null,
+                  "column_end": null,
+                  "filename": "lib/todo_web/controllers/page_controller.ex",
+                  "line_no": 4,
+                  "message": "There is no whitespace around parentheses/brackets most of the time, but here there is.",
+                  "priority": 12,
+                  "scope": "TodoWeb.PageController.index",
+                  "trigger": "( c"
+                }
+              ]
+            } ]]
+            local diagnostic = parser({ err = error })
+            assert.are.same({
+                {
+                    source = "credo",
+                    message = "There is no whitespace around parentheses/brackets most of the time, but here there is.",
+                    row = 4,
+                    col = nil,
+                    end_col = nil,
+                    severity = 1,
+                },
+            }, diagnostic)
+        end)
     end)
 
     describe("luacheck", function()


### PR DESCRIPTION
When working on a project that logs out a warning if loading a
dev.secret.exs file, I noticed that vscode users did not have any
issues. Taking a look through the plugin, it looks for the first
occurance of a `{` and parses from there.

https://github.com/pantajoe/vscode-elixir-credo/blob/main/src/execution.ts#L44