### PR TITLE
feat: migrate to diagnostic API and support linting on save (feat. golangci-lint)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,9 @@ for external processes.
 null-ls is in **beta status**. Please see below for steps to follow if something
 doesn't work the way you expect (or doesn't work at all).
 
-At the moment, null-is is compatible with Neovim 0.5 (stable) and 0.6 (head),
-but you'll get the best experience from the latest version you can run.
+At the moment, null-is is compatible with Neovim 0.5.1 (stable) and 0.6 (head),
+but some features and performance improvements are exclusive to the latest
+version.
 
 Note that null-ls development takes place primarily on macOS and Linux and may
 not work as expected (or at all) on Windows. Contributions to expand Windows
@@ -286,6 +287,8 @@ with an alternative, please open an issue!
 The test suite includes unit and integration tests and depends on plenary.nvim.
 Run `make test` in the root of the project to run the suite or
 `FILE=filename_spec.lua make test-file` to test an individual file.
+
+E2E tests expect the latest Neovim master.
 
 ## Alternatives
 

--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -1888,6 +1888,32 @@ local sources = { null_ls.builtins.diagnostics.yamllint }
 - `command = "yamllint"`
 - `args = { "--format", "parsable", "-" }`
 
+### Diagnostics on save
+
+**NOTE**: These sources depend on Neovim version 0.6.0 and are not compatible
+with previous versions.
+
+These sources run **only** on save, meaning that the diagnostics you see will
+not reflect changes to the buffer until you write the changes to the disk.
+
+#### [golangci-lint](https://golangci-lint.run/)
+
+##### About
+
+A Go linter aggregator.
+
+##### Usage
+
+```lua
+local sources = { null_ls.builtins.diagnostics.golangci_lint }
+```
+
+##### Defaults
+
+- `filetypes = { "go" }`
+- `command = "golangci-lint"`
+- `args = { "run", "--fix=false", "--fast", "--out-format=json", "$DIRNAME", "--path-prefix", "$ROOT" }`
+
 ### Code actions
 
 #### [gitsigns.nvim](https://github.com/lewis6991/gitsigns.nvim)

--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -2008,7 +2008,7 @@ following snippet:
 runtime_condit
 ```
 
-#### Vsnip
+#### [vim-vsnip](https://github.com/hrsh7th/vim-vsnip)
 
 ##### About
 
@@ -2020,4 +2020,6 @@ Snippets managed by [vim-vsnip](https://github.com/hrsh7th/vim-vsnip).
 local sources = { null_ls.builtins.completion.vsnip }
 ```
 
