### PR TITLE
fix(logger): configurable logging behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,22 @@ memory without any external processes, in most cases it should run faster than
 similar solutions. If you notice that performance is worse with null-ls than
 with an alternative, please open an issue!
 
+### Debugging
+
+1. Enable debug logging
+
+   ```lua
+   require("null-ls").config({
+      debug = true,
+   })
+
+   ```
+
+2. Use `:NullLsLog` to open the log file.
+
+As with LSP logging, `debug` will slow down Neovim. Make sure to disable the
+option after you've collected the information you're looking for.
+
 ## Tests
 
 The test suite includes unit and integration tests and depends on plenary.nvim.

--- a/doc/CONFIG.md
+++ b/doc/CONFIG.md
@@ -47,14 +47,30 @@ The following code block shows the available options and their defaults.
 
 ```lua
 local defaults = {
+    sources = nil,
     diagnostics_format = "#{m}",
     debounce = 250,
     default_timeout = 5000,
-    sources = nil,
+    debug = false,
+    log = {
+        enable = true,
+        level = "warn",
+        use_console = "async",
+    },
 }
 ```
 
-## diagnostics_format (string)
+### sources (list)
+
+Defines a list of sources for null-ls to register. Users can add built-in
+sources (see [BUILTINS.md](BUILTINS.md)) or custom sources (see
+[MAIN.md](MAIN.md)).
+
+If you've installed an integration that provides its own sources and aren't
+interested in built-in sources, you don't have to define any sources here. The
+integration will register them independently.
+
+### diagnostics_format (string)
 
 Sets the default format used for diagnostics. The plugin will replace the
 following special components with the relevant diagnostic information:
@@ -78,7 +94,7 @@ Formats diagnostics as follows:
 You can also set `diagnostics_format` for built-ins by using the `with` method,
 described in [BUILTINS](BUILTINS.md).
 
-## debounce (number)
+### debounce (number)
 
 The `debounce` setting controls the amount of time between the last change to a
 buffer and the next diagnostic refresh. **It does not affect code actions or
@@ -96,15 +112,35 @@ out. Note that built-in sources can define their own timeout period and that
 users can override the timeout period on a per-source basis, too (see
 [BUILTINS.md](BUILTINS.md)).
 
-### sources (list)
+### debug (boolean)
 
-Defines a list of sources for null-ls to register. Users can add built-in
-sources (see [BUILTINS.md](BUILTINS.md)) or custom sources (see
-[MAIN.md](MAIN.md)).
+Displays all possible log messages and writes them to the null-ls log, which you
+can view with the command `:NullLsLog`. Also enables extra source validation.
+This option can slow down Neovim, so it's strongly recommended to disable it for
+normal use.
 
-If you've installed an integration that provides its own sources and aren't
-interested in built-in sources, you don't have to define any sources here. The
-integration will register them independently.
+`debug = true` is the same as setting `log.level` to `"trace"` and
+`log.use_console` to `false`. For finer-grained control, see the `log` options
+below.
+
+### log (table)
+
+Sets options for null-ls logging.
+
+#### log.enable (boolean)
+
+Enables or disables logging altogether. Setting this to `false` will suppress
+important operational warnings and is not recommended.
+
+#### log.level (one of "error", "warn", "info", "debug", "trace")
+
+Sets the logging level.
+
+#### log.use_console (one of "sync", "async", false)
+
+Determines whether to show log output in Neovim's `:messages`. `sync` is slower
+but guarantees that messages will appear in order. Setting this to `false` will
+skip the console but still log to the file specified by `:NullLsLog`.
 
 ## Disabling null-ls
 

--- a/lua/null-ls/code-actions.lua
+++ b/lua/null-ls/code-actions.lua
@@ -1,6 +1,7 @@
 local s = require("null-ls.state")
 local u = require("null-ls.utils")
 local methods = require("null-ls.methods")
+local log = require("null-ls.logger")
 
 local M = {}
 
@@ -28,8 +29,8 @@ M.handler = function(method, original_params, handler)
             params = params,
             postprocess = postprocess,
             callback = function(actions)
