### PR TITLE
docs(builtins): update `shfmt` config

### DIFF
--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -1075,7 +1075,7 @@ local sources = { null_ls.builtins.formatting.shfmt }
 
 - `filetypes = { "sh" }`
 - `command = "shfmt"`
-- `args = {}`
+- `args = { "-filename", "$FILENAME" }`
 
 #### [sqlformat](https://manpages.ubuntu.com/manpages/xenial/man1/sqlformat.1.html)
 

--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -1073,7 +1073,7 @@ local sources = { null_ls.builtins.formatting.shfmt }
 
 ##### Defaults
 
-- `filetypes = { "sh", "zsh" }`
+- `filetypes = { "sh" }`
 - `command = "shfmt"`
 - `args = {}`
 


### PR DESCRIPTION
1. Removed `zsh` filetype. AFAIK this was recently removed from the formatter.
2. `shfmt` args were not empty inside the code. So I updated the docs accordingly.