### PR TITLE
feat: improve source API

### DIFF
--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -80,6 +80,19 @@ If you see `filetypes = {}` in a source's description, that means the source is
 active for all filetypes by default. You may want to define a specific list of
 filetypes to avoid conflicts or other issues.
 
+You can also pass a list of specifically disabled filetypes:
+
+```lua
+local sources = {
+    null_ls.builtins.code_actions.gitsigns.with({
+        disabled_filetypes = { "lua" },
+    }),
+}
+```
+
+null-ls is always inactive in non-file buffers (e.g. file trees, finders) so
+theres's no need to specify them here.
+
 ### Arguments
 
 To add more arguments to a source's defaults, use `extra_args`:

--- a/doc/CONFIG.md
+++ b/doc/CONFIG.md
@@ -124,3 +124,6 @@ end
 If null-ls is already running but you want to stop it, you can use the methods
 provided by nvim-lspconfig (`:LspStart`, `:LspStop`, and `:LspRestart`) to
 control its behavior.
+
+You can also deregister sources using the source API, as described in
+[SOURCES](SOURCES.md).

--- a/doc/MAIN.md
+++ b/doc/MAIN.md
@@ -95,6 +95,9 @@ my_source.filetypes = { "lua", "teal" }
 my_source.filetypes = {}
 ```
 
+Sources can also include a list of `disabled_filetypes`. null-ls checks these
+first, so they'll supersede any defined filetypes.
+
 ### Registration
 
 null-ls can register sources via the `config` method (intended for a user's

--- a/doc/MAIN.md
+++ b/doc/MAIN.md
@@ -14,11 +14,13 @@ Splits into the following documents:
 - [CONFIG](CONFIG.md), which describes the available configuration
   options
 
-- [HELPERS](HELPERS.md), which describes available helpers and how to use
-  them to make new sources
-
 - [BUILTINS](BUILTINS.md), which describes how to use and make built-in
   sources
+
+- [SOURCES](SOURCES.md), which describes the source API
+
+- [HELPERS](HELPERS.md), which describes available helpers and how to use
+  them to make new sources
 
 - [TESTING](TESTING.md), which describes best practices for testing null-ls
   integrations

--- a/doc/SOURCES.md
+++ b/doc/SOURCES.md
@@ -1,0 +1,127 @@
+# Sources
+
+This document describes the source API, which allows users to register /
+deregister sources and get registered sources.
+
+All methods are available on the main `null-ls` module unless specified
+otherwise. Methods not mentioned here are either internal or unstable, so use
+them at your own risk.
+
+```lua
+require("null-ls").get_sources()
+```
+
+Methods that add, remove, or otherwise change sources prompt nvim-lspconfig to
+update its list of filetypes, as displayed in `:LspConfig`.
+
+## get_sources()
+
+Returns a list (array-like table) of all registered sources. The returned table
+references the same table that null-ls uses internally, so mutating sources will
+affect how null-ls operates accordingly.
+
+Registered sources have the following structure, which differs from their
+pre-registration structure:
+
+```lua
+local example_source = {
+    name = "example_source",
+    filetypes = { ["lua"] = true },
+    methods = { [require("null-ls").methods.FORMATTING] = true },
+    generator = {
+        fn = function()
+            return "I am a source!"
+        end,
+    },
+    id = 1
+}
+```
+
+### name
+
+The name of the source. Sources without a name are automatically assigned the
+name `anonymous source`. Users or integrations may register any number of
+sources with the same name.
+
+### filetypes
+
+A table of filetypes, where each key represents a supported filetype.
+Transformed from the original list.
+
+### methods
+
+A table of methods, where each key represents a supported method. Transformed
+from the original method or list of methods.
+
+### generator
+
+The source's generator.
+
+### id
+
+The source's ID. Assigned automatically. Each source receives the next available
+ID.
+
+## register(to_register)
+
+The main method for registering sources. `to_register` can have the following
+structures:
+
+- A single source (registered individually):
+
+```lua
+require("null-ls").register(my_source)
+```
+
+- A list (array-like table) of sources (registered sequentially):
+
+```lua
+require("null-ls").register({ my_source, my_other_source })
+```
+
+- A table of sources with shared configuration (`name` and `filetypes` override
+  source-specific options):
+
+```lua
+require("null-ls").register({
+    name = "my_sources",
+    filetypes = { "lua" },
+    sources = { my_source, my_other_source },
+})
+```
+
+For information on sources, see [MAIN](MAIN.md).
+
+## deregister(query)
+
+Removes all sources matching `query` from the internal list of sources. `query`
+can be a string, in which case it's treated as a name, or an object with the
+following structure:
+
+```lua
+local query = {
+    name = "my-source", -- string
+    method = require("null-ls").methods.FORMATTING, -- null-ls method
+    id = 1, -- number
+}
+```
+
+All keys in the query are optional, and passing an empty query will deregister
+all sources.
+
+Note that special characters are automatically escaped when `query` is a string
+but not when it's an object, which allows using Lua string matchers.
+
+## reset_sources()
+
+Clears all registered sources.
+
+## is_registered(name)
+
+Returns `true` if null-ls has registered a source with the name `name` (exact
+match). For more flexible queries, check the results of `get_sources()` manually.
+
+## register_name(name)
+
+Allows integrations to register a name (independent of its sources), which they
+can check with `is_registered(name)` to avoid double registration.

--- a/doc/SOURCES.md
+++ b/doc/SOURCES.md
@@ -45,8 +45,12 @@ sources with the same name.
 
 ### filetypes
 
-A table of filetypes, where each key represents a supported filetype.
-Transformed from the original list.
+A table of filetypes, where each key represents a filetype and each value
+indicates whether the source supports that filetype. Transformed from the
+original `filetypes` and `disabled_filetype` lists.
+
+The special key `_all` indicates that a source is active for all filetypes
+(unless superseded by a `false` value for a filetype key).
 
 ### methods
 

--- a/lua/null-ls/code-actions.lua
+++ b/lua/null-ls/code-actions.lua
@@ -16,7 +16,7 @@ M.handler = function(method, original_params, handler)
         if not original_params.textDocument then
             return
         end
-        if original_params._null_ls_ignore then
+        if original_params._null_ls_ignore or (original_params.ctx and original_params.ctx._null_ls_ignore) then
             return
         end
 

--- a/lua/null-ls/config.lua
+++ b/lua/null-ls/config.lua
@@ -1,5 +1,3 @@
-local methods = require("null-ls.methods")
-
 local validate = vim.validate
 
 local defaults = {
@@ -7,14 +5,16 @@ local defaults = {
     debounce = 250,
     default_timeout = 5000,
     debug = false,
-    _generators = {},
-    _filetypes = {},
-    _all_filetypes = false,
+    -- private
+    -- list of transformed sources
+    _sources = {},
+    -- list of names registered by integrations
     _names = {},
-    _methods = {},
-    _registered = false,
+    -- prevent double setup
     _setup = false,
 }
+
+local config = vim.deepcopy(defaults)
 
 local type_overrides = {
     on_attach = { "function", "nil" },
@@ -40,157 +40,6 @@ local wanted_type = function(k)
     return type(defaults[k]), true
 end
 
-local config = vim.deepcopy(defaults)
-
-local register_filetypes = function(filetypes)
-    if vim.tbl_isempty(filetypes) then
-        config._all_filetypes = true
-        return
-    end
-
-    for _, filetype in pairs(filetypes) do
-        if not vim.tbl_contains(config._filetypes, filetype) then
-            table.insert(config._filetypes, filetype)
-        end
-    end
-    require("null-ls.lspconfig").on_register_filetypes()
-end
-
-local should_register = function(source, filetypes, source_methods)
-    local name = source.name
-    -- can't do anything without a name
-    if not source.name then
-        return true
-    end
-
-    for _, method in ipairs(source_methods) do
-        config._methods[method] = config._methods[method] or {}
-        if config._methods[method][name] and not source._is_copy then
-            return false
-        end
-
-        config._methods[method][name] = vim.list_extend(config._methods[method][name] or {}, filetypes)
-    end
-
-    return true
-end
-
-local register_source = function(source, filetypes)
-    if type(source) == "function" then
-        source = source()
-        if not source then
-            return
-        end
-    end
-
-    local generator, name = source.generator, source.name
-    local source_methods = type(source.method) == "table" and source.method or { source.method }
-    filetypes = filetypes or source.filetypes
-
-    validate({
-        generator = { generator, "table" },
-        filetypes = { filetypes, "table" },
-        name = { name, "string", true },
-    })
-
-    if not should_register(source, filetypes, source_methods) then
-        return
-    end
-
-    for _, method in pairs(source_methods) do
-        validate({
-            method = {
-                method,
-                function(m)
-                    return methods.internal[m] ~= nil
-                end,
-                "supported null-ls method",
-            },
-        })
-
-        local fn, async, opts = generator.fn, generator.async, generator.opts
-        validate({
-            fn = { fn, "function" },
-            async = { async, "boolean", true },
-            opts = { opts, "table", true },
-        })
-
-        if not config._generators[method] then
-            config._generators[method] = {}
-        end
-        register_filetypes(filetypes)
-
-        generator.filetypes = filetypes
-        generator.opts = opts or {}
-        table.insert(config._generators[method], generator)
-    end
-
-    config._registered = true
-    require("null-ls.lspconfig").on_register_source(source_methods)
-end
-
--- allow integrations to check if source is registered
-local is_registered = function(name)
-    return config._names[name] ~= nil
-end
-
-local register = function(to_register)
-    -- register a single source
-    if type(to_register) == "function" or (type(to_register) == "table" and to_register.method) then
-        register_source(to_register)
-        return
-    end
-
-    -- register a simple list of sources
-    if not to_register.sources then
-        for _, source in pairs(to_register) do
-            register_source(source)
-        end
-        return
-    end
-
-    -- register multiple sources with shared configuration
-    local sources, filetypes, name = to_register.sources, to_register.filetypes, to_register.name
-    validate({ sources = { sources, "table" }, name = { name, "string", true } })
-
-    if name then
-        if is_registered(name) then
-            return
-        end
-        config._names[name] = true
-    end
-
-    for _, source in pairs(sources) do
-        register_source(source, filetypes)
-    end
-end
-
-local M = {}
-
-M.get = function()
-    return config
-end
-M._set = function(new_config)
-    config = vim.tbl_extend("force", config, new_config)
-end
-M.reset = function()
-    config = vim.deepcopy(defaults)
-end
-
-M.is_registered = is_registered
-M.register_name = function(name)
-    config._names[name] = true
-end
-
-M.register = register
-
-M.reset_sources = function()
-    config._generators = {}
-    config._names = {}
-    config._methods = {}
-    config._filetypes = {}
-end
-
 local validate_config = function(user_config)
     local to_validate, validated = {}, {}
 
@@ -209,6 +58,71 @@ local validate_config = function(user_config)
     return validated
 end
 
+local register_source = function(source)
+    source = require("null-ls.sources").validate_and_transform(source)
+    if not source then
+        return
+    end
+
+    table.insert(config._sources, source)
+    config._names[source.name] = true
+    require("null-ls.lspconfig").on_register_source(source)
+end
+
+local register = function(to_register)
+    if type(to_register) == "function" or (type(to_register) == "table" and to_register.method) then
+        -- register a single source
+        register_source(to_register)
+    elseif not to_register.sources then
+        -- register a simple list of sources
+        for _, source in ipairs(to_register) do
+            register_source(source)
+        end
+    else
+        -- register multiple sources with shared configuration
+        for _, source in ipairs(to_register.sources) do
+            source.filetypes = to_register.filetypes
+            source.name = to_register.name
+
+            register_source(source)
+        end
+    end
+
+    require("null-ls.lspconfig").on_register_sources()
+end
+
+local M = {}
+
+M.get = function()
+    return config
+end
+
+M._set = function(new_config)
+    config = vim.tbl_extend("force", config, new_config)
+end
+
+M.reset = function()
+    config = vim.deepcopy(defaults)
+end
+
+M.reset_sources = function()
+    config._sources = {}
+    config._names = {}
+    require("null-ls.lspconfig").on_register_sources()
+end
+
+M.register = register
+
+-- allow integrations to check if source is registered
+M.is_registered = function(name)
+    return config._names[name] ~= nil
+end
+
+-- allow integrations to register a name to quickly check if they've already registered
+M.register_name = function(name)
+    config._names[name] = true
+end
+
 M.setup = function(user_config)
     if config._setup then
         return
@@ -221,6 +135,8 @@ M.setup = function(user_config)
         register(config.sources)
     end
 
+    -- keep only transformed sources under private key
+    config.sources = nil
     config._setup = true
 end
 

--- a/lua/null-ls/config.lua
+++ b/lua/null-ls/config.lua
@@ -102,6 +102,7 @@ M._set = function(new_config)
 end
 
 M.reset = function()
+    M.reset_sources()
     config = vim.deepcopy(defaults)
 end
 

--- a/lua/null-ls/config.lua
+++ b/lua/null-ls/config.lua
@@ -5,11 +5,6 @@ local defaults = {
     debounce = 250,
     default_timeout = 5000,
     debug = false,
-    -- private
-    -- list of transformed sources
-    _sources = {},
-    -- list of names registered by integrations
-    _names = {},
     -- prevent double setup
     _setup = false,
 }
@@ -58,39 +53,6 @@ local validate_config = function(user_config)
     return validated
 end
 
-local register_source = function(source)
-    source = require("null-ls.sources").validate_and_transform(source)
-    if not source then
-        return
-    end
-
-    table.insert(config._sources, source)
-    config._names[source.name] = true
-    require("null-ls.lspconfig").on_register_source(source)
-end
-
-local register = function(to_register)
-    if type(to_register) == "function" or (type(to_register) == "table" and to_register.method) then
-        -- register a single source
-        register_source(to_register)
-    elseif not to_register.sources then
-        -- register a simple list of sources
-        for _, source in ipairs(to_register) do
-            register_source(source)
-        end
-    else
-        -- register multiple sources with shared configuration
-        for _, source in ipairs(to_register.sources) do
-            source.filetypes = to_register.filetypes
-            source.name = to_register.name
-
-            register_source(source)
-        end
-    end
-
-    require("null-ls.lspconfig").on_register_sources()
-end
-
 local M = {}
 
 M.get = function()
@@ -102,26 +64,8 @@ M._set = function(new_config)
 end
 
 M.reset = function()
-    M.reset_sources()
     config = vim.deepcopy(defaults)
-end
-
-M.reset_sources = function()
-    config._sources = {}
-    config._names = {}
-    require("null-ls.lspconfig").on_register_sources()
-end
-
-M.register = register
-
--- allow integrations to check if source is registered
-M.is_registered = function(name)
-    return config._names[name] ~= nil
-end
-
--- allow integrations to register a name to quickly check if they've already registered
-M.register_name = function(name)
-    config._names[name] = true
+    require("null-ls.sources").reset()
 end
 
 M.setup = function(user_config)
@@ -133,11 +77,9 @@ M.setup = function(user_config)
     config = vim.tbl_extend("force", config, validated)
 
     if config.sources then
-        register(config.sources)
+        require("null-ls.sources").register(config.sources)
     end
 
-    -- keep only transformed sources under private key
-    config.sources = nil
     config._setup = true
 end
 

--- a/lua/null-ls/diagnostics.lua
+++ b/lua/null-ls/diagnostics.lua
@@ -62,7 +62,7 @@ M.handler = function(original_params)
             u.debug_log(diagnostics)
 
             local bufnr = vim.uri_to_bufnr(uri)
-            if vim.fn.has("nvim-0.5.1") > 0 then
+            if u.has_version("0.5.1") then
                 handler(nil, { diagnostics = diagnostics, uri = uri }, {
                     method = methods.lsp.PUBLISH_DIAGNOSTICS,
                     client_id = original_params.client_id,

--- a/lua/null-ls/formatting.lua
+++ b/lua/null-ls/formatting.lua
@@ -66,7 +66,7 @@ M.apply_edits = function(edits, params)
 
     local marks, views = save_win_data(bufnr)
 
-    if vim.fn.has("nvim-0.5.1") > 0 then
+    if u.has_version("0.5.1") then
         handler(nil, diffed_edits, { method = params.lsp_method, client_id = params.client_id, bufnr = bufnr })
     else
         ---@diagnostic disable-next-line: redundant-parameter

--- a/lua/null-ls/generators.lua
+++ b/lua/null-ls/generators.lua
@@ -1,5 +1,6 @@
 local c = require("null-ls.config")
 local u = require("null-ls.utils")
+local sources = require("null-ls.sources")
 
 local M = {}
 
@@ -107,9 +108,13 @@ M.run_registered_sequentially = function(opts)
 end
 
 M.get_available = function(filetype, method)
-    return vim.tbl_filter(function(generator)
-        return not generator._failed and u.filetype_matches(generator.filetypes, filetype)
-    end, c.get()._generators[method] or {})
+    local available = {}
+    for _, source in ipairs(c.get()._sources) do
+        if sources.is_available(source, filetype, method) then
+            table.insert(available, source.generator)
+        end
+    end
+    return available
 end
 
 M.can_run = function(filetype, method)

--- a/lua/null-ls/generators.lua
+++ b/lua/null-ls/generators.lua
@@ -1,6 +1,4 @@
-local c = require("null-ls.config")
 local u = require("null-ls.utils")
-local sources = require("null-ls.sources")
 
 local M = {}
 
@@ -109,16 +107,14 @@ end
 
 M.get_available = function(filetype, method)
     local available = {}
-    for _, source in ipairs(c.get()._sources) do
-        if sources.is_available(source, filetype, method) then
-            table.insert(available, source.generator)
-        end
+    for _, source in ipairs(require("null-ls.sources").get_available(filetype, method)) do
+        table.insert(available, source.generator)
     end
     return available
 end
 
 M.can_run = function(filetype, method)
-    return not vim.tbl_isempty(M.get_available(filetype, method))
+    return #M.get_available(filetype, method) > 0
 end
 
 return M

--- a/lua/null-ls/handlers.lua
+++ b/lua/null-ls/handlers.lua
@@ -5,7 +5,7 @@ local M = {}
 
 function M.setup()
     -- code action batching is merged into master
-    if vim.fn.has("nvim-0.6.0") > 0 then
+    if u.has_version("0.6.0") then
         return
     end
 
@@ -16,7 +16,7 @@ end
 function M.combine(method, ms)
     ms = ms or 100
     local orig = u.resolve_handler(method)
-    local is_new = vim.fn.has("nvim-0.5.1") > 0
+    local is_new = u.has_version("0.5.1")
 
     local all_results = {}
 

--- a/lua/null-ls/helpers.lua
+++ b/lua/null-ls/helpers.lua
@@ -339,9 +339,9 @@ M.make_builtin = function(opts)
     builtin.with = function(user_opts)
         local builtin_copy = vim.deepcopy(builtin)
         setmetatable(builtin_copy, getmetatable(builtin))
-        builtin_copy._is_copy = true
 
         builtin_copy.filetypes = user_opts.filetypes or builtin_copy.filetypes
+        builtin_copy.disabled_filetypes = user_opts.disabled_filetypes
 
         -- Extend args manually as vim.tbl_deep_extend overwrites the list
         if

--- a/lua/null-ls/helpers.lua
+++ b/lua/null-ls/helpers.lua
@@ -45,7 +45,7 @@ local parse_args = function(args, params)
     }
 
     local parsed = {}
-    for _, arg in pairs(args) do
+    for _, arg in ipairs(args) do
         arg = tostring(arg):gsub("$(%w+)", function(v)
             return vars[v] and vars[v]()
         end)

--- a/lua/null-ls/info.lua
+++ b/lua/null-ls/info.lua
@@ -12,11 +12,11 @@ M.get_active_sources = function(bufnr, ft)
     ft = ft or api.nvim_buf_get_option(bufnr, "filetype")
 
     local active_sources = {}
-    for method, source in pairs(c.get()._methods) do
-        for name, filetypes in pairs(source) do
-            if u.filetype_matches(filetypes, ft) then
+    for _, source in ipairs(c.get()._sources) do
+        if require("null-ls.sources").is_available(source, ft) then
+            for method in pairs(source.methods) do
                 active_sources[method] = active_sources[method] or {}
-                table.insert(active_sources[method], name)
+                table.insert(active_sources[method], source.name)
             end
         end
     end
@@ -27,7 +27,6 @@ M.show_window = function()
     local windows = require("lspconfig.ui.windows")
 
     local client = u.get_client()
-
     local bufnr = api.nvim_get_current_buf()
     if not client or not lsp.buf_is_attached(bufnr, client.id) then
         u.echo("WarningMsg", "failed to get info: buffer is not attached")

--- a/lua/null-ls/info.lua
+++ b/lua/null-ls/info.lua
@@ -12,12 +12,10 @@ M.get_active_sources = function(bufnr, ft)
     ft = ft or api.nvim_buf_get_option(bufnr, "filetype")
 
     local active_sources = {}
-    for _, source in ipairs(c.get()._sources) do
-        if require("null-ls.sources").is_available(source, ft) then
-            for method in pairs(source.methods) do
-                active_sources[method] = active_sources[method] or {}
-                table.insert(active_sources[method], source.name)
-            end
+    for _, source in ipairs(require("null-ls.sources").get_available(ft)) do
+        for method in pairs(source.methods) do
+            active_sources[method] = active_sources[method] or {}
+            table.insert(active_sources[method], source.name)
         end
     end
     return active_sources

--- a/lua/null-ls/init.lua
+++ b/lua/null-ls/init.lua
@@ -4,6 +4,7 @@ local c = require("null-ls.config")
 
 local M = {}
 
+M.get_sources = sources.get_all()
 M.register = sources.register
 M.deregister = sources.deregister
 M.reset_sources = sources.reset

--- a/lua/null-ls/init.lua
+++ b/lua/null-ls/init.lua
@@ -1,11 +1,14 @@
 local helpers = require("null-ls.helpers")
+local sources = require("null-ls.sources")
 local c = require("null-ls.config")
 
 local M = {}
 
-M.register = c.register
-M.is_registered = c.is_registered
-M.register_name = c.register_name
+M.register = sources.register
+M.deregister = sources.deregister
+M.reset_sources = sources.reset
+M.is_registered = sources.is_registered
+M.register_name = sources.register_name
 
 M.methods = require("null-ls.methods").internal
 M.builtins = require("null-ls.builtins")

--- a/lua/null-ls/lspconfig.lua
+++ b/lua/null-ls/lspconfig.lua
@@ -19,7 +19,7 @@ local should_attach = function(bufnr)
 
     local ft = api.nvim_buf_get_option(bufnr, "filetype")
     -- writing and immediately deleting a buffer (e.g. :wq from a git commit) triggers a bug on 0.5 which is fixed on master
-    if vim.fn.has("nvim-0.6") == 0 and ft == "gitcommit" then
+    if ft == "gitcommit" and not u.has_version("0.6.0") then
         return false
     end
 

--- a/lua/null-ls/lspconfig.lua
+++ b/lua/null-ls/lspconfig.lua
@@ -5,22 +5,10 @@ local u = require("null-ls.utils")
 
 local api = vim.api
 
--- update filetypes shown in :LspInfo
-local get_registered_filetypes = function()
-    local filetypes = {}
-    for _, source in ipairs(c.get()._sources) do
-        for ft in pairs(source.filetypes) do
-            if ft ~= "_all" and not vim.tbl_contains(filetypes, ft) then
-                table.insert(filetypes, ft)
-            end
-        end
-    end
-    return filetypes
-end
-
 local should_attach = function(bufnr)
+    local all_sources = sources.get_all()
     -- don't attach if no sources have been registered
-    if vim.tbl_isempty(c.get()._sources) then
+    if vim.tbl_isempty(all_sources) then
         return false
     end
 
@@ -35,7 +23,7 @@ local should_attach = function(bufnr)
         return false
     end
 
-    for _, source in ipairs(c.get()._sources) do
+    for _, source in ipairs(all_sources) do
         if sources.is_available(source, ft) then
             return true
         end
@@ -55,7 +43,7 @@ function M.setup()
             return lsputil.root_pattern("Makefile", ".git")(fname) or lsputil.path.dirname(fname)
         end,
         flags = { debounce_text_changes = c.get().debounce },
-        filetypes = get_registered_filetypes(),
+        filetypes = sources.get_filetypes(),
         autostart = false,
     }
 
@@ -102,7 +90,7 @@ function M.on_register_sources()
         return
     end
 
-    config.filetypes = get_registered_filetypes()
+    config.filetypes = sources.get_filetypes()
 end
 
 function M.try_add(bufnr)

--- a/lua/null-ls/lspconfig.lua
+++ b/lua/null-ls/lspconfig.lua
@@ -1,65 +1,93 @@
 local methods = require("null-ls.methods")
+local sources = require("null-ls.sources")
 local c = require("null-ls.config")
 local u = require("null-ls.utils")
 
 local api = vim.api
 
+-- update filetypes shown in :LspInfo
+local get_registered_filetypes = function()
+    local filetypes = {}
+    for _, source in ipairs(c.get()._sources) do
+        for ft in pairs(source.filetypes) do
+            if ft ~= "_all" and not vim.tbl_contains(filetypes, ft) then
+                table.insert(filetypes, ft)
+            end
+        end
+    end
+    return filetypes
+end
+
+local should_attach = function(bufnr)
+    -- don't attach if no sources have been registered
+    if vim.tbl_isempty(c.get()._sources) then
+        return false
+    end
+
+    -- lspconfig checks if buftype == "nofile", but we want to be defensive, since (if configured) null-ls will try attaching to any buffer
+    if api.nvim_buf_get_option(bufnr, "buftype") ~= "" then
+        return
+    end
+
+    local ft = api.nvim_buf_get_option(bufnr, "filetype")
+    -- writing and immediately deleting a buffer (e.g. :wq from a git commit) triggers a bug on 0.5 which is fixed on master
+    if vim.fn.has("nvim-0.6") == 0 and ft == "gitcommit" then
+        return false
+    end
+
+    for _, source in ipairs(c.get()._sources) do
+        if sources.is_available(source, ft) then
+            return true
+        end
+    end
+
+    return false
+end
+
 local M = {}
 
 function M.setup()
-    local configs = require("lspconfig/configs")
-    local util = require("lspconfig/util")
-
-    local config_def = {
+    local lsputil = require("lspconfig.util")
+    local default_config = {
         cmd = { "nvim" },
         name = "null-ls",
         root_dir = function(fname)
-            return util.root_pattern("Makefile", ".git")(fname) or util.path.dirname(fname)
+            return lsputil.root_pattern("Makefile", ".git")(fname) or lsputil.path.dirname(fname)
         end,
         flags = { debounce_text_changes = c.get().debounce },
-        filetypes = c.get()._filetypes,
+        filetypes = get_registered_filetypes(),
         autostart = false,
     }
 
-    configs["null-ls"] = {
-        default_config = config_def,
+    require("lspconfig/configs")["null-ls"] = {
+        default_config = default_config,
     }
 
     -- listen on FileType and try attaching
     vim.cmd([[
       augroup NullLs
         autocmd!
-        autocmd FileType * unsilent lua require("null-ls.lspconfig").try_add()
+        autocmd FileType * lua require("null-ls.lspconfig").try_add()
       augroup end
     ]])
 end
 
--- update filetypes shown in :LspInfo
-function M.on_register_filetypes()
-    local config = require("lspconfig")["null-ls"]
-    if not config then
-        return
-    end
-
-    config.filetypes = c.get()._filetypes
-end
-
--- try attaching to existing buffers and (if applicable) send a didChange notification to refresh diagnostics
-function M.on_register_source(source_methods)
-    -- lspconfig hasn't been set up yet, meaning the source was registered normally (i.e. not dynamically)
+-- after registering a new source, try attaching to existing buffers and refresh diagnostics
+function M.on_register_source(source)
     if not require("lspconfig")["null-ls"] then
         return
     end
 
     local client = u.get_client()
-    local is_diagnostic_source = vim.tbl_contains(source_methods, methods.internal.DIAGNOSTICS)
-    local handle_existing_buffer = function(buf)
-        if buf.name == "" then
-            return
-        end
+    if not client then
+        return
+    end
 
+    local handle_existing_buffer = function(buf)
         M.try_add(buf.bufnr)
-        if client and is_diagnostic_source then
+        if
+            sources.is_available(source, api.nvim_buf_get_option(buf.bufnr, "filetype"), methods.internal.DIAGNOSTICS)
+        then
             client.notify(methods.lsp.DID_CHANGE, { textDocument = { uri = vim.uri_from_bufnr(buf.bufnr) } })
         end
     end
@@ -67,31 +95,24 @@ function M.on_register_source(source_methods)
     vim.tbl_map(handle_existing_buffer, vim.fn.getbufinfo({ listed = 1 }))
 end
 
-function M.try_add(bufnr)
+-- refresh filetypes after modifying registered sources
+function M.on_register_sources()
     local config = require("lspconfig")["null-ls"]
-    if not (config and config.manager) then
+    if not config then
         return
     end
 
-    -- don't attach if no sources have been registered
-    if not c.get()._registered then
+    config.filetypes = get_registered_filetypes()
+end
+
+function M.try_add(bufnr)
+    local config = require("lspconfig")["null-ls"]
+    if not config and config.manager then
         return
     end
 
     bufnr = bufnr or api.nvim_get_current_buf()
-    local ft, buftype = api.nvim_buf_get_option(bufnr, "filetype"), api.nvim_buf_get_option(bufnr, "buftype")
-
-    -- writing and immediately deleting a buffer (e.g. :wq from a git commit) triggers a bug on 0.5, but it's fixed on master
-    if vim.fn.has("nvim-0.6") == 0 and ft == "gitcommit" then
-        return
-    end
-
-    -- lspconfig checks if buftype == "nofile", but we want to be defensive, since (if configured) null-ls will try attaching to any buffer
-    if buftype ~= "" then
-        return
-    end
-
-    if not c.get()._all_filetypes and not u.filetype_matches(c.get()._filetypes, ft) then
+    if not should_attach(bufnr) then
         return
     end
 

--- a/lua/null-ls/lspconfig.lua
+++ b/lua/null-ls/lspconfig.lua
@@ -12,9 +12,8 @@ local should_attach = function(bufnr)
         return false
     end
 
-    -- lspconfig checks if buftype == "nofile", but we want to be defensive,
-    -- since (if configured) null-ls will try attaching to any buffer
-    if api.nvim_buf_get_option(bufnr, "buftype") ~= "" then
+    -- be paranoid and try to make sure that the buffer represents an actual file
+    if api.nvim_buf_get_option(bufnr, "buftype") ~= "" or api.nvim_buf_get_name(bufnr) == "" then
         return false
     end
 

--- a/lua/null-ls/lspconfig.lua
+++ b/lua/null-ls/lspconfig.lua
@@ -12,13 +12,15 @@ local should_attach = function(bufnr)
         return false
     end
 
-    -- lspconfig checks if buftype == "nofile", but we want to be defensive, since (if configured) null-ls will try attaching to any buffer
+    -- lspconfig checks if buftype == "nofile", but we want to be defensive,
+    -- since (if configured) null-ls will try attaching to any buffer
     if api.nvim_buf_get_option(bufnr, "buftype") ~= "" then
-        return
+        return false
     end
 
     local ft = api.nvim_buf_get_option(bufnr, "filetype")
-    -- writing and immediately deleting a buffer (e.g. :wq from a git commit) triggers a bug on 0.5 which is fixed on master
+    -- writing and immediately deleting a buffer (e.g. :wq from a git commit)
+    -- triggers a bug on 0.5 which is fixed on master
     if ft == "gitcommit" and not u.has_version("0.6.0") then
         return false
     end
@@ -76,7 +78,9 @@ function M.on_register_source(source)
         if
             sources.is_available(source, api.nvim_buf_get_option(buf.bufnr, "filetype"), methods.internal.DIAGNOSTICS)
         then
-            client.notify(methods.lsp.DID_CHANGE, { textDocument = { uri = vim.uri_from_bufnr(buf.bufnr) } })
+            client.notify(methods.lsp.DID_CHANGE, {
+                textDocument = { uri = vim.uri_from_bufnr(buf.bufnr) },
+            })
         end
     end
 

--- a/lua/null-ls/rpc.lua
+++ b/lua/null-ls/rpc.lua
@@ -23,9 +23,9 @@ local capabilities = {
     },
 }
 
-local lastpid = 5000
+M.capabilities = capabilities
 
-function M.setup()
+M.setup = function()
     local rpc = require("vim.lsp.rpc")
 
     local rpc_start = rpc.start
@@ -38,15 +38,9 @@ function M.setup()
     end
 end
 
-local function get_client(pid)
-    for _, client in pairs(vim.lsp.get_active_clients()) do
-        if client.rpc.pid == pid then
-            return client
-        end
-    end
-end
+local lastpid = 5000
 
-function M.start(dispatchers)
+M.start = function(dispatchers)
     lastpid = lastpid + 1
     local message_id = 1
     local pid = lastpid
@@ -57,7 +51,7 @@ function M.start(dispatchers)
         params = params or {}
         callback = callback and vim.schedule_wrap(callback)
         message_id = message_id + 1
-        client = client or get_client(pid)
+        client = client or u.get_client()
 
         if type(params) ~= "table" then
             params = { params }

--- a/lua/null-ls/sources.lua
+++ b/lua/null-ls/sources.lua
@@ -76,6 +76,8 @@ M.deregister = function(query)
             table.remove(all_sources, i)
         end
     end
+
+    require("null-ls.lspconfig").on_register_sources()
 end
 
 M.validate_and_transform = function(source)

--- a/lua/null-ls/sources.lua
+++ b/lua/null-ls/sources.lua
@@ -28,8 +28,11 @@ M.is_available = function(source, filetype, method)
         return false
     end
 
-    return (not filetype or source.filetypes["_all"] or source.filetypes[filetype])
-        and (not method or source.methods[method])
+    return (
+            not filetype
+            or (source.filetypes[filetype] == nil and source.filetypes["_all"])
+            or source.filetypes[filetype]
+        ) and (not method or source.methods[method])
 end
 
 M.get_available = function(filetype, method)
@@ -91,11 +94,12 @@ M.validate_and_transform = function(source)
     local generator, name = source.generator, source.name or "anonymous source"
     generator.opts = generator.opts or {}
     local methods = type(source.method) == "table" and source.method or { source.method }
-    local filetypes = source.filetypes
+    local filetypes, disabled_filetypes = source.filetypes, source.disabled_filetypes
 
     validate({
         generator = { generator, "table" },
         filetypes = { filetypes, "table" },
+        disabled_filetypes = { disabled_filetypes, "table", true },
         name = { name, "string" },
         methods = { methods, "table" },
         fn = { generator.fn, "function" },
@@ -116,6 +120,12 @@ M.validate_and_transform = function(source)
     else
         for _, ft in ipairs(filetypes) do
             filetype_map[ft] = true
+        end
+    end
+
+    if disabled_filetypes then
+        for _, ft in ipairs(disabled_filetypes) do
+            filetype_map[ft] = false
         end
     end
 

--- a/lua/null-ls/sources.lua
+++ b/lua/null-ls/sources.lua
@@ -11,6 +11,32 @@ M.is_available = function(source, filetype, method)
         and (not method or source.methods[method])
 end
 
+M.get_available = function(filetype, method)
+    local available = {}
+    for _, source in ipairs(require("null-ls.config").get()._sources) do
+        if M.is_available(source, filetype, method) then
+            table.insert(available, source)
+        end
+    end
+    return available
+end
+
+M.get_all = function()
+    return require("null-ls.config").get()._sources
+end
+
+M.get_filetypes = function()
+    local filetypes = {}
+    for _, source in ipairs(M.get_all()) do
+        for ft in pairs(source.filetypes) do
+            if ft ~= "_all" and not vim.tbl_contains(filetypes, ft) then
+                table.insert(filetypes, ft)
+            end
+        end
+    end
+    return filetypes
+end
+
 M.validate_and_transform = function(source)
     if type(source) == "function" then
         source = source()

--- a/lua/null-ls/sources.lua
+++ b/lua/null-ls/sources.lua
@@ -1,0 +1,74 @@
+local validate = vim.validate
+
+local M = {}
+
+M.is_available = function(source, filetype, method)
+    if source.generator._failed then
+        return false
+    end
+
+    return (not filetype or source.filetypes["_all"] or source.filetypes[filetype])
+        and (not method or source.methods[method])
+end
+
+M.validate_and_transform = function(source)
+    if type(source) == "function" then
+        source = source()
+        if not source then
+            return
+        end
+    end
+
+    local generator, name = source.generator, source.name or "anonymous source"
+    generator.opts = generator.opts or {}
+    local methods = type(source.method) == "table" and source.method or { source.method }
+    local filetypes = source.filetypes
+
+    validate({
+        generator = { generator, "table" },
+        filetypes = { filetypes, "table" },
+        name = { name, "string" },
+        methods = { methods, "table" },
+        fn = { generator.fn, "function" },
+        opts = { generator.opts, "table" },
+        async = { generator.async, "boolean", true },
+        method = {
+            methods,
+            function(m)
+                return not vim.tbl_isempty(m), "at least one method"
+            end,
+        },
+    })
+
+    -- use map for filetypes and methods to simplify checks
+    local filetype_map, method_map = {}, {}
+    if vim.tbl_isempty(filetypes) then
+        filetype_map["_all"] = true
+    else
+        for _, ft in ipairs(filetypes) do
+            filetype_map[ft] = true
+        end
+    end
+
+    for _, method in ipairs(methods) do
+        validate({
+            method = {
+                method,
+                function(m)
+                    return require("null-ls.methods").internal[m] ~= nil
+                end,
+                "supported null-ls method",
+            },
+        })
+        method_map[method] = true
+    end
+
+    return {
+        name = name,
+        generator = generator,
+        filetypes = filetype_map,
+        methods = method_map,
+    }
+end
+
+return M

--- a/lua/null-ls/utils.lua
+++ b/lua/null-ls/utils.lua
@@ -74,10 +74,6 @@ M.debug_log = function(...)
     require("null-ls.logger").debug(...)
 end
 
-M.filetype_matches = function(filetypes, ft)
-    return vim.tbl_isempty(filetypes) or vim.tbl_contains(filetypes, ft)
-end
-
 M.get_client = function()
     for _, client in ipairs(vim.lsp.get_active_clients()) do
         if client.name == "null-ls" then

--- a/lua/null-ls/utils.lua
+++ b/lua/null-ls/utils.lua
@@ -148,7 +148,7 @@ M.make_params = function(original_params, method)
     end
 
     if params.lsp_method == methods.lsp.COMPLETION then
-        local line = vim.api.nvim_get_current_line()
+        local line = params.content[params.row]
         local line_to_cursor = line:sub(1, pos[2])
         local regex = vim.regex("\\k*$")
 

--- a/lua/null-ls/utils.lua
+++ b/lua/null-ls/utils.lua
@@ -82,6 +82,15 @@ M.get_client = function()
     end
 end
 
+M.resolve_handler = function(method)
+    local client = M.get_client()
+    return client and client.handlers[method] or vim.lsp.handlers[method]
+end
+
+M.has_version = function(ver)
+    return vim.fn.has("nvim-" .. ver) > 0
+end
+
 -- lsp-compatible range is 0-indexed.
 -- lua-friendly range is 1-indexed.
 M.range = {
@@ -205,11 +214,7 @@ M.table = {
     end,
 }
 
-M.resolve_handler = function(method)
-    local client = M.get_client()
-    return client and client.handlers[method] or vim.lsp.handlers[method]
-end
-
+-- TODO: remove on 0.6.0 release
 function M.debounce(ms, fn)
     local timer = vim.loop.new_timer()
     return function(...)

--- a/test/spec/code-actions_spec.lua
+++ b/test/spec/code-actions_spec.lua
@@ -43,8 +43,16 @@ describe("code_actions", function()
         describe("method == CODE_ACTION", function()
             local method = methods.lsp.CODE_ACTION
 
-            it("should return immediately if null_ls_ignore flag is set", function()
+            it("should return immediately if null_ls_ignore flag is set on params", function()
                 local params = { _null_ls_ignore = true }
+                code_actions.handler(method, params, handler)
+
+                assert.stub(u.make_params).was_not_called()
+                assert.equals(params._null_ls_handled, nil)
+            end)
+
+            it("should return immediately if null_ls_ignore flag is set on ctx", function()
+                local params = { ctx = { _null_ls_ignore = true } }
                 code_actions.handler(method, params, handler)
 
                 assert.stub(u.make_params).was_not_called()

--- a/test/spec/config_spec.lua
+++ b/test/spec/config_spec.lua
@@ -1,29 +1,16 @@
-local methods = require("null-ls.methods")
 local stub = require("luassert.stub")
 
 describe("config", function()
     local c = require("null-ls.config")
-    local on_register_source = stub(require("null-ls.lspconfig"), "on_register_source")
-    local on_register_sources = stub(require("null-ls.lspconfig"), "on_register_sources")
 
-    local mock_source
-    before_each(function()
-        mock_source = {
-            name = "mock source",
-            method = methods.internal.CODE_ACTION,
-            filetypes = { "txt", "markdown" },
-            generator = {
-                fn = function()
-                    print("I am a generator")
-                end,
-            },
-        }
-    end)
+    local register = stub(require("null-ls.sources"), "register")
+    local reset = stub(require("null-ls.sources"), "reset")
 
     after_each(function()
+        register:clear()
+        reset:clear()
+
         c.reset()
-        on_register_source:clear()
-        on_register_sources:clear()
     end)
 
     describe("get", function()
@@ -43,129 +30,10 @@ describe("config", function()
             assert.equals(c.get().debounce, 250)
         end)
 
-        it("should call on_register_sources", function()
+        it("should call sources.reset", function()
             c.reset()
 
-            assert.stub(on_register_sources).was_called()
-        end)
-    end)
-
-    describe("reset_sources", function()
-        it("should reset source-related tables but leave config values", function()
-            c.setup({ debounce = 500, sources = { mock_source } })
-
-            c.reset_sources()
-
-            assert.equals(vim.tbl_count(c.get()._sources), 0)
-            assert.equals(vim.tbl_count(c.get()._names), 0)
-            assert.equals(c.get().debounce, 500)
-        end)
-
-        it("should call on_register_sources", function()
-            c.reset_sources()
-
-            assert.stub(on_register_sources).was_called()
-        end)
-    end)
-
-    describe("register", function()
-        local find_source = function(name)
-            for _, source in ipairs(c.get()._sources) do
-                if source.name == name then
-                    return source
-                end
-            end
-        end
-
-        it("should register single source", function()
-            c.register(mock_source)
-
-            local sources = c.get()._sources
-            assert.equals(vim.tbl_count(sources), 1)
-            assert.truthy(find_source(mock_source.name))
-        end)
-
-        it("should call on_register_source", function()
-            c.register(mock_source)
-
-            assert.stub(on_register_source).was_called()
-        end)
-
-        it("should handle large number of duplicates", function()
-            for _ = 1, 99 do
-                c.register(mock_source)
-            end
-
-            local sources = c.get()._sources
-            assert.equals(vim.tbl_count(sources), 99)
-        end)
-
-        it("should register multiple sources from simple list", function()
-            c.register({ mock_source, mock_source })
-
-            local sources = c.get()._sources
-            assert.equals(vim.tbl_count(sources), 2)
-        end)
-
-        it("should call on_register_source once per source", function()
-            c.register({ mock_source, mock_source })
-
-            assert.stub(on_register_source).was_called(2)
-        end)
-
-        it("should call on_register_sources only once", function()
-            c.register({ mock_source, mock_source })
-
-            assert.stub(on_register_sources).was_called(1)
-        end)
-
-        it("should register multiple sources with shared configuration", function()
-            c.register({
-                name = "shared config source",
-                filetypes = { "txt" }, -- should take precedence over source filetypes
-                sources = { mock_source, mock_source },
-            })
-
-            local sources = c.get()._sources
-            assert.equals(vim.tbl_count(sources), 2)
-            local found = find_source("shared config source")
-            assert.truthy(found)
-            assert.same(found.filetypes, { ["txt"] = true })
-        end)
-    end)
-
-    describe("is_registered", function()
-        local mock_name = "mock-name"
-        local mock_sources = {
-            name = mock_name,
-            filetypes = { "txt" },
-            sources = { mock_source, mock_source },
-        }
-
-        it("should return false if source and name are not registered", function()
-            assert.equals(c.is_registered(mock_name), false)
-        end)
-
-        it("should return true if source is registered", function()
-            c.register(mock_sources)
-
-            assert.equals(c.is_registered(mock_name), true)
-        end)
-
-        it("should return true if name is registered", function()
-            c.register_name(mock_name)
-
-            assert.equals(c.is_registered(mock_name), true)
-        end)
-    end)
-
-    describe("register_name", function()
-        local mock_name = "mock-name"
-
-        it("should register name", function()
-            c.register_name(mock_name)
-
-            assert.equals(c.is_registered(mock_name), true)
+            assert.stub(reset).was_called()
         end)
     end)
 
@@ -217,21 +85,18 @@ describe("config", function()
         end)
 
         it("should throw if config value is private", function()
-            local _names = { "my-integration" }
-
-            local ok, err = pcall(c.setup, { _names = _names })
+            local ok, err = pcall(c.setup, { _setup = true })
 
             assert.equals(ok, false)
             assert.matches("expected nil", err)
         end)
 
-        it("should register source under private key and set config.sources to nil", function()
-            c.setup({ sources = { mock_source } })
+        it("should register sources", function()
+            local mock_sources = { "mock-source", "mock-source-2" }
 
-            local sources = c.get()._sources
+            c.setup({ sources = mock_sources })
 
-            assert.equals(vim.tbl_count(sources), 1)
-            assert.falsy(c.get().sources)
+            assert.stub(register).was_called_with(mock_sources)
         end)
     end)
 end)

--- a/test/spec/config_spec.lua
+++ b/test/spec/config_spec.lua
@@ -42,6 +42,12 @@ describe("config", function()
 
             assert.equals(c.get().debounce, 250)
         end)
+
+        it("should call on_register_sources", function()
+            c.reset()
+
+            assert.stub(on_register_sources).was_called()
+        end)
     end)
 
     describe("reset_sources", function()
@@ -79,12 +85,10 @@ describe("config", function()
             assert.truthy(find_source(mock_source.name))
         end)
 
-        it("should call on_register_source with transformed source", function()
+        it("should call on_register_source", function()
             c.register(mock_source)
 
-            assert.stub(on_register_source).was_called_with(
-                require("null-ls.sources").validate_and_transform(mock_source)
-            )
+            assert.stub(on_register_source).was_called()
         end)
 
         it("should handle large number of duplicates", function()

--- a/test/spec/config_spec.lua
+++ b/test/spec/config_spec.lua
@@ -7,6 +7,7 @@ describe("config", function()
     local mock_source
     before_each(function()
         mock_source = {
+            name = "mock source",
             method = methods.internal.CODE_ACTION,
             filetypes = { "txt", "markdown" },
             generator = {
@@ -39,129 +40,63 @@ describe("config", function()
         end)
     end)
 
+    describe("reset_sources", function()
+        it("should reset source-related tables but leave config values", function()
+            c.setup({ debounce = 500, sources = { mock_source } })
+
+            c.reset_sources()
+
+            assert.equals(vim.tbl_count(c.get()._sources), 0)
+            assert.equals(vim.tbl_count(c.get()._names), 0)
+            assert.equals(c.get().debounce, 500)
+        end)
+    end)
+
     describe("register", function()
+        local find_source = function(name)
+            for _, source in ipairs(c.get()._sources) do
+                if source.name == name then
+                    return source
+                end
+            end
+        end
+
         it("should register single source", function()
             c.register(mock_source)
 
-            local generators = c.get()._generators
-            assert.equals(vim.tbl_count(generators), 1)
-            assert.equals(vim.tbl_count(generators[mock_source.method]), 1)
-            assert.equals(vim.tbl_count(c.get()._filetypes), 2)
-            assert.equals(c.get()._all_filetypes, false)
-            assert.equals(c.get()._registered, true)
+            local sources = c.get()._sources
+            assert.equals(vim.tbl_count(sources), 1)
+            assert.truthy(find_source(mock_source.name))
         end)
 
-        it("should set all_filetypes if filetypes is empty table", function()
-            mock_source.filetypes = {}
+        it("should handle large number of duplicates", function()
+            for _ = 1, 99 do
+                c.register(mock_source)
+            end
 
-            c.register(mock_source)
-
-            assert.equals(vim.tbl_count(c.get()._filetypes), 0)
-            assert.equals(c.get()._all_filetypes, true)
-        end)
-
-        it("should throw if source method is invalid", function()
-            mock_source.method = "badMethod"
-
-            local ok, err = pcall(c.register, mock_source)
-
-            assert.equals(ok, false)
-            assert.matches("expected supported null%-ls method", err)
-        end)
-
-        it("should register source filetypes under methods if name is defined", function()
-            mock_source.name = "mock-source"
-
-            c.register(mock_source)
-
-            local source_methods = c.get()._methods
-            assert.truthy(source_methods[mock_source.method])
-            assert.truthy(source_methods[mock_source.method][mock_source.name])
-            assert.same(source_methods[mock_source.method][mock_source.name], mock_source.filetypes)
-        end)
-
-        it("should not register source with same name twice", function()
-            mock_source.name = "mock-source"
-
-            c.register(mock_source)
-            c.register(mock_source)
-
-            local generators = c.get()._generators
-            assert.equals(vim.tbl_count(generators[mock_source.method]), 1)
-        end)
-
-        it("should register sources with same name if they are copies", function()
-            mock_source.name = "mock-source"
-            mock_source._is_copy = true
-
-            local copy = vim.deepcopy(mock_source)
-            mock_source.filetypes = { "lua" }
-
-            c.register(mock_source)
-            c.register(copy)
-
-            local generators = c.get()._generators
-            assert.equals(vim.tbl_count(generators[mock_source.method]), 2)
-            assert.same(c.get()._methods[mock_source.method][mock_source.name], { "lua", "txt", "markdown" })
-        end)
-
-        it("should register function source", function()
-            c.register(function()
-                return mock_source
-            end)
-
-            local generators = c.get()._generators
-            assert.equals(vim.tbl_count(generators), 1)
-            assert.equals(vim.tbl_count(generators[mock_source.method]), 1)
-        end)
-
-        it("should register additional generators for same method", function()
-            c.register(mock_source)
-            c.register(mock_source)
-
-            local generators = c.get()._generators
-            assert.equals(vim.tbl_count(generators), 1)
-            assert.equals(vim.tbl_count(generators[mock_source.method]), 2)
-            assert.equals(vim.tbl_count(c.get()._filetypes), 2)
+            local sources = c.get()._sources
+            assert.equals(vim.tbl_count(sources), 99)
         end)
 
         it("should register multiple sources from simple list", function()
             c.register({ mock_source, mock_source })
 
-            local generators = c.get()._generators
-            assert.equals(vim.tbl_count(generators), 1)
-            assert.equals(vim.tbl_count(generators[mock_source.method]), 2)
-            assert.equals(vim.tbl_count(c.get()._filetypes), 2)
+            local sources = c.get()._sources
+            assert.equals(vim.tbl_count(sources), 2)
         end)
 
         it("should register multiple sources with shared configuration", function()
             c.register({
-                name = "mock-source",
+                name = "shared config source",
                 filetypes = { "txt" }, -- should take precedence over source filetypes
                 sources = { mock_source, mock_source },
             })
 
-            local generators = c.get()._generators
-            assert.equals(vim.tbl_count(generators), 1)
-            assert.equals(vim.tbl_count(generators[mock_source.method]), 2)
-            assert.equals(vim.tbl_count(c.get()._filetypes), 1)
-            assert.equals(c.get()._names["mock-source"], true)
-        end)
-
-        it("should not register mutiple sources with same name twice", function()
-            local mock_sources = {
-                name = "mock-source",
-                filetypes = { "txt" },
-                sources = { mock_source, mock_source },
-            }
-
-            c.register(mock_sources)
-            c.register(mock_sources)
-
-            local generators = c.get()._generators
-            assert.equals(vim.tbl_count(generators), 1)
-            assert.equals(vim.tbl_count(generators[mock_source.method]), 2)
-            assert.equals(vim.tbl_count(c.get()._filetypes), 1)
+            local sources = c.get()._sources
+            assert.equals(vim.tbl_count(sources), 2)
+            local found = find_source("shared config source")
+            assert.truthy(found)
+            assert.same(found.filetypes, { ["txt"] = true })
         end)
     end)
 
@@ -173,12 +108,18 @@ describe("config", function()
             sources = { mock_source, mock_source },
         }
 
-        it("should return false if name is not registered", function()
+        it("should return false if source and name are not registered", function()
             assert.equals(c.is_registered(mock_name), false)
         end)
 
-        it("should return true if name is registered", function()
+        it("should return true if source is registered", function()
             c.register(mock_sources)
+
+            assert.equals(c.is_registered(mock_name), true)
+        end)
+
+        it("should return true if name is registered", function()
+            c.register_name(mock_name)
 
             assert.equals(c.is_registered(mock_name), true)
         end)
@@ -191,19 +132,6 @@ describe("config", function()
             c.register_name(mock_name)
 
             assert.equals(c.is_registered(mock_name), true)
-        end)
-    end)
-
-    describe("reset_sources", function()
-        it("should reset source-related values only", function()
-            c.setup({ debounce = 500, sources = { mock_source } })
-
-            c.reset_sources()
-
-            assert.equals(vim.tbl_count(c.get()._generators), 0)
-            assert.equals(vim.tbl_count(c.get()._methods), 0)
-            assert.equals(vim.tbl_count(c.get()._filetypes), 0)
-            assert.equals(c.get().debounce, 500)
         end)
     end)
 
@@ -263,14 +191,13 @@ describe("config", function()
             assert.matches("expected nil", err)
         end)
 
-        it("should register sources", function()
+        it("should register source under private key and set config.sources to nil", function()
             c.setup({ sources = { mock_source } })
 
-            local generators = c.get()._generators
+            local sources = c.get()._sources
 
-            assert.equals(vim.tbl_count(generators), 1)
-            assert.equals(vim.tbl_count(generators[mock_source.method]), 1)
-            assert.equals(vim.tbl_count(c.get()._filetypes), 2)
+            assert.equals(vim.tbl_count(sources), 1)
+            assert.falsy(c.get().sources)
         end)
     end)
 end)

--- a/test/spec/e2e_spec.lua
+++ b/test/spec/e2e_spec.lua
@@ -63,14 +63,6 @@ describe("e2e", function()
             assert.equals(null_ls_action.command, methods.internal.CODE_ACTION)
         end)
 
-        it("should only register source once", function()
-            c.register(builtins._test.toggle_line_comment)
-
-            actions = get_code_actions()
-
-            assert.equals(vim.tbl_count(actions[1].result), 1)
-        end)
-
         it("should apply code action", function()
             vim.lsp.buf.execute_command(null_ls_action)
 

--- a/test/spec/e2e_spec.lua
+++ b/test/spec/e2e_spec.lua
@@ -1,5 +1,6 @@
 local builtins = require("null-ls.builtins")
 local methods = require("null-ls.methods")
+local sources = require("null-ls.sources")
 local main = require("null-ls")
 
 local c = require("null-ls.config")
@@ -33,16 +34,17 @@ local get_code_actions = function()
 end
 
 describe("e2e", function()
-    _G._TEST = true
     after_each(function()
         vim.cmd("bufdo! bdelete!")
+
         c.reset()
+        sources.reset()
     end)
 
     describe("code actions", function()
         local actions, null_ls_action
         before_each(function()
-            c.register(builtins._test.toggle_line_comment)
+            sources.register(builtins._test.toggle_line_comment)
 
             tu.edit_test_file("test-file.lua")
             lsp_wait()
@@ -81,7 +83,7 @@ describe("e2e", function()
         end)
 
         it("should combine actions from multiple sources", function()
-            c.register(builtins._test.mock_code_action)
+            sources.register(builtins._test.mock_code_action)
 
             actions = get_code_actions()
 
@@ -91,7 +93,7 @@ describe("e2e", function()
         it("should handle code action timeout", function()
             -- action calls a script that waits for 250 ms,
             -- but action timeout is 100 ms
-            c.register(builtins._test.slow_code_action)
+            sources.register(builtins._test.slow_code_action)
 
             actions = get_code_actions()
 
@@ -106,7 +108,7 @@ describe("e2e", function()
         end
 
         before_each(function()
-            c.register(builtins.diagnostics.write_good)
+            sources.register(builtins.diagnostics.write_good)
 
             tu.edit_test_file("test-file.md")
             lsp_wait()
@@ -140,7 +142,7 @@ describe("e2e", function()
             end
 
             it("should show diagnostics from multiple sources", function()
-                c.register(builtins.diagnostics.markdownlint)
+                sources.register(builtins.diagnostics.markdownlint)
                 vim.cmd("e")
                 lsp_wait()
 
@@ -162,8 +164,8 @@ describe("e2e", function()
         end)
 
         it("should format diagnostics with source-specific diagnostics_format", function()
-            c.reset_sources()
-            c.register(builtins.diagnostics.write_good.with({ diagnostics_format = "#{m} (#{s})" }))
+            sources.reset()
+            sources.register(builtins.diagnostics.write_good.with({ diagnostics_format = "#{m} (#{s})" }))
             vim.cmd("e")
             lsp_wait()
 
@@ -183,7 +185,7 @@ describe("e2e", function()
 
         local bufnr
         before_each(function()
-            c.register(builtins.formatting.prettier)
+            sources.register(builtins.formatting.prettier)
 
             tu.edit_test_file("test-file.js")
             -- make sure file wasn't accidentally saved
@@ -242,11 +244,11 @@ describe("e2e", function()
             local prettier = builtins.formatting.prettier
             local original_args = prettier._opts.args
             before_each(function()
-                c.reset()
+                sources.reset()
 
                 prettier._opts.args = { "--write", "$FILENAME" }
                 prettier._opts.to_temp_file = true
-                c.register(prettier)
+                sources.register(prettier)
             end)
             after_each(function()
                 prettier._opts.args = original_args
@@ -273,7 +275,7 @@ describe("e2e", function()
         local formatted = 'import { User } from "./test-types";\nimport {Other} from "./test-types"\n'
 
         before_each(function()
-            c.register(builtins.formatting.prettier)
+            sources.register(builtins.formatting.prettier)
             tu.edit_test_file("range-formatting.js")
             assert.is_not.equals(u.buf.content(nil, true), formatted)
 
@@ -306,7 +308,7 @@ describe("e2e", function()
             ]],
                 false
             )
-            c.register(builtins.diagnostics.teal)
+            sources.register(builtins.diagnostics.teal)
 
             tu.edit_test_file("test-file.tl")
             lsp_wait()
@@ -344,7 +346,7 @@ describe("e2e", function()
     describe("cached generator", function()
         local actions, null_ls_action
         before_each(function()
-            c.register(builtins._test.cached_code_action)
+            sources.register(builtins._test.cached_code_action)
             tu.edit_test_file("test-file.txt")
             lsp_wait()
 
@@ -379,8 +381,8 @@ describe("e2e", function()
 
     describe("sequential formatting", function()
         it("should format file sequentially", function()
-            c.register(builtins._test.first_formatter)
-            c.register(builtins._test.second_formatter)
+            sources.register(builtins._test.first_formatter)
+            sources.register(builtins._test.second_formatter)
             tu.edit_test_file("test-file.txt")
             lsp_wait()
 
@@ -391,8 +393,8 @@ describe("e2e", function()
         end)
 
         it("should format file according to source order", function()
-            c.register(builtins._test.second_formatter)
-            c.register(builtins._test.first_formatter)
+            sources.register(builtins._test.second_formatter)
+            sources.register(builtins._test.first_formatter)
             tu.edit_test_file("test-file.txt")
             lsp_wait()
 
@@ -403,8 +405,8 @@ describe("e2e", function()
         end)
 
         it("should skip formatters that fail runtime conditions", function()
-            c.register(builtins._test.first_formatter)
-            c.register(builtins._test.runtime_skipped_formatter)
+            sources.register(builtins._test.first_formatter)
+            sources.register(builtins._test.runtime_skipped_formatter)
             tu.edit_test_file("test-file.txt")
             lsp_wait()
 
@@ -421,7 +423,7 @@ describe("e2e", function()
             local client = u.get_client()
             client.handlers[methods.lsp.FORMATTING] = mock_handler
 
-            c.register(builtins._test.first_formatter)
+            sources.register(builtins._test.first_formatter)
             tu.edit_test_file("test-file.txt")
             lsp_wait()
         end)
@@ -441,7 +443,7 @@ describe("e2e", function()
         local mock_handler = require("luassert.stub").new()
 
         before_each(function()
-            c.register(builtins._test.mock_hover)
+            sources.register(builtins._test.mock_hover)
             tu.edit_test_file("test-file.txt")
             lsp_wait()
 

--- a/test/spec/generators_spec.lua
+++ b/test/spec/generators_spec.lua
@@ -3,13 +3,13 @@ local stub = require("luassert.stub")
 local a = require("plenary.async_lib")
 
 local methods = require("null-ls.methods")
+local sources = require("null-ls.sources")
 local u = require("null-ls.utils")
-local c = require("null-ls.config")
 
 local uv = vim.loop
 
 local register = function(method, generator, filetypes)
-    c.register({
+    sources.register({
         method = method,
         generator = generator,
         filetypes = filetypes or { "lua" },
@@ -79,7 +79,7 @@ describe("generators", function()
 
     after_each(function()
         postprocess:clear()
-        c.reset_sources()
+        sources.reset()
     end)
 
     a.tests.describe("run", function()

--- a/test/spec/helpers_spec.lua
+++ b/test/spec/helpers_spec.lua
@@ -770,13 +770,18 @@ describe("helpers", function()
                 local copy = builtin.with({ filetypes = { "txt" } })
 
                 assert.not_same(builtin, copy)
-                assert.equals(copy._is_copy, true)
             end)
 
             it("should override filetypes", function()
                 local copy = builtin.with({ filetypes = { "txt" } })
 
                 assert.same(copy.filetypes, { "txt" })
+            end)
+
+            it("should set disabled filetypes", function()
+                local copy = builtin.with({ disabled_filetypes = { "teal" } })
+
+                assert.same(copy.disabled_filetypes, { "teal" })
             end)
 
             it("should override values on opts", function()

--- a/test/spec/info_spec.lua
+++ b/test/spec/info_spec.lua
@@ -77,5 +77,14 @@ describe("info", function()
             assert.equals(content[5], "")
             assert.equals(content[6], "Formatting: anonymous source, anonymous source")
         end)
+
+        it("should show log path when debug option is enabled", function()
+            c._set({ debug = true })
+
+            info.show_window()
+
+            local content = api.nvim_buf_get_lines(api.nvim_win_get_buf(0), 0, -1, false)
+            assert.equals(content[1], "null-ls log: " .. vim.fn.stdpath("cache") .. "/null-ls.log")
+        end)
     end)
 end)

--- a/test/spec/info_spec.lua
+++ b/test/spec/info_spec.lua
@@ -1,0 +1,79 @@
+local stub = require("luassert.stub")
+
+local builtins = require("null-ls.builtins")
+local methods = require("null-ls.methods")
+local c = require("null-ls.config")
+local u = require("null-ls.utils")
+
+local api = vim.api
+
+describe("info", function()
+    local info = require("null-ls.info")
+    after_each(function()
+        c.reset()
+        vim.bo.filetype = ""
+    end)
+
+    describe("get_active_sources", function()
+        before_each(function()
+            vim.bo.filetype = "text"
+            c.register({
+                builtins._test.mock_hover,
+                builtins._test.first_formatter,
+                builtins._test.second_formatter,
+                -- filetype doesn't match
+                builtins._test.mock_code_action,
+            })
+        end)
+
+        it("should get table of active sources indexed by method", function()
+            local active = info.get_active_sources()
+            assert.truthy(active[methods.internal.HOVER])
+            assert.truthy(active[methods.internal.FORMATTING])
+            assert.truthy(#active[methods.internal.HOVER] == 1)
+            assert.truthy(#active[methods.internal.FORMATTING] == 2)
+        end)
+    end)
+
+    describe("show_window", function()
+        local get_client = stub(u, "get_client")
+        local buf_is_attached = stub(vim.lsp, "buf_is_attached")
+        before_each(function()
+            get_client.returns({})
+            buf_is_attached.returns(true)
+        end)
+        after_each(function()
+            get_client:clear()
+        end)
+
+        before_each(function()
+            vim.bo.filetype = "text"
+            c.register({
+                -- order of active sources is not fixed,
+                -- so we have to avoid using more methods to assert against window content
+                builtins._test.first_formatter,
+                builtins._test.second_formatter,
+            })
+        end)
+
+        it("should create window with log message and active sources", function()
+            info.show_window()
+
+            local bufnr = api.nvim_win_get_buf(0)
+            assert.equals(api.nvim_buf_get_option(bufnr, "buftype"), "nofile")
+            assert.equals(api.nvim_buf_get_option(bufnr, "filetype"), "null-ls-info")
+            assert.equals(api.nvim_buf_get_option(bufnr, "modifiable"), false)
+
+            local content = api.nvim_buf_get_lines(bufnr, 0, -1, false)
+            assert.equals(
+                content[1],
+                "null-ls log: not enabled (this is normal; see the README if you need to enable logging)"
+            )
+            assert.equals(content[2], "Detected filetype: text")
+            assert.equals(content[3], "")
+            assert.equals(content[4], "2 source(s) active for this buffer:")
+            assert.equals(content[5], "")
+            assert.equals(content[6], "Formatting: anonymous source, anonymous source")
+        end)
+    end)
+end)

--- a/test/spec/info_spec.lua
+++ b/test/spec/info_spec.lua
@@ -2,6 +2,7 @@ local stub = require("luassert.stub")
 
 local builtins = require("null-ls.builtins")
 local methods = require("null-ls.methods")
+local sources = require("null-ls.sources")
 local c = require("null-ls.config")
 local u = require("null-ls.utils")
 
@@ -10,6 +11,7 @@ local api = vim.api
 describe("info", function()
     local info = require("null-ls.info")
     after_each(function()
+        sources.reset()
         c.reset()
         vim.bo.filetype = ""
     end)
@@ -17,7 +19,7 @@ describe("info", function()
     describe("get_active_sources", function()
         before_each(function()
             vim.bo.filetype = "text"
-            c.register({
+            sources.register({
                 builtins._test.mock_hover,
                 builtins._test.first_formatter,
                 builtins._test.second_formatter,
@@ -48,7 +50,7 @@ describe("info", function()
 
         before_each(function()
             vim.bo.filetype = "text"
-            c.register({
+            sources.register({
                 -- order of active sources is not fixed,
                 -- so we have to avoid using more methods to assert against window content
                 builtins._test.first_formatter,

--- a/test/spec/lspconfig_spec.lua
+++ b/test/spec/lspconfig_spec.lua
@@ -1,0 +1,142 @@
+local stub = require("luassert.stub")
+
+local methods = require("null-ls.methods")
+local c = require("null-ls.config")
+local u = require("null-ls.utils")
+
+describe("lspconfig", function()
+    local lspconfig = require("null-ls.lspconfig")
+
+    -- this has side effects so we can only do it once
+    lspconfig.setup()
+
+    after_each(function()
+        c.reset()
+    end)
+
+    describe("setup", function()
+        it("should set up default config", function()
+            local null_ls_config = require("lspconfig/configs")["null-ls"]
+            assert.truthy(null_ls_config)
+
+            local default_config = null_ls_config.document_config.default_config
+            assert.equals(default_config.name, "null-ls")
+            assert.equals(default_config.autostart, false)
+            assert.same(default_config.cmd, { "nvim" })
+            assert.same(default_config.flags, { debounce_text_changes = c.get().debounce })
+            assert.same(default_config.filetypes, {})
+            assert.truthy(type(default_config.root_dir) == "function")
+        end)
+
+        it("should set up autocommand", function()
+            assert.truthy(vim.fn.exists("#NullLs#FileType") > 0)
+        end)
+
+        describe("root_dir", function()
+            it("should return root dir", function()
+                local cwd = vim.fn.getcwd()
+
+                local root_dir = require("lspconfig/configs")["null-ls"].document_config.default_config.root_dir
+
+                assert.equals(root_dir(cwd), cwd)
+            end)
+        end)
+    end)
+
+    describe("on_register_source", function()
+        local mock_source
+        local get_client, try_add
+        before_each(function()
+            mock_source = {
+                filetypes = { ["lua"] = true },
+                methods = { [methods.internal.DIAGNOSTICS] = true },
+                generator = {},
+            }
+
+            get_client = stub(u, "get_client")
+            try_add = stub(lspconfig, "try_add")
+        end)
+        after_each(function()
+            vim.bo.filetype = ""
+            get_client:revert()
+            try_add:revert()
+        end)
+
+        it("should do nothing if client does not exist", function()
+            lspconfig.on_register_source(mock_source)
+
+            assert.stub(try_add).was_not_called()
+        end)
+
+        it("should call try_add with bufnr", function()
+            get_client.returns({})
+
+            lspconfig.on_register_source(mock_source)
+
+            assert.stub(try_add).was_called_with(vim.api.nvim_get_current_buf())
+        end)
+
+        it("should call client.notify if source is available", function()
+            local mock_client = { notify = stub.new() }
+            get_client.returns(mock_client)
+            vim.bo.filetype = "lua"
+
+            lspconfig.on_register_source(mock_source)
+
+            assert.stub(mock_client.notify).was_called_with(methods.lsp.DID_CHANGE, {
+                textDocument = {
+                    uri = vim.uri_from_bufnr(vim.api.nvim_get_current_buf()),
+                },
+            })
+        end)
+    end)
+
+    describe("on_register_sources", function()
+        after_each(function()
+            require("lspconfig")["null-ls"].filetypes = {}
+        end)
+
+        it("should update config.filetypes", function()
+            c.register(require("null-ls.builtins")._test.mock_code_action)
+
+            lspconfig.on_register_sources()
+
+            local filetypes = require("lspconfig")["null-ls"].filetypes
+            assert.equals(#filetypes, 1)
+            assert.truthy(vim.tbl_contains(filetypes, "lua"))
+        end)
+    end)
+
+    describe("try_add", function()
+        local mock_source = {
+            filetypes = { ["lua"] = true },
+            methods = { [methods.internal.DIAGNOSTICS] = true },
+            generator = {},
+        }
+
+        local original_manager = require("lspconfig")["null-ls"].manager
+        local mock_manager = {
+            try_add = stub.new(),
+        }
+
+        before_each(function()
+            require("lspconfig")["null-ls"].manager = mock_manager
+        end)
+        after_each(function()
+            require("lspconfig")["null-ls"].manager = original_manager
+            mock_manager.try_add:clear()
+
+            vim.bo.filetype = ""
+            vim.bo.buftype = ""
+        end)
+
+        it("should attach if source is available and filetype matches", function()
+            c._set({ _sources = { mock_source } })
+            vim.bo.filetype = "lua"
+
+            lspconfig.try_add()
+
+            assert.stub(mock_manager.try_add).was_called_with(vim.api.nvim_get_current_buf())
+        end)
+    end)
+end)

--- a/test/spec/rpc_spec.lua
+++ b/test/spec/rpc_spec.lua
@@ -1,0 +1,220 @@
+local stub = require("luassert.stub")
+
+local methods = require("null-ls.methods")
+local handlers = require("null-ls.handlers")
+local u = require("null-ls.utils")
+
+describe("rpc", function()
+    local rpc = require("null-ls.rpc")
+
+    describe("setup", function()
+        local original_rpc_start = require("vim.lsp.rpc").start
+        local rpc_start, start
+        before_each(function()
+            rpc_start = stub(require("vim.lsp.rpc"), "start")
+            start = stub(rpc, "start")
+        end)
+        after_each(function()
+            require("vim.lsp.rpc").start = original_rpc_start
+            start:revert()
+        end)
+
+        it("should override original rpc.start method", function()
+            rpc.setup()
+
+            assert.is_not.equals(require("vim.lsp.rpc").start, rpc_start)
+        end)
+
+        it("should call original rpc_start method if config does not exist", function()
+            rpc.setup()
+
+            require("vim.lsp.rpc").start("command", "args", "dispatchers", "other_args")
+
+            assert.stub(rpc_start).was_called_with("command", "args", "dispatchers", "other_args")
+        end)
+
+        it("should call rpc.start override if config exists and command matches", function()
+            require("lspconfig")["null-ls"] = { cmd = { "nvim" } }
+            rpc.setup()
+
+            require("vim.lsp.rpc").start("nvim", "args", "dispatchers", "other_args")
+
+            assert.stub(rpc.start).was_called_with("dispatchers")
+        end)
+    end)
+
+    describe("start", function()
+        local wait_for_scheduler = function()
+            vim.wait(0)
+        end
+
+        stub(require("null-ls.diagnostics"), "handler")
+        stub(require("null-ls.code-actions"), "handler")
+        stub(require("null-ls.formatting"), "handler")
+        stub(require("null-ls.hover"), "handler")
+        stub(require("null-ls.completion"), "handler")
+        stub(handlers, "setup_client")
+        stub(u, "get_client")
+
+        local rpc_object
+        local dispatchers = { on_exit = stub.new() }
+
+        before_each(function()
+            rpc_object = rpc.start(dispatchers)
+        end)
+        after_each(function()
+            dispatchers.on_exit:clear()
+            require("null-ls.diagnostics").handler:clear()
+            require("null-ls.code-actions").handler:clear()
+            require("null-ls.formatting").handler:clear()
+            require("null-ls.hover").handler:clear()
+            require("null-ls.completion").handler:clear()
+            handlers.setup_client:clear()
+            u.get_client:clear()
+            u.get_client.returns(nil)
+        end)
+
+        it("should return object with methods", function()
+            assert.truthy(type(rpc_object.request), "function")
+            assert.truthy(type(rpc_object.notify), "function")
+            assert.truthy(type(rpc_object.handle.is_closing), "function")
+            assert.truthy(type(rpc_object.handle.kill), "function")
+            assert.truthy(type(rpc_object.pid), "number")
+        end)
+
+        describe("stopped", function()
+            it("should be false if not killed", function()
+                assert.falsy(rpc_object.handle.is_closing())
+            end)
+
+            it("should be true if killed", function()
+                rpc_object.handle.kill()
+
+                assert.truthy(rpc_object.handle.is_closing())
+            end)
+        end)
+
+        describe("handle", function()
+            local callback, request
+            before_each(function()
+                callback = stub.new()
+                request = rpc_object.request
+            end)
+
+            it("should return success response and message id", function()
+                local success, message_id = request(methods.lsp.FORMATTING, {}, callback)
+
+                assert.truthy(success)
+                -- depends on test order
+                assert.equals(message_id, 2)
+
+                _, message_id = request(methods.lsp.FORMATTING, {}, callback)
+                assert.equals(message_id, 3)
+            end)
+
+            it("should convert non-table params to table", function()
+                request(methods.lsp.FORMATTING, "params", callback)
+
+                assert.same(
+                    require("null-ls.code-actions").handler.calls[1].refs[2],
+                    { method = methods.lsp.FORMATTING, "params" }
+                )
+            end)
+
+            it("should set params.client_id and set up client if found", function()
+                local mock_client = { id = 99 }
+                u.get_client.returns(mock_client)
+
+                request(methods.lsp.FORMATTING, {}, callback)
+
+                assert.same(
+                    require("null-ls.code-actions").handler.calls[1].refs[2],
+                    { method = methods.lsp.FORMATTING, client_id = mock_client.id }
+                )
+                assert.stub(handlers.setup_client).was_called_with(mock_client)
+            end)
+
+            it("should call callback with empty response if request is not handled", function()
+                request(methods.lsp.FORMATTING, {}, callback)
+
+                wait_for_scheduler()
+
+                assert.stub(callback).was_called_with(nil, nil)
+            end)
+
+            it("should call request handlers", function()
+                local method = methods.lsp.FORMATTING
+                local assert_was_called = function(handler)
+                    -- callback gets wrapped, so we can't assert against it
+                    assert.equals(handler.calls[1].refs[1], method)
+                    assert.same(handler.calls[1].refs[2], { method = method })
+                end
+
+                request(method, {}, callback)
+
+                assert_was_called(require("null-ls.code-actions").handler)
+                assert_was_called(require("null-ls.formatting").handler)
+                assert_was_called(require("null-ls.hover").handler)
+                assert_was_called(require("null-ls.completion").handler)
+            end)
+
+            it("should not call callback if request was handled", function()
+                request(methods.lsp.FORMATTING, { _null_ls_handled = true }, callback)
+
+                wait_for_scheduler()
+
+                assert.stub(callback).was_not_called()
+            end)
+        end)
+
+        describe("request", function()
+            local callback, request
+            before_each(function()
+                callback = stub.new()
+                request = rpc_object.request
+            end)
+
+            it("should send capabilities on initialize request", function()
+                request(methods.lsp.INITIALIZE, {}, callback)
+
+                wait_for_scheduler()
+
+                assert.stub(callback).was_called_with(nil, { capabilities = rpc.capabilities })
+            end)
+
+            it("should set stopped and send empty response on shutdown request", function()
+                request(methods.lsp.SHUTDOWN, {}, callback)
+
+                wait_for_scheduler()
+
+                assert.stub(callback).was_called_with(nil, nil)
+                -- works sometimes but is flaky due to the scheduler
+                -- assert.truthy(rpc_object.handle.is_closing())
+            end)
+
+            it("should call dispatchers.on_exit on exit request", function()
+                request(methods.lsp.EXIT, {}, callback)
+
+                wait_for_scheduler()
+
+                assert.stub(callback).was_not_called()
+                assert.stub(dispatchers.on_exit).was_called_with(0, 0)
+            end)
+        end)
+
+        describe("notify", function()
+            local notify
+            before_each(function()
+                notify = rpc_object.notify
+            end)
+
+            it("should call diagnostics handler with params", function()
+                notify(methods.lsp.DID_CHANGE, {})
+
+                assert.stub(require("null-ls.diagnostics").handler).was_called_with({
+                    method = methods.lsp.DID_CHANGE,
+                })
+            end)
+        end)
+    end)
+end)

--- a/test/spec/sources_spec.lua
+++ b/test/spec/sources_spec.lua
@@ -59,6 +59,15 @@ describe("sources", function()
             assert.truthy(is_available)
         end)
 
+        it("should return false if filetype is disabled", function()
+            mock_source.filetypes["_all"] = true
+            mock_source.filetypes["tl"] = false
+
+            local is_available = sources.is_available(mock_source, "tl")
+
+            assert.falsy(is_available)
+        end)
+
         it("should return true if method matches and no filetype is specified", function()
             local is_available = sources.is_available(mock_source, nil, methods.internal.FORMATTING)
 
@@ -271,6 +280,14 @@ describe("sources", function()
             assert.equals(validated.generator.opts, mock_source.generator.opts)
             assert.same(validated.filetypes, { ["lua"] = true })
             assert.same(validated.methods, { [methods.internal.FORMATTING] = true })
+        end)
+
+        it("should set disabled filetypes", function()
+            mock_source.disabled_filetypes = { "teal" }
+
+            local validated = sources.validate_and_transform(mock_source)
+
+            assert.same(validated.filetypes, { ["lua"] = true, ["teal"] = false })
         end)
 
         it("should handle table of methods", function()

--- a/test/spec/sources_spec.lua
+++ b/test/spec/sources_spec.lua
@@ -1,0 +1,187 @@
+local methods = require("null-ls.methods")
+local sources = require("null-ls.sources")
+
+describe("sources", function()
+    describe("is_available", function()
+        local mock_source
+        before_each(function()
+            mock_source = {
+                generator = {},
+                filetypes = { ["lua"] = true },
+                methods = { [methods.internal.FORMATTING] = true },
+            }
+        end)
+
+        it("should return false if source generator failed", function()
+            mock_source.generator._failed = true
+
+            local is_available = sources.is_available(mock_source)
+
+            assert.falsy(is_available)
+        end)
+
+        it("should return false if filetype does not match", function()
+            local is_available = sources.is_available(mock_source, "tl")
+
+            assert.falsy(is_available)
+        end)
+
+        it("should return false if method does not match", function()
+            local is_available = sources.is_available(mock_source, nil, methods.internal.DIAGNOSTICS)
+
+            assert.falsy(is_available)
+        end)
+
+        it("should return true if filetype matches and no method is specified", function()
+            local is_available = sources.is_available(mock_source, "lua")
+
+            assert.truthy(is_available)
+        end)
+
+        it("should return true if filetype includes _all key", function()
+            mock_source.filetypes["_all"] = true
+
+            local is_available = sources.is_available(mock_source, "tl")
+
+            assert.truthy(is_available)
+        end)
+
+        it("should return true if method matches and no filetype is specified", function()
+            local is_available = sources.is_available(mock_source, nil, methods.internal.FORMATTING)
+
+            assert.truthy(is_available)
+        end)
+
+        it("should return true if filetype and method match", function()
+            local is_available = sources.is_available(mock_source, "lua", methods.internal.FORMATTING)
+
+            assert.truthy(is_available)
+        end)
+    end)
+
+    describe("validate_and_transform", function()
+        local mock_source
+        before_each(function()
+            mock_source = {
+                generator = { fn = function() end, opts = {}, async = false },
+                name = "mock generator",
+                filetypes = { "lua" },
+                method = methods.internal.FORMATTING,
+            }
+        end)
+
+        it("should validate and return transformed source", function()
+            local validated = sources.validate_and_transform(mock_source)
+
+            assert.truthy(validated)
+            assert.equals(validated.name, mock_source.name)
+            assert.equals(validated.generator.async, mock_source.generator.async)
+            assert.equals(validated.generator.fn, mock_source.generator.fn)
+            assert.equals(validated.generator.opts, mock_source.generator.opts)
+            assert.same(validated.filetypes, { ["lua"] = true })
+            assert.same(validated.methods, { [methods.internal.FORMATTING] = true })
+        end)
+
+        it("should handle table of methods", function()
+            mock_source.method = { methods.internal.FORMATTING, methods.internal.RANGE_FORMATTING }
+
+            local validated = sources.validate_and_transform(mock_source)
+
+            assert.truthy(validated)
+            assert.same(
+                validated.methods,
+                { [methods.internal.FORMATTING] = true, [methods.internal.RANGE_FORMATTING] = true }
+            )
+        end)
+
+        it("should set default name", function()
+            mock_source.name = nil
+
+            local validated = sources.validate_and_transform(mock_source)
+
+            assert.truthy(validated)
+            assert.equals(validated.name, "anonymous source")
+        end)
+
+        it("should set default generator opts", function()
+            mock_source.generator.opts = nil
+
+            local validated = sources.validate_and_transform(mock_source)
+
+            assert.truthy(validated)
+            assert.same(validated.generator.opts, {})
+        end)
+
+        it("should handle function source", function()
+            local validated = sources.validate_and_transform(function()
+                return mock_source
+            end)
+
+            assert.truthy(validated)
+        end)
+
+        it("should return nil when function source returns nil", function()
+            local validated = sources.validate_and_transform(function()
+                return nil
+            end)
+
+            assert.falsy(validated)
+        end)
+
+        it("should throw if generator is invalid", function()
+            mock_source.generator = nil
+
+            assert.has_error(function()
+                sources.validate_and_transform(mock_source)
+            end)
+        end)
+
+        it("should throw if filetypes is invalid", function()
+            mock_source.filetypes = nil
+
+            assert.has_error(function()
+                sources.validate_and_transform(mock_source)
+            end)
+        end)
+
+        it("should throw if no method", function()
+            mock_source.method = nil
+
+            assert.has_error(function()
+                sources.validate_and_transform(mock_source)
+            end)
+        end)
+
+        it("should throw if method is empty", function()
+            mock_source.method = {}
+
+            assert.has_error(function()
+                sources.validate_and_transform(mock_source)
+            end)
+        end)
+
+        it("should throw if method does not exist", function()
+            mock_source.method = "notAMethod"
+
+            assert.has_error(function()
+                sources.validate_and_transform(mock_source)
+            end)
+        end)
+
+        it("should throw if generator.fn is invalid", function()
+            mock_source.generator.fn = nil
+
+            assert.has_error(function()
+                sources.validate_and_transform(mock_source)
+            end)
+        end)
+
+        it("should throw if generator.async is invalid", function()
+            mock_source.generator.async = "true"
+
+            assert.has_error(function()
+                sources.validate_and_transform(mock_source)
+            end)
+        end)
+    end)
+end)

--- a/test/spec/sources_spec.lua
+++ b/test/spec/sources_spec.lua
@@ -1,3 +1,4 @@
+local c = require("null-ls.config")
 local methods = require("null-ls.methods")
 local sources = require("null-ls.sources")
 
@@ -10,6 +11,10 @@ describe("sources", function()
                 filetypes = { ["lua"] = true },
                 methods = { [methods.internal.FORMATTING] = true },
             }
+        end)
+
+        after_each(function()
+            c.reset()
         end)
 
         it("should return false if source generator failed", function()
@@ -56,6 +61,73 @@ describe("sources", function()
             local is_available = sources.is_available(mock_source, "lua", methods.internal.FORMATTING)
 
             assert.truthy(is_available)
+        end)
+    end)
+
+    describe("get_available", function()
+        local mock_sources = {
+            {
+                filetypes = { ["lua"] = true },
+                generator = {},
+                methods = { [methods.internal.FORMATTING] = true },
+            },
+            {
+                filetypes = { ["teal"] = true },
+                generator = {},
+                methods = { [methods.internal.DIAGNOSTICS] = true },
+            },
+        }
+        before_each(function()
+            c._set({ _sources = mock_sources })
+        end)
+
+        it("should get available sources by filetype", function()
+            local available = sources.get_available("lua")
+
+            assert.equals(#available, 1)
+        end)
+
+        it("should get available sources by method", function()
+            local available = sources.get_available(nil, methods.internal.DIAGNOSTICS)
+
+            assert.equals(#available, 1)
+        end)
+    end)
+
+    describe("get_all", function()
+        local mock_sources = {
+            { filetypes = { ["lua"] = true } },
+            { filetypes = { ["teal"] = true } },
+        }
+        before_each(function()
+            c._set({ _sources = mock_sources })
+        end)
+
+        it("should get all registered sources", function()
+            local all_sources = sources.get_all()
+
+            assert.equals(#all_sources, #mock_sources)
+        end)
+    end)
+
+    describe("get_filetypes", function()
+        local mock_sources = {
+            { filetypes = { ["lua"] = true } },
+            { filetypes = { ["lua"] = true } },
+            { filetypes = { ["teal"] = true } },
+            { filetypes = { ["_all"] = true } },
+        }
+        before_each(function()
+            c._set({ _sources = mock_sources })
+        end)
+
+        it("should get list of registered source filetypes", function()
+            local filetypes = sources.get_filetypes()
+
+            assert.equals(#filetypes, 2)
+            assert.truthy(vim.tbl_contains(filetypes, "lua"))
+            assert.truthy(vim.tbl_contains(filetypes, "teal"))
+            assert.falsy(vim.tbl_contains(filetypes, "_all"))
         end)
     end)
 

--- a/test/spec/utils_spec.lua
+++ b/test/spec/utils_spec.lua
@@ -142,6 +142,36 @@ describe("utils", function()
         end)
     end)
 
+    describe("has_version", function()
+        local has
+        before_each(function()
+            has = stub(vim.fn, "has")
+        end)
+        after_each(function()
+            has:revert()
+        end)
+
+        it("should call has with full nvim version name", function()
+            has.returns(0)
+
+            u.has_version("0.6.0")
+
+            assert.stub(has).was_called_with("nvim-0.6.0")
+        end)
+
+        it("should return false if has resullt is 0", function()
+            has.returns(0)
+
+            assert.falsy(u.has_version("0.6.0"))
+        end)
+
+        it("should return true if has result is greater than 0", function()
+            has.returns(1)
+
+            assert.truthy(u.has_version("0.6.0"))
+        end)
+    end)
+
     describe("range", function()
         describe("to_lsp", function()
             it("should convert lua-friendly range to lsp range", function()

--- a/test/spec/utils_spec.lua
+++ b/test/spec/utils_spec.lua
@@ -24,35 +24,6 @@ describe("utils", function()
         end)
     end)
 
-    describe("filetype_matches", function()
-        it("should return true when filetypes is empty", function()
-            local filetypes = {}
-            local ft = "lua"
-
-            local matches = u.filetype_matches(filetypes, ft)
-
-            assert.equals(matches, true)
-        end)
-
-        it("should return true when filetypes includes ft", function()
-            local filetypes = { "lua" }
-            local ft = "lua"
-
-            local matches = u.filetype_matches(filetypes, ft)
-
-            assert.equals(matches, true)
-        end)
-
-        it("should return false when filetypes is not empty and does not include ft", function()
-            local filetypes = { "javascript" }
-            local ft = "lua"
-
-            local matches = u.filetype_matches(filetypes, ft)
-
-            assert.equals(matches, false)
-        end)
-    end)
-
     describe("range", function()
         describe("to_lsp", function()
             it("should convert lua-friendly range to lsp range", function()


### PR DESCRIPTION
The goal of this PR is to simplify how sources are registered to clean up a messy portion of the code base and enable new features, namely:

- Disabling filetypes per source (i.e. enable all filetypes besides a subset)
- More transparent querying of registered sources (no need to go through the info API, which isn't really ideal for consumption)
- Disabling sources
- Registering an arbitrary number of sources with the same name (which lets through duplicates, but that hasn't been an issue AFAIK)
- ~~Running sources on demand (not really related, but something I want to include)~~ out of scope and not really consistent with the goal of LSP-like behavior

Currently, generators are stored independently and anonymously, making it impossible to disable them or otherwise manipulate them once registered. Coupling sources and their generators is both logical and solves the issue, so we now store the sources themselves in the config object. We also avoid registering filetypes and methods independently and simply check the sources themselves for availability (with a simple transformation applied on registration to make this check easier).

I also have to think about how to handle disabling sources. ~~Users will most likely want to disable them by name~~ Edit: I think the best solution is a simple query mechanism that either specifies a string (assumed to be a name) or an object specifying name, method, and / or ID that then disables all matching sources. 

Finally, I want to add test coverage to the `info`, `rpc`, and `lspconfig` modules . Working on this project has taken up a good chunk of my life lately, so I want to finish this, clean up a few outstanding feature requests, and take a break. 

TODO:

- [x] Add missing coverage
- [x] Add `disable` method
- [x] Document source API