-                u.debug_log("received code actions from generators")
-                u.debug_log(actions)
+                log:trace("received code actions from generators")
+                log:trace(actions)
 
                 -- sort actions by title
                 table.sort(actions, function(a, b)

--- a/lua/null-ls/completion.lua
+++ b/lua/null-ls/completion.lua
@@ -1,6 +1,7 @@
 local u = require("null-ls.utils")
 local methods = require("null-ls.methods")
 local config = require("null-ls.config").get()
+local log = require("null-ls.logger")
 
 local M = {}
 
@@ -12,11 +13,12 @@ M.handler = function(method, original_params, handler)
             method = methods.map[method],
             params = params,
             callback = function(results)
-                u.debug_log("received completion results from generators")
-                u.debug_log(results)
                 if #results == 0 then
+                    log:debug("received no completion results from generators")
                     handler({})
                 else
+                    log:debug("received completion results from generators")
+                    log:trace(vim.inspect(results))
                     local items = {}
                     local isIncomplete = false
                     for _, result in ipairs(results) do

--- a/lua/null-ls/config.lua
+++ b/lua/null-ls/config.lua
@@ -4,7 +4,18 @@ local defaults = {
     diagnostics_format = "#{m}",
     debounce = 250,
     default_timeout = 5000,
+    ---@usage setting this to true will enable debug logging
     debug = false,
+    log = {
+        ---@usage disable logging completely
+        enable = true,
+        ---@usage set logging level
+        --- possible valuse: {"error", "warn", "info", "debug", "trace"}
+        level = "warn",
+        ---@usage whether to print the output to neovim's
+        --- possible values: 'sync','async', false
+        use_console = "async",
+    },
     -- prevent double setup
     _setup = false,
     -- force using LSP handler, even when native API is available (e.g diagnostics)
@@ -77,6 +88,9 @@ M.setup = function(user_config)
 
     local validated = validate_config(user_config)
     config = vim.tbl_extend("force", config, validated)
+
+    -- FIXME: validating log options should maintain any default options
+    config.log = vim.tbl_extend("keep", config.log, defaults.log)
 
     if config.sources then
         require("null-ls.sources").register(config.sources)

--- a/lua/null-ls/diagnostics.lua
+++ b/lua/null-ls/diagnostics.lua
@@ -2,6 +2,7 @@ local u = require("null-ls.utils")
 local s = require("null-ls.state")
 local c = require("null-ls.config")
 local methods = require("null-ls.methods")
+local log = require("null-ls.logger")
 
 local api = vim.api
 
@@ -96,7 +97,7 @@ M.handler = function(original_params)
     local changedtick = original_params.textDocument.version or api.nvim_buf_get_changedtick(bufnr)
 
     if method == methods.lsp.DID_SAVE and changedtick == last_changedtick[uri] then
-        u.debug_log("buffer unchanged; ignoring didSave notification")
+        log:debug("buffer unchanged; ignoring didSave notification")
         return
     end
 
@@ -111,14 +112,14 @@ M.handler = function(original_params)
         postprocess = postprocess,
         index_by_id = should_use_diagnostic_api(),
         callback = function(diagnostics)
-            u.debug_log("received diagnostics from generators")
-            u.debug_log(diagnostics)
+            log:trace("received diagnostics from generators")
+            log:trace(diagnostics)
 
             if
                 last_changedtick[uri] -- nil if received didExit notification
                 and last_changedtick[uri] > changedtick -- buffer changed between notification and callback
             then
-                u.debug_log("buffer changed; ignoring received diagnostics")
+                log:debug("buffer changed; ignoring received diagnostics")
                 return
             end
 

--- a/lua/null-ls/formatting.lua
+++ b/lua/null-ls/formatting.lua
@@ -1,5 +1,6 @@
 local u = require("null-ls.utils")
 local methods = require("null-ls.methods")
+local log = require("null-ls.logger")
 
 local api = vim.api
 
@@ -51,8 +52,8 @@ M.apply_edits = function(edits, params)
     -- formatting and rangeFormatting handlers are identical
     local handler = u.resolve_handler(params.lsp_method)
 
-    u.debug_log("received edits from generators:")
-    u.debug_log(edits)
+    log:debug("received edits from generators")
+    log:trace(edits)
 
     local diffed_edits = {}
     for _, edit in ipairs(edits) do
@@ -72,8 +73,8 @@ M.apply_edits = function(edits, params)
         restore_win_data(marks, views, bufnr)
     end)
 
-    u.debug_log("successfully applied edits:")
-    u.debug_log(diffed_edits)
+    log:debug("successfully applied edits")
+    log:trace(diffed_edits)
 end
 
 M.handler = function(method, original_params, handler)

--- a/lua/null-ls/generators.lua
+++ b/lua/null-ls/generators.lua
@@ -1,4 +1,5 @@
 local u = require("null-ls.utils")
+local log = require("null-ls.logger")
 
 local M = {}
 
@@ -6,10 +7,10 @@ M.run = function(generators, params, postprocess, callback, should_index)
     local a = require("plenary.async")
 
     local runner = function()
-        u.debug_log("running generators for method " .. params.method)
+        log:trace("running generators for method " .. params.method)
 
         if vim.tbl_isempty(generators) then
-            u.debug_log("no generators available")
+            log:debug("no generators available")
             return {}
         end
 
@@ -42,8 +43,7 @@ M.run = function(generators, params, postprocess, callback, should_index)
                 end
 
                 if not ok then
-                    u.echo("WarningMsg", "failed to run generator: " .. results)
-                    -- prevent failed generators from running again
+                    log:warn("failed to run generator: " .. results)
                     generator._failed = true
                     return
                 end

--- a/lua/null-ls/helpers.lua
+++ b/lua/null-ls/helpers.lua
@@ -160,16 +160,15 @@ M.generator_factory = function(opts)
             opts.command = command
         end
 
-        local err_msg = ""
+        local err_msg
         if vim.fn.executable(command) ~= 1 then
             err_msg = string.format(
                 "command %s is not executable (make sure it's installed and on your $PATH)",
                 command
             )
-            log:debug(err_msg)
         end
 
-        assert(err_msg, "")
+        assert(not err_msg, err_msg)
         assert(not from_temp_file or to_temp_file, "from_temp_file requires to_temp_file to be true")
 
         _validated = true

--- a/lua/null-ls/helpers.lua
+++ b/lua/null-ls/helpers.lua
@@ -1,6 +1,7 @@
 local u = require("null-ls.utils")
 local c = require("null-ls.config")
 local s = require("null-ls.state")
+local log = require("null-ls.logger")
 
 local api = vim.api
 local validate = vim.validate
@@ -159,10 +160,16 @@ M.generator_factory = function(opts)
             opts.command = command
         end
 
-        assert(
-            vim.fn.executable(command) > 0,
-            string.format("command %s is not executable (make sure it's installed and on your $PATH)", command)
-        )
+        local err_msg = ""
+        if vim.fn.executable(command) ~= 1 then
+            err_msg = string.format(
+                "command %s is not executable (make sure it's installed and on your $PATH)",
+                command
+            )
+            log:debug(err_msg)
+        end
+
+        assert(err_msg, "")
         assert(not from_temp_file or to_temp_file, "from_temp_file requires to_temp_file to be true")
 
         _validated = true
@@ -177,8 +184,8 @@ M.generator_factory = function(opts)
             end
 
             local wrapper = function(error_output, output)
-                u.debug_log("error output: " .. (error_output or "nil"))
-                u.debug_log("output: " .. (output or "nil"))
+                log:trace("error output: " .. (error_output or "nil"))
+                log:trace("output: " .. (output or "nil"))
 
                 if ignore_stderr then
                     error_output = nil
@@ -259,7 +266,7 @@ M.generator_factory = function(opts)
                             vim.loop.fs_close(fd)
                         end)
                         if not ok then