-Registering this source will show available snippets in the completion list, but vim-vsnip is responsible for expanding them. See [vim-vsnip's documentation for setup instructions](https://github.com/hrsh7th/vim-vsnip#2-setting).
+Registering this source will show available snippets in the completion list, but
+vim-vsnip is in charge of expanding them. See [vim-vsnip's documentation for
+setup instructions](https://github.com/hrsh7th/vim-vsnip#2-setting).

--- a/lua/null-ls/builtins/diagnostics/golangci_lint.lua
+++ b/lua/null-ls/builtins/diagnostics/golangci_lint.lua
@@ -25,13 +25,16 @@ return h.make_builtin({
         end,
         on_output = function(params)
             local diags = {}
-            for _, d in ipairs(params.output.Issues) do
-                if d.Pos.Filename == params.bufname then
-                    table.insert(diags, {
-                        row = d.Pos.Line,
-                        col = d.Pos.Column,
-                        message = d.Text,
-                    })
+            local issues = params.output["Issues"]
+            if type(issues) == "table" then
+                for _, d in ipairs(issues) do
+                    if d.Pos.Filename == params.bufname then
+                        table.insert(diags, {
+                            row = d.Pos.Line,
+                            col = d.Pos.Column,
+                            message = d.Text,
+                        })
+                    end
                 end
             end
             return diags

--- a/lua/null-ls/builtins/diagnostics/golangci_lint.lua
+++ b/lua/null-ls/builtins/diagnostics/golangci_lint.lua
@@ -1,0 +1,41 @@
+local h = require("null-ls.helpers")
+local methods = require("null-ls.methods")
+
+local DIAGNOSTICS_ON_SAVE = methods.internal.DIAGNOSTICS_ON_SAVE
+
+return h.make_builtin({
+    method = DIAGNOSTICS_ON_SAVE,
+    filetypes = { "go" },
+    generator_opts = {
+        command = "golangci-lint",
+        to_stdin = true,
+        from_stderr = false,
+        args = {
+            "run",
+            "--fix=false",
+            "--fast",
+            "--out-format=json",
+            "$DIRNAME",
+            "--path-prefix",
+            "$ROOT",
+        },
+        format = "json",
+        check_exit_code = function(code)
+            return code <= 2
+        end,
+        on_output = function(params)
+            local diags = {}
+            for _, d in ipairs(params.output.Issues) do
+                if d.Pos.Filename == params.bufname then
+                    table.insert(diags, {
+                        row = d.Pos.Line,
+                        col = d.Pos.Column,
+                        message = d.Text,
+                    })
+                end
+            end
+            return diags
+        end,
+    },
+    factory = h.generator_factory,
+})

--- a/lua/null-ls/config.lua
+++ b/lua/null-ls/config.lua
@@ -7,6 +7,8 @@ local defaults = {
     debug = false,
     -- prevent double setup
     _setup = false,
+    -- force using LSP handler, even when native API is available (e.g diagnostics)
+    _use_lsp_handler = false,
 }
 
 local config = vim.deepcopy(defaults)

--- a/lua/null-ls/diagnostics.lua
+++ b/lua/null-ls/diagnostics.lua
@@ -92,10 +92,16 @@ M.handler = function(original_params)
         s.clear_cache(uri)
     end
 
-    local params = u.make_params(original_params, methods.map[method])
     local bufnr = vim.uri_to_bufnr(uri)
-
     local changedtick = original_params.textDocument.version or api.nvim_buf_get_changedtick(bufnr)
+
+    if method == methods.lsp.DID_SAVE and changedtick == last_changedtick[uri] then
+        u.debug_log("buffer unchanged; ignoring didSave notification")
+        return
+    end
+
+    local params = u.make_params(original_params, methods.map[method])
+
     last_changedtick[uri] = changedtick
 
     require("null-ls.generators").run_registered({

--- a/lua/null-ls/diagnostics.lua
+++ b/lua/null-ls/diagnostics.lua
@@ -81,18 +81,11 @@ M.handler = function(original_params)
                 return
             end
 
-            if u.has_version("0.5.1") then
-                handler(nil, { diagnostics = diagnostics, uri = uri }, {
-                    method = methods.lsp.PUBLISH_DIAGNOSTICS,
-                    client_id = original_params.client_id,
-                    bufnr = bufnr,
-                })
-            else
-                handler(nil, methods.lsp.PUBLISH_DIAGNOSTICS, {
-                    diagnostics = diagnostics,
-                    uri = uri,
-                }, original_params.client_id, bufnr)
-            end
+            handler(nil, { diagnostics = diagnostics, uri = uri }, {
+                method = methods.lsp.PUBLISH_DIAGNOSTICS,
+                client_id = original_params.client_id,
+                bufnr = bufnr,
+            })
         end,
     })
 end

--- a/lua/null-ls/formatting.lua
+++ b/lua/null-ls/formatting.lua
@@ -66,12 +66,7 @@ M.apply_edits = function(edits, params)
 
     local marks, views = save_win_data(bufnr)
 
-    if u.has_version("0.5.1") then
-        handler(nil, diffed_edits, { method = params.lsp_method, client_id = params.client_id, bufnr = bufnr })
-    else
-        ---@diagnostic disable-next-line: redundant-parameter
-        handler(nil, params.lsp_method, diffed_edits, params.client_id, bufnr)
-    end
+    handler(nil, diffed_edits, { method = params.lsp_method, client_id = params.client_id, bufnr = bufnr })
 
     vim.schedule(function()
         restore_win_data(marks, views, bufnr)

--- a/lua/null-ls/handlers.lua
+++ b/lua/null-ls/handlers.lua
@@ -15,33 +15,22 @@ end
 -- this will override a handler, batch results and debounce them
 function M.combine(method, ms)
     ms = ms or 100
-    local orig = u.resolve_handler(method)
-    local is_new = u.has_version("0.5.1")
 
+    local orig = u.resolve_handler(method)
     local all_results = {}
 
     local handler = u.debounce(ms, function()
         if #all_results > 0 then
-            if is_new then
-                pcall(orig, nil, all_results)
-            else
-                pcall(orig, nil, nil, all_results)
-            end
+            pcall(orig, nil, all_results)
             all_results = {}
         end
     end)
 
-    if is_new then
-        vim.lsp.handlers[method] = function(_, results)
-            vim.list_extend(all_results, results or {})
-            handler()
-        end
-    else
-        vim.lsp.handlers[method] = function(_, _, results)
-            vim.list_extend(all_results, results or {})
-            handler()
-        end
+    vim.lsp.handlers[method] = function(_, results)
+        vim.list_extend(all_results, results or {})
+        handler()
     end
+
     return vim.lsp.handlers[method]
 end
 

--- a/lua/null-ls/lspconfig.lua
+++ b/lua/null-ls/lspconfig.lua
@@ -19,7 +19,7 @@ local should_attach = function(bufnr)
 
     local ft = api.nvim_buf_get_option(bufnr, "filetype")
     -- writing and immediately deleting a buffer (e.g. :wq from a git commit)
-    -- triggers a bug on 0.5 which is fixed on master
+    -- triggers a bug on 0.5.1 which is fixed on master
     if ft == "gitcommit" and not u.has_version("0.6.0") then
         return false
     end

--- a/lua/null-ls/methods.lua
+++ b/lua/null-ls/methods.lua
@@ -10,6 +10,7 @@ local lsp_methods = {
     DID_CHANGE = "textDocument/didChange",
     DID_OPEN = "textDocument/didOpen",
     DID_CLOSE = "textDocument/didClose",
+    DID_SAVE = "textDocument/didSave",
     HOVER = "textDocument/hover",
     COMPLETION = "textDocument/completion",
 }
@@ -18,6 +19,8 @@ vim.tbl_add_reverse_lookup(lsp_methods)
 local internal_methods = {
     CODE_ACTION = "NULL_LS_CODE_ACTION",
     DIAGNOSTICS = "NULL_LS_DIAGNOSTICS",
+    DIAGNOSTICS_ON_OPEN = "NULL_LS_DIAGNOSTICS_ON_OPEN",
+    DIAGNOSTICS_ON_SAVE = "NULL_LS_DIAGNOSTICS_ON_SAVE",
     FORMATTING = "NULL_LS_FORMATTING",
     RANGE_FORMATTING = "NULL_LS_RANGE_FORMATTING",
     HOVER = "NULL_LS_HOVER",
@@ -29,15 +32,24 @@ local lsp_to_internal_map = {
     [lsp_methods.CODE_ACTION] = internal_methods.CODE_ACTION,
     [lsp_methods.FORMATTING] = internal_methods.FORMATTING,
     [lsp_methods.RANGE_FORMATTING] = internal_methods.RANGE_FORMATTING,
-    [lsp_methods.DID_OPEN] = internal_methods.DIAGNOSTICS,
     [lsp_methods.DID_CHANGE] = internal_methods.DIAGNOSTICS,
+    [lsp_methods.DID_SAVE] = internal_methods.DIAGNOSTICS_ON_SAVE,
+    [lsp_methods.DID_OPEN] = internal_methods.DIAGNOSTICS_ON_OPEN,
     [lsp_methods.HOVER] = internal_methods.HOVER,
     [lsp_methods.COMPLETION] = internal_methods.COMPLETION,
+}
+
+local overrides = {
+    [internal_methods.DIAGNOSTICS_ON_OPEN] = {
+        [internal_methods.DIAGNOSTICS] = true,
+        [internal_methods.DIAGNOSTICS_ON_SAVE] = true,
+    },
 }
 
 local readable_map = {
     [internal_methods.CODE_ACTION] = "Code actions",
     [internal_methods.DIAGNOSTICS] = "Diagnostics",
+    [internal_methods.DIAGNOSTICS_ON_SAVE] = "Diagnostics on save",
     [internal_methods.FORMATTING] = "Formatting",
     [internal_methods.RANGE_FORMATTING] = "Range formatting",
     [internal_methods.HOVER] = "Hover",
@@ -49,5 +61,6 @@ M.lsp = lsp_methods
 M.internal = internal_methods
 M.map = lsp_to_internal_map
 M.readable = readable_map
+M.overrides = overrides
 
 return M

--- a/lua/null-ls/rpc.lua
+++ b/lua/null-ls/rpc.lua
@@ -20,6 +20,7 @@ local capabilities = {
     textDocumentSync = {
         change = 1, -- prompt LSP client to send full document text on didOpen and didChange
         openClose = true,
+        save = true,
     },
 }
 

--- a/lua/null-ls/sources.lua
+++ b/lua/null-ls/sources.lua
@@ -1,4 +1,5 @@
 local methods = require("null-ls.methods")
+local u = require("null-ls.utils")
 
 local validate = vim.validate
 
@@ -151,6 +152,11 @@ M.validate_and_transform = function(source)
             },
         })
         method_map[method] = true
+    end
+
+    if method_map[methods.internal.DIAGNOSTICS_ON_SAVE] and not u.has_version("0.6.0") then
+        u.echo("WarningMsg", string.format("source %s is not supported on nvim versions < 0.6.0", name))
+        return
     end
 
     return {

--- a/lua/null-ls/sources.lua
+++ b/lua/null-ls/sources.lua
@@ -1,3 +1,5 @@
+local methods = require("null-ls.methods")
+
 local validate = vim.validate
 
 local registered = {
@@ -28,11 +30,21 @@ M.is_available = function(source, filetype, method)
         return false
     end
 
-    return (
-            not filetype
-            or (source.filetypes[filetype] == nil and source.filetypes["_all"])
-            or source.filetypes[filetype]
-        ) and (not method or source.methods[method])
+    local filetype_matches = not filetype
+        or source.filetypes["_all"] and source.filetypes[filetype] == nil
+        or source.filetypes[filetype] == true
+
+    local method_matches = not method or source.methods[method] == true
+    if not method_matches and methods.overrides[method] then
+        for m in pairs(methods.overrides[method]) do
+            if source.methods[m] then
+                method_matches = true
+                break
+            end
+        end
+    end
+
+    return filetype_matches and method_matches
 end
 
 M.get_available = function(filetype, method)
@@ -93,7 +105,7 @@ M.validate_and_transform = function(source)
 
     local generator, name = source.generator, source.name or "anonymous source"
     generator.opts = generator.opts or {}
-    local methods = type(source.method) == "table" and source.method or { source.method }
+    local source_methods = type(source.method) == "table" and source.method or { source.method }
     local filetypes, disabled_filetypes = source.filetypes, source.disabled_filetypes
 
     validate({
@@ -101,12 +113,11 @@ M.validate_and_transform = function(source)
         filetypes = { filetypes, "table" },
         disabled_filetypes = { disabled_filetypes, "table", true },
         name = { name, "string" },
-        methods = { methods, "table" },
         fn = { generator.fn, "function" },
         opts = { generator.opts, "table" },
         async = { generator.async, "boolean", true },
         method = {
-            methods,
+            source_methods,
             function(m)
                 return not vim.tbl_isempty(m), "at least one method"
             end,
@@ -129,7 +140,7 @@ M.validate_and_transform = function(source)
         end
     end
 
-    for _, method in ipairs(methods) do
+    for _, method in ipairs(source_methods) do
         validate({
             method = {
                 method,

--- a/test/spec/diagnostics_spec.lua
+++ b/test/spec/diagnostics_spec.lua
@@ -67,7 +67,7 @@ describe("diagnostics", function()
         it("should call make_params with params and method", function()
             diagnostics.handler(mock_params)
 
-            assert.stub(u.make_params).was_called_with(mock_params, methods.internal.DIAGNOSTICS)
+            assert.stub(u.make_params).was_called_with(mock_params, methods.internal.DIAGNOSTICS_ON_OPEN)
         end)
 
         describe("handler", function()

--- a/test/spec/diagnostics_spec.lua
+++ b/test/spec/diagnostics_spec.lua
@@ -88,57 +88,21 @@ describe("diagnostics", function()
         end)
 
         describe("handler", function()
-            local has = stub(vim.fn, "has")
-            after_each(function()
-                has:clear()
-            end)
+            it("should send results of diagnostic generators to lsp handler", function()
+                u.make_params.returns({ uri = mock_params.textDocument.uri })
 
-            describe("0.5", function()
-                before_each(function()
-                    has.returns(0)
-                end)
+                diagnostics.handler(mock_params)
+                local callback = generators.run_registered.calls[1].refs[1].callback
+                callback("diagnostics")
 
-                it("should send results of diagnostic generators to lsp handler", function()
-                    u.make_params.returns({ uri = mock_params.textDocument.uri })
-
-                    diagnostics.handler(mock_params)
-                    local callback = generators.run_registered.calls[1].refs[1].callback
-                    callback("diagnostics")
-
-                    assert.stub(lsp.handlers[methods.lsp.PUBLISH_DIAGNOSTICS]).was_called_with(
-                        nil,
-                        methods.lsp.PUBLISH_DIAGNOSTICS,
-                        {
-                            diagnostics = "diagnostics",
-                            uri = mock_params.textDocument.uri,
-                        },
-                        mock_client_id,
-                        vim.uri_to_bufnr(mock_uri)
-                    )
-                end)
-            end)
-
-            describe("0.5.1", function()
-                before_each(function()
-                    has.returns(1)
-                end)
-
-                it("should send results of diagnostic generators to lsp handler", function()
-                    u.make_params.returns({ uri = mock_params.textDocument.uri })
-
-                    diagnostics.handler(mock_params)
-                    local callback = generators.run_registered.calls[1].refs[1].callback
-                    callback("diagnostics")
-
-                    assert.stub(lsp.handlers[methods.lsp.PUBLISH_DIAGNOSTICS]).was_called_with(nil, {
-                        diagnostics = "diagnostics",
-                        uri = mock_params.textDocument.uri,
-                    }, {
-                        method = methods.lsp.PUBLISH_DIAGNOSTICS,
-                        client_id = mock_client_id,
-                        bufnr = vim.uri_to_bufnr(mock_uri),
-                    })
-                end)
+                assert.stub(lsp.handlers[methods.lsp.PUBLISH_DIAGNOSTICS]).was_called_with(nil, {
+                    diagnostics = "diagnostics",
+                    uri = mock_params.textDocument.uri,
+                }, {
+                    method = methods.lsp.PUBLISH_DIAGNOSTICS,
+                    client_id = mock_client_id,
+                    bufnr = vim.uri_to_bufnr(mock_uri),
+                })
             end)
         end)
 

--- a/test/spec/e2e_spec.lua
+++ b/test/spec/e2e_spec.lua
@@ -115,16 +115,16 @@ describe("e2e", function()
         end)
 
         it("should get buffer diagnostics on attach", function()
-            local buf_diagnostics = lsp.diagnostic.get(0)
+            local buf_diagnostics = vim.diagnostic.get(0)
             assert.equals(vim.tbl_count(buf_diagnostics), 1)
 
             local write_good_diagnostic = buf_diagnostics[1]
             assert.equals(write_good_diagnostic.message, '"really" can weaken meaning')
             assert.equals(write_good_diagnostic.source, "write-good")
-            assert.same(write_good_diagnostic.range, {
-                start = { character = 7, line = 0 },
-                ["end"] = { character = 13, line = 0 },
-            })
+            assert.equals(write_good_diagnostic.lnum, 0)
+            assert.equals(write_good_diagnostic.end_lnum, 0)
+            assert.equals(write_good_diagnostic.col, 7)
+            assert.equals(write_good_diagnostic.end_col, 13)
         end)
 
         it("should update buffer diagnostics on text change", function()
@@ -132,7 +132,7 @@ describe("e2e", function()
             api.nvim_buf_set_text(api.nvim_get_current_buf(), 0, 6, 0, 13, {})
             lsp_wait()
 
-            assert.equals(vim.tbl_count(lsp.diagnostic.get(0)), 0)
+            assert.equals(vim.tbl_count(vim.diagnostic.get(0)), 0)
         end)
 
         describe("multiple diagnostics", function()
@@ -146,7 +146,7 @@ describe("e2e", function()
                 vim.cmd("e")
                 lsp_wait()
 
-                local diagnostics = lsp.diagnostic.get(0)
+                local diagnostics = vim.diagnostic.get(0)
                 assert.equals(vim.tbl_count(diagnostics), 2)
 
                 local markdownlint_diagnostic, write_good_diagnostic
@@ -169,7 +169,7 @@ describe("e2e", function()
             vim.cmd("e")
             lsp_wait()
 
-            local write_good_diagnostic = lsp.diagnostic.get(0)[1]
+            local write_good_diagnostic = vim.diagnostic.get(0)[1]
 
             assert.equals(write_good_diagnostic.message, '"really" can weaken meaning (write-good)')
         end)
@@ -330,16 +330,16 @@ describe("e2e", function()
             api.nvim_buf_set_text(api.nvim_get_current_buf(), 0, 52, 0, 53, { ".." })
             lsp_wait()
 
-            local buf_diagnostics = lsp.diagnostic.get(0)
+            local buf_diagnostics = vim.diagnostic.get(0)
             assert.equals(vim.tbl_count(buf_diagnostics), 1)
 
             local tl_check_diagnostic = buf_diagnostics[1]
             assert.equals(tl_check_diagnostic.message, "in return value: got string, expected number")
             assert.equals(tl_check_diagnostic.source, "tl check")
-            assert.same(tl_check_diagnostic.range, {
-                start = { character = 52, line = 0 },
-                ["end"] = { character = 0, line = 1 },
-            })
+            assert.equals(tl_check_diagnostic.lnum, 0)
+            assert.equals(tl_check_diagnostic.end_lnum, 1)
+            assert.equals(tl_check_diagnostic.col, 52)
+            assert.equals(tl_check_diagnostic.end_col, 0)
         end)
     end)
 

--- a/test/spec/formatting_spec.lua
+++ b/test/spec/formatting_spec.lua
@@ -113,49 +113,17 @@ describe("formatting", function()
         end)
 
         describe("handler", function()
-            local has = stub(vim.fn, "has")
-            after_each(function()
-                has:clear()
-            end)
+            it("should call lsp_handler with text edit response", function()
+                formatting.handler(methods.lsp.FORMATTING, mock_params, handler)
 
-            describe("0.5", function()
-                before_each(function()
-                    has.returns(0)
-                end)
+                local callback = generators.run_registered_sequentially.calls[1].refs[1].callback
+                callback(mock_edits, mock_params)
 
-                it("should call lsp_handler with text edit response", function()
-                    formatting.handler(methods.lsp.FORMATTING, mock_params, handler)
-
-                    local callback = generators.run_registered_sequentially.calls[1].refs[1].callback
-                    callback(mock_edits, mock_params)
-
-                    assert.stub(lsp_handler).was_called_with(
-                        nil,
-                        mock_params.lsp_method,
-                        { mock_diffed },
-                        mock_params.client_id,
-                        mock_params.bufnr
-                    )
-                end)
-            end)
-
-            describe("0.5.1", function()
-                before_each(function()
-                    has.returns(1)
-                end)
-
-                it("should call lsp_handler with text edit response", function()
-                    formatting.handler(methods.lsp.FORMATTING, mock_params, handler)
-
-                    local callback = generators.run_registered_sequentially.calls[1].refs[1].callback
-                    callback(mock_edits, mock_params)
-
-                    assert.stub(lsp_handler).was_called_with(nil, { mock_diffed }, {
-                        method = mock_params.lsp_method,
-                        client_id = mock_params.client_id,
-                        bufnr = mock_params.bufnr,
-                    })
-                end)
+                assert.stub(lsp_handler).was_called_with(nil, { mock_diffed }, {
+                    method = mock_params.lsp_method,
+                    client_id = mock_params.client_id,
+                    bufnr = mock_params.bufnr,
+                })
             end)
         end)
     end)

--- a/test/spec/generators_spec.lua
+++ b/test/spec/generators_spec.lua
@@ -283,10 +283,33 @@ describe("generators", function()
             generators.run_registered(mock_opts)
 
             assert.stub(run).was_called_with(
-                { sync_generator },
+                generators.get_available(mock_opts.filetype, mock_opts.method),
                 mock_opts.params,
                 mock_opts.postprocess,
-                mock_opts.callback
+                mock_opts.callback,
+                nil
+            )
+        end)
+
+        it("should call run with available generators indexed by id", function()
+            register(method, sync_generator, { "lua" })
+            local mock_opts = {
+                filetype = mock_params.ft,
+                method = mock_params.method,
+                params = mock_params,
+                postprocess = postprocess,
+                callback = callback,
+                index_by_id = true,
+            }
+
+            generators.run_registered(mock_opts)
+
+            assert.stub(run).was_called_with(
+                generators.get_available(mock_opts.filetype, mock_opts.method, mock_opts.index_by_id),
+                mock_opts.params,
+                mock_opts.postprocess,
+                mock_opts.callback,
+                true
             )
         end)
     end)
@@ -360,6 +383,20 @@ describe("generators", function()
             local available = generators.get_available("lua", method)
 
             assert.same(available, {})
+        end)
+
+        it("should index generators by id if index_by_id is true", function()
+            register(method, sync_generator, { "lua" })
+
+            local available = generators.get_available("lua", method, true)
+
+            local generator_id
+            for id in pairs(available) do
+                generator_id = id
+                break
+            end
+
+            assert.same(available, { [generator_id] = sync_generator })
         end)
     end)
 

--- a/test/spec/sources_spec.lua
+++ b/test/spec/sources_spec.lua
@@ -1,6 +1,8 @@
 local stub = require("luassert.stub")
+local mock = require("luassert.mock")
 
 local methods = require("null-ls.methods")
+local u = mock(require("null-ls.utils"), true)
 
 describe("sources", function()
     local sources = require("null-ls.sources")
@@ -270,12 +272,17 @@ describe("sources", function()
     describe("validate_and_transform", function()
         local mock_source
         before_each(function()
+            u.has_version.returns(true)
             mock_source = {
                 generator = { fn = function() end, opts = {}, async = false },
                 name = "mock generator",
                 filetypes = { "lua" },
                 method = methods.internal.FORMATTING,
             }
+        end)
+
+        after_each(function()
+            u.has_version:clear()
         end)
 
         it("should validate and return transformed source", function()
@@ -340,6 +347,15 @@ describe("sources", function()
             local validated = sources.validate_and_transform(function()
                 return nil
             end)
+
+            assert.falsy(validated)
+        end)
+
+        it("should return nil if nvim version does not support method", function()
+            mock_source.method = methods.internal.DIAGNOSTICS_ON_SAVE
+            u.has_version.returns(false)
+
+            local validated = sources.validate_and_transform(mock_source)
 
             assert.falsy(validated)
         end)

--- a/test/spec/sources_spec.lua
+++ b/test/spec/sources_spec.lua
@@ -74,6 +74,14 @@ describe("sources", function()
             assert.truthy(is_available)
         end)
 
+        it("should return true if method has override", function()
+            mock_source.methods = { [methods.internal.DIAGNOSTICS_ON_SAVE] = true }
+
+            local is_available = sources.is_available(mock_source, nil, methods.internal.DIAGNOSTICS_ON_OPEN)
+
+            assert.truthy(is_available)
+        end)
+
         it("should return true if filetype and method match", function()
             local is_available = sources.is_available(mock_source, "lua", methods.internal.FORMATTING)
 


### PR DESCRIPTION
Closes #166 and supersedes #318.

The main change in this PR is to migrate to the `vim.diagnostic` API when available, the biggest advantage of which is the ability to use separate namespaces for each source. This lets us push multiple sets of diagnostics at a time, which enables running linters on save (more on this in a bit) and lays the groundwork for better source management, as mentioned in #337. It's also simpler to use, both internally and from a user config perspective.

Previously, pushing diagnostics on `textDocument/didSave` notifications wasn't possible for the reasons discussed in #166, but with the diagnostic API in place, adding support was simple. The one issue was handling `textDocument/didOpen` notifications, since these should prompt null-ls to run both on-change and on-save linters. I'm not thrilled with the workaround (checking a separate `overrides` table) and want to see if I can come up with something better.

I combined the implementations in #318 and #69 to add support for golangci-lint as the first on-save source. I don't use Go at all and only have a sample repository for testing, so I'd appreciate feedback from @zalegrala and anyone else who's able to test this out in a real development environment. 

Finally, this PR drops support for Neovim version 0.5.0, which is a breaking change but shouldn't be a big deal.