### PR TITLE
Use `--stdin-path` argument in phpcbf to make exclude-pattern works

### DIFF
--- a/lua/null-ls/builtins/formatting/phpcbf.lua
+++ b/lua/null-ls/builtins/formatting/phpcbf.lua
@@ -11,6 +11,8 @@ return h.make_builtin({
         args = {
             -- silence status messages during processing
             "-q",
+            -- passes the filename to phpcs, so it respects all include and exclude patterns
+            "--stdin-path=$FILENAME",
             -- process stdin
             "-",
         },


### PR DESCRIPTION
Ref: https://github.com/jose-elias-alvarez/null-ls.nvim/discussions/341