-                            u.echo("WarningMsg", "failed to read from temp file: " .. err)
+                            log:warn("failed to read from temp file: " .. err)
                         end
                     end
 
@@ -272,8 +279,7 @@ M.generator_factory = function(opts)
             spawn_args = type(spawn_args) == "function" and spawn_args(params) or spawn_args
             spawn_args = parse_args(spawn_args, params)
 
-            u.debug_log("spawning command " .. command .. " with args:")
-            u.debug_log(spawn_args)
+            log:debug(string.format("spawning command [%s] with args { %s }", command, vim.inspect(spawn_args)))
             loop.spawn(command, spawn_args, spawn_opts)
         end,
         filetypes = opts.filetypes,
@@ -375,11 +381,11 @@ M.make_builtin = function(opts)
             return function()
                 local should_register = condition(u.make_conditional_utils())
                 if should_register then
-                    u.debug_log("registering conditional source " .. builtin_copy.name)
-                    return builtin_copy
+                    log:debug("registering conditional source " .. builtin.name)
+                    return builtin
                 end
 
-                u.debug_log("not registering conditional source " .. builtin_copy.name)
+                log:debug("not registering conditional source " .. builtin.name)
             end
         end
 

--- a/lua/null-ls/helpers.lua
+++ b/lua/null-ls/helpers.lua
@@ -278,7 +278,7 @@ M.generator_factory = function(opts)
             spawn_args = type(spawn_args) == "function" and spawn_args(params) or spawn_args
             spawn_args = parse_args(spawn_args, params)
 
-            log:debug(string.format("spawning command [%s] with args { %s }", command, vim.inspect(spawn_args)))
+            log:debug(string.format("spawning command [%s] with args %s", command, vim.inspect(spawn_args)))
             loop.spawn(command, spawn_args, spawn_opts)
         end,
         filetypes = opts.filetypes,

--- a/lua/null-ls/hover.lua
+++ b/lua/null-ls/hover.lua
@@ -1,5 +1,6 @@
 local u = require("null-ls.utils")
 local methods = require("null-ls.methods")
+local log = require("null-ls.logger")
 
 local M = {}
 
@@ -11,8 +12,8 @@ M.handler = function(method, original_params, handler)
             method = methods.map[method],
             params = params,
             callback = function(results)
-                u.debug_log("received hover results from generators")
-                u.debug_log(results)
+                log:trace("received hover results from generators")
+                log:trace(results)
                 handler({ contents = { results } })
             end,
         })

--- a/lua/null-ls/info.lua
+++ b/lua/null-ls/info.lua
@@ -1,6 +1,7 @@
 local methods = require("null-ls.methods")
 local u = require("null-ls.utils")
 local c = require("null-ls.config")
+local log = require("null-ls.logger")
 
 local lsp = vim.lsp
 local api = vim.api
@@ -27,7 +28,7 @@ M.show_window = function()
     local client = u.get_client()
     local bufnr = api.nvim_get_current_buf()
     if not client or not lsp.buf_is_attached(bufnr, client.id) then
-        u.echo("WarningMsg", "failed to get info: buffer is not attached")
+        log:warn("failed to get info: buffer is not attached")
         return
     end
 

--- a/lua/null-ls/info.lua
+++ b/lua/null-ls/info.lua
@@ -34,7 +34,7 @@ M.show_window = function()
 
     local lines = {}
 
-    local log_path = c.get().debug and require("lspconfig.util").path.join(vim.fn.stdpath("cache"), "null-ls.log")
+    local log_path = c.get().debug and log:get_path()
         or "not enabled (this is normal; see the README if you need to enable logging)"
     table.insert(lines, "null-ls log: " .. log_path)
 

--- a/lua/null-ls/init.lua
+++ b/lua/null-ls/init.lua
@@ -29,6 +29,7 @@ M.config = function(user_config)
     require("null-ls.handlers").setup()
 
     vim.cmd("command! NullLsInfo lua require('null-ls').null_ls_info()")
+    vim.cmd("command! NullLsLog lua vim.fn.execute('edit ' .. require('null-ls.logger').get_path())")
 end
 
 return M

--- a/lua/null-ls/logger.lua
+++ b/lua/null-ls/logger.lua
@@ -20,7 +20,7 @@ function log:add_entry(msg, level)
     }
     if c.get().debug then
         default_opts.use_console = false
-        default_opts.log_level = "trace"
+        default_opts.level = "trace"
     end
     if status_ok then
         local handle = plenary.log.new(default_opts)

