### PR TITLE
add .null-ls-root to LSP root patterns

### DIFF
--- a/doc/CONFIG.md
+++ b/doc/CONFIG.md
@@ -127,3 +127,7 @@ control its behavior.
 
 You can also deregister sources using the source API, as described in
 [SOURCES](SOURCES.md).
+
+## Explicitly defining the project root
+
+Create an empty file `.null-ls-root` in the directory you want to mark as the project root for null-ls.

--- a/lua/null-ls/lspconfig.lua
+++ b/lua/null-ls/lspconfig.lua
@@ -41,7 +41,7 @@ function M.setup()
         cmd = { "nvim" },
         name = "null-ls",
         root_dir = function(fname)
-            return lsputil.root_pattern("Makefile", ".git")(fname) or lsputil.path.dirname(fname)
+            return lsputil.root_pattern(".null-ls-root", "Makefile", ".git")(fname) or lsputil.path.dirname(fname)
         end,
         flags = { debounce_text_changes = c.get().debounce },
         filetypes = sources.get_filetypes(),


### PR DESCRIPTION
Allows to explicitly set the project root for certain projects