--- a/lua/null-ls/logger.lua
+++ b/lua/null-ls/logger.lua
@@ -1,1 +1,70 @@
-return require("plenary.log").new({ plugin = "null-ls", use_console = false, level = "debug" })
+local log = {}
+
+--- Adds a log entry using Plenary.log
+---@param msg any
+---@param level string [same as vim.log.log_levels]
+function log:add_entry(msg, level)
+    assert(type(level) == "string")
+    if self.__handle then
+        -- plenary uses lower-case log levels
+        self.__handle[level:lower()](msg)
+        return
+    end
+    local status_ok, plenary = pcall(require, "plenary")
+    local c = require("null-ls.config")
+    local default_opts = {
+        plugin = "null-ls",
+        level = c.get().log.level or "warn",
+        use_console = c.get().log.use_console,
+        info_level = 4,
+    }
+    if c.get().debug then
+        default_opts.use_console = false
+        default_opts.log_level = "trace"
+    end
+    if status_ok then
+        local handle = plenary.log.new(default_opts)
+        handle[level:lower()](msg)
+        self.__handle = handle
+    end
+    -- don't do anything if plenary is not available
+end
+
+---Retrieves the path of the logfile
+---@return string path of the logfile
+function log:get_path()
+    return string.format("%s/%s.log", vim.fn.stdpath("cache"), "null-ls")
+end
+
+---Add a log entry at TRACE level
+---@param msg any
+function log:trace(msg)
+    self:add_entry(msg, "TRACE")
+end
+
+---Add a log entry at DEBUG level
+---@param msg any
+function log:debug(msg)
+    self:add_entry(msg, "DEBUG")
+end
+
+---Add a log entry at INFO level
+---@param msg any
+function log:info(msg)
+    self:add_entry(msg, "INFO")
+end
+
+---Add a log entry at WARN level
+---@param msg any
+function log:warn(msg)
+    self:add_entry(msg, "WARN")
+end
+
+---Add a log entry at ERROR level
+---@param msg any
+function log:error(msg)
+    self:add_entry(msg, "ERROR")
+end
+
+setmetatable({}, log)
+return log

--- a/lua/null-ls/logger.lua
+++ b/lua/null-ls/logger.lua
@@ -1,3 +1,4 @@
+local c = require("null-ls.config")
 local log = {}
 
 --- Adds a log entry using Plenary.log
@@ -10,8 +11,7 @@ function log:add_entry(msg, level)
         self.__handle[level:lower()](msg)
         return
     end
-    local status_ok, plenary = pcall(require, "plenary")
-    local c = require("null-ls.config")
+
     local default_opts = {
         plugin = "null-ls",
         level = c.get().log.level or "warn",
@@ -22,12 +22,10 @@ function log:add_entry(msg, level)
         default_opts.use_console = false
         default_opts.level = "trace"
     end
-    if status_ok then
-        local handle = plenary.log.new(default_opts)
-        handle[level:lower()](msg)
-        self.__handle = handle
-    end
-    -- don't do anything if plenary is not available
+
+    local handle = require("plenary.log").new(default_opts)
+    handle[level:lower()](msg)
+    self.__handle = handle
 end
 
 ---Retrieves the path of the logfile

--- a/lua/null-ls/rpc.lua
+++ b/lua/null-ls/rpc.lua
@@ -1,5 +1,6 @@
 local methods = require("null-ls.methods")
 local u = require("null-ls.utils")
+local log = require("null-ls.logger")
 
 local M = {}
 
@@ -96,7 +97,7 @@ M.start = function(dispatchers)
     end
 
     local function request(method, params, callback, notify_callback)
-        u.debug_log("received LSP request for method " .. method)
+        log:trace("received LSP request for method " .. method)
 
         -- clear pending requests from client object
         local success = handle(method, params, callback)
@@ -112,7 +113,7 @@ M.start = function(dispatchers)
     end
 
     local function notify(method, params)
-        u.debug_log("received LSP notification for method " .. method)
+        log:trace("received LSP notification for method " .. method)
         return handle(method, params, nil, true)
     end
 

--- a/lua/null-ls/utils.lua
+++ b/lua/null-ls/utils.lua
@@ -1,4 +1,3 @@
-local c = require("null-ls.config")
 local methods = require("null-ls.methods")
 
 local api = vim.api
@@ -64,14 +63,6 @@ end
 M.split_at_newline = function(bufnr, text)
     local line_ending = get_line_ending(bufnr)
     return vim.split(text, line_ending), line_ending
-end
-
-M.debug_log = function(...)
-    if not c.get().debug then
-        return
-    end
-
-    require("null-ls.logger").debug(...)
 end
 
 M.get_client = function()

--- a/test/spec/e2e_spec.lua
+++ b/test/spec/e2e_spec.lua
@@ -16,7 +16,7 @@ local lsp_wait = function(wait_time)
     vim.wait(wait_time or 400)
 end
 
-main.config()
+main.config({ log = { enable = false } })
 require("lspconfig")["null-ls"].setup({
     flags = {
         debounce_text_changes = nil,

--- a/test/spec/formatting_spec.lua
+++ b/test/spec/formatting_spec.lua
@@ -9,6 +9,7 @@ local diff = require("null-ls.diff")
 local method = methods.lsp.FORMATTING
 
 local lsp = mock(vim.lsp, true)
+mock(require("null-ls.logger"), true)
 
 describe("formatting", function()
     stub(vim, "cmd")

--- a/test/spec/generators_spec.lua
+++ b/test/spec/generators_spec.lua
@@ -1,12 +1,13 @@
-local match = require("luassert.match")
 local stub = require("luassert.stub")
+local mock = require("luassert.mock")
 local a = require("plenary.async_lib")
 
 local methods = require("null-ls.methods")
 local sources = require("null-ls.sources")
-local u = require("null-ls.utils")
 
 local uv = vim.loop
+
+mock(require("null-ls.logger"), true)
 
 local register = function(method, generator, filetypes)
     sources.register({
@@ -83,11 +84,6 @@ describe("generators", function()
     end)
 
     a.tests.describe("run", function()
-        local echo = stub(u, "echo")
-        after_each(function()
-            echo:clear()
-        end)
-
         local wrapped_run = a.wrap(generators.run, 4)
 
         it("should return empty table when generators is empty", function()
@@ -113,7 +109,6 @@ describe("generators", function()
         it("should handle error thrown in sync generator", function()
             local results = wrapped_run({ error_generator }, mock_params, postprocess)()
 
-            assert.stub(u.echo).was_called_with("WarningMsg", match.has_match("something went wrong"))
             assert.equals(error_generator._failed, true)
             assert.equals(vim.tbl_count(results), 0)
         end)
@@ -123,7 +118,6 @@ describe("generators", function()
 
             local results = wrapped_run({ error_generator }, mock_params, postprocess)()
 
-            assert.stub(u.echo).was_called_with("WarningMsg", match.has_match("something went wrong"))
             assert.equals(error_generator._failed, true)
             assert.equals(vim.tbl_count(results), 0)
         end)
@@ -135,7 +129,6 @@ describe("generators", function()
 
             local results = wrapped_run({ error_generator }, mock_params, postprocess)()
 
-            assert.stub(u.echo).was_called_with("WarningMsg", match.has_match("something went wrong"))
             assert.equals(error_generator._failed, true)
             assert.equals(vim.tbl_count(results), 0)
         end)

--- a/test/spec/utils_spec.lua
+++ b/test/spec/utils_spec.lua
@@ -89,30 +89,6 @@ describe("utils", function()
         end)
     end)
 
-    describe("debug_log", function()
-        local logger
-        before_each(function()
-            logger = stub(require("null-ls.logger"), "debug")
-        end)
-        after_each(function()
-            logger:revert()
-        end)
-
-        it("should do nothing if debug option is not set", function()
-            u.debug_log("my message")
-
-            assert.stub(logger).was_not_called()
-        end)
-
-        it("should call logger with message if debug option is set", function()
-            c._set({ debug = true })
-
-            u.debug_log("my message")
-
-            assert.stub(logger).was_called_with("my message")
-        end)
-    end)
-
     describe("get_client", function()
         local get_active_clients
         before_each(function()


### PR DESCRIPTION
- Set the correct stack level in plenary.log
- Use all the levels of logging with the ability of using the console
- Switch `echo_error` to use `Log:warn()`
- Switch most of `u.debug_log()` to `Log:trace()` while keeping some of them as `Log:debug()`

Fixes #280


- fix(logger): configurable logging behavior
- fix(logger): restore the quick debug toggle
- fix(logger): rebase
- chore: use lower-case for logger instances
- fix(logger): explicit mention of empty completion
- chore: naming convention
