### PR TITLE
feat(builtins): add prefer_local and only_local options

### DIFF
--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -158,6 +158,28 @@ See [CONFIG](CONFIG.md) to learn about the structure of `diagnostics_format`.
 Note that specifying `diagnostics_format` for a built-in will override your
 global `diagnostics_format` for that source.
 
+## Local executables
+
+To prefer using a local executable for a built-in, use the `prefer_local`
+option. This will cause null-ls to search upwards from the current buffer's
+directory, try to find a local executable at each parent directory, and fall
+back to a global executable if it can't find one locally.
+
+`prefer_local` can be a boolean or a string, in which case it's treated as a
+prefix. For example, the following settings will cause null-ls to search for
+`node_modules/.bin/prettier`:
+
+```lua
+local sources = {
+    null_ls.builtins.formatting.prettier.with({
+        prefer_local = "node_modules/.bin",
+    }),
+}
+```
+
+To _only_ use a local executable without falling back, use `only_local`, which
+accepts the same options.
+
 ## Conditional registration
 
 null-ls supports dynamic registration, meaning that you can register sources

--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -180,6 +180,10 @@ local sources = {
 To _only_ use a local executable without falling back, use `only_local`, which
 accepts the same options.
 
+By default, these options will also set the `cwd` of the spawned process to the
+parent directory of the local executable (if found). You can override this by
+manually setting `cwd` to a function that should return your preferred `cwd`.
+
 ## Conditional registration
 
 null-ls supports dynamic registration, meaning that you can register sources

--- a/doc/HELPERS.md
+++ b/doc/HELPERS.md
@@ -38,6 +38,7 @@ helpers.generator_factory({
     use_cache, -- boolean (optional)
     runtime_condition, -- function (optional)
     cwd, -- function (optional)
+    dynamic_command, -- function(optional)
 })
 ```
 
@@ -193,6 +194,18 @@ Optional callback to set the working directory for the spawned process. Takes a
 single argument, `params`, which is a table containing information about the
 current editor state (described in [MAIN](./MAIN.md)). If the callback returns
 `nil`, the working directory defaults to the project's root.
+
+### dynamic_command
+
+Optional callback to set `command` dynamically. Takes two arguments, a string
+containing the base `command` and a `params` object containing information about
+the current buffer's state. The callback should return a string containing the
+command to run or `nil`, meaning that no command should run.
+
+`dynamic_command` runs every time its parent generator runs and can affect
+performance, so it's best to cache its output when possible.
+
+Note that setting `dynamic_command` will disable `command` validation.
 
 ## formatter_factory
 

--- a/doc/HELPERS.md
+++ b/doc/HELPERS.md
@@ -197,10 +197,11 @@ current editor state (described in [MAIN](./MAIN.md)). If the callback returns
 
 ### dynamic_command
 
-Optional callback to set `command` dynamically. Takes two arguments, a string
-containing the base `command` and a `params` object containing information about
-the current buffer's state. The callback should return a string containing the
-command to run or `nil`, meaning that no command should run.
+Optional callback to set `command` dynamically. Takes one arguments, a `params`
+object containing information about the current buffer's state. The generator's
+original command (if set) is available as `params.command`. The callback should
+return a string containing the command to run or `nil`, meaning that no command
+should run.
 
 `dynamic_command` runs every time its parent generator runs and can affect
 performance, so it's best to cache its output when possible.

--- a/lua/null-ls/diagnostics.lua
+++ b/lua/null-ls/diagnostics.lua
@@ -121,9 +121,12 @@ M.handler = function(original_params)
     end
 
     local method, uri = original_params.method, original_params.textDocument.uri
+    local bufnr = vim.uri_to_bufnr(uri)
+
     if method == methods.lsp.DID_CLOSE then
         changedticks_by_uri[uri] = nil
         s.clear_cache(uri)
+        s.clear_commands(bufnr)
         return
     end
 
@@ -131,7 +134,6 @@ M.handler = function(original_params)
         s.clear_cache(uri)
     end
 
-    local bufnr = vim.uri_to_bufnr(uri)
     local changedtick = original_params.textDocument.version or api.nvim_buf_get_changedtick(bufnr)
 
     if method == methods.lsp.DID_SAVE and changedtick == get_last_changedtick(uri, method) then

--- a/lua/null-ls/helpers.lua
+++ b/lua/null-ls/helpers.lua
@@ -428,7 +428,7 @@ M.make_builtin = function(opts)
                 -- a string means command was resolved on last run
                 -- false means the command already failed to resolve, so don't bother checking again
                 if resolved and (type(resolved.command) == "string" or resolved.command == false) then
-                    return resolved
+                    return resolved.command
                 end
 
                 local maybe_prefix = prefer_local or only_local

--- a/lua/null-ls/helpers.lua
+++ b/lua/null-ls/helpers.lua
@@ -424,17 +424,10 @@ M.make_builtin = function(opts)
             builtin_copy._opts.dynamic_command = function(params)
                 local lsputil = require("lspconfig.util")
 
-                -- assume the resolved command stays the same for the lifetime of the buffer,
-                -- to avoid a potentially expensive search on every run
                 local resolved = s.get_resolved_command(params.bufnr, params.command)
-                if
-                    resolved
-                    and (
-                        type(resolved.command)
-                            == "string" -- command was resolved on last run
-                        or resolved.command == false -- command failed to resolve, so don't bother checking again
-                    )
-                then
+                -- a string means command was resolved on last run
+                -- false means the command already failed to resolve, so don't bother checking again
+                if resolved and (type(resolved.command) == "string" or resolved.command == false) then
                     return resolved
                 end
 

--- a/lua/null-ls/state.lua
+++ b/lua/null-ls/state.lua
@@ -3,6 +3,7 @@ local api = vim.api
 local initial_state = {
     actions = {},
     cache = {},
+    commands = {},
 }
 
 local state = vim.deepcopy(initial_state)
@@ -68,6 +69,19 @@ M.clear_cache = function(uri)
     end
 
     state.cache[uri] = nil
+end
+
+M.set_command = function(bufnr, base, resolved)
+    state.commands[bufnr] = state.commands[bufnr] or {}
+    state.commands[bufnr][base] = resolved
+end
+
+M.get_command = function(bufnr, base)
+    return state.commands[bufnr] and state.commands[bufnr][base]
+end
+
+M.clear_commands = function(bufnr)
+    state.commands[bufnr] = nil
 end
 
 return M

--- a/lua/null-ls/state.lua
+++ b/lua/null-ls/state.lua
@@ -71,12 +71,12 @@ M.clear_cache = function(uri)
     state.cache[uri] = nil
 end
 
-M.set_command = function(bufnr, base, resolved)
+M.set_resolved_command = function(bufnr, base, resolved)
     state.commands[bufnr] = state.commands[bufnr] or {}
     state.commands[bufnr][base] = resolved
 end
 
-M.get_command = function(bufnr, base)
+M.get_resolved_command = function(bufnr, base)
     return state.commands[bufnr] and state.commands[bufnr][base]
 end
 

--- a/lua/null-ls/utils.lua
+++ b/lua/null-ls/utils.lua
@@ -82,6 +82,15 @@ M.has_version = function(ver)
     return vim.fn.has("nvim-" .. ver) > 0
 end
 
+M.is_executable = function(cmd)
+    local is_executable = vim.fn.executable(cmd) > 0
+    if is_executable then
+        return true
+    end
+
+    return false, string.format("command %s is not executable (make sure it's installed and on your $PATH)", cmd)
+end
+
 -- lsp-compatible range is 0-indexed.
 -- lua-friendly range is 1-indexed.
 M.range = {

--- a/test/files/cat
+++ b/test/files/cat
@@ -1,0 +1,1 @@
+echo "Hello!"

--- a/test/spec/diagnostics_spec.lua
+++ b/test/spec/diagnostics_spec.lua
@@ -15,6 +15,7 @@ describe("diagnostics", function()
 
     describe("handler", function()
         stub(s, "clear_cache")
+        stub(s, "clear_commands")
         stub(u, "make_params")
         stub(generators, "run_registered")
 
@@ -40,7 +41,9 @@ describe("diagnostics", function()
 
         after_each(function()
             mock_handler:clear()
+
             s.clear_cache:clear()
+            s.clear_commands:clear()
             generators.run_registered:clear()
             u.make_params:clear()
 
@@ -48,12 +51,13 @@ describe("diagnostics", function()
             c.reset()
         end)
 
-        it("should call clear_cache with uri when method is DID_CLOSE", function()
+        it("should call clear_cache with uri and clear_commands with bufnr when method is DID_CLOSE", function()
             mock_params.method = methods.lsp.DID_CLOSE
 
             diagnostics.handler(mock_params)
 
             assert.stub(s.clear_cache).was_called_with(mock_params.textDocument.uri)
+            assert.stub(s.clear_commands).was_called_with(vim.uri_to_bufnr(mock_params.textDocument.uri))
         end)
 
         it("should call clear_cache with uri when method is DID_CHANGE", function()

--- a/test/spec/e2e_spec.lua
+++ b/test/spec/e2e_spec.lua
@@ -104,7 +104,7 @@ describe("e2e", function()
     end)
 
     describe("diagnostics", function()
-        if vim.fn.executable("write-good") == 0 then
+        if not u.is_executable("write-good") then
             print("skipping diagnostic tests (write-good not installed)")
             return
         end
@@ -138,7 +138,7 @@ describe("e2e", function()
         end)
 
         describe("multiple diagnostics", function()
-            if vim.fn.executable("markdownlint") == 0 then
+            if not u.is_executable("markdownlint") then
                 print("skipping multiple diagnostics tests (markdownlint not installed)")
                 return
             end
@@ -178,7 +178,7 @@ describe("e2e", function()
     end)
 
     describe("formatting", function()
-        if vim.fn.executable("prettier") == 0 then
+        if not u.is_executable("prettier") then
             print("skipping formatting tests (prettier not installed)")
             return
         end
@@ -268,7 +268,7 @@ describe("e2e", function()
     end)
 
     describe("range formatting", function()
-        if vim.fn.executable("prettier") == 0 then
+        if not u.is_executable("prettier") then
             print("skipping range formatting tests (prettier not installed)")
             return
         end
@@ -295,7 +295,7 @@ describe("e2e", function()
     end)
 
     describe("temp file source", function()
-        if vim.fn.executable("tl") == 0 then
+        if not u.is_executable("tl") then
             print("skipping temp file source tests (teal not installed)")
             return
         end

--- a/test/spec/e2e_spec.lua
+++ b/test/spec/e2e_spec.lua
@@ -401,6 +401,7 @@ describe("e2e", function()
 
                 assert.equals(vim.tbl_count(actions[1].result), 1)
                 assert.equals(copy._opts._last_command, tu.test_dir .. "/files/cat")
+                assert.equals(copy._opts._last_cwd, tu.test_dir .. "/files")
             end)
 
             it("should fall back to global executable when local is unavailable", function()
@@ -416,6 +417,7 @@ describe("e2e", function()
 
                 assert.equals(vim.tbl_count(actions[1].result), 1)
                 assert.equals(copy._opts._last_command, "ls")
+                assert.equals(copy._opts._last_cwd, vim.loop.cwd())
             end)
         end)
 
@@ -433,6 +435,7 @@ describe("e2e", function()
 
                 assert.equals(vim.tbl_count(actions[1].result), 1)
                 assert.equals(copy._opts._last_command, tu.test_dir .. "/files/cat")
+                assert.equals(copy._opts._last_cwd, tu.test_dir .. "/files")
             end)
 
             it("should not run when local executable is unavailable", function()
@@ -447,6 +450,8 @@ describe("e2e", function()
                 lsp_wait()
 
                 assert.equals(vim.tbl_count(actions[1].result), 0)
+                assert.equals(copy._opts.last_command, nil)
+                assert.equals(copy._opts._last_cwd, nil)
             end)
         end)
     end)

--- a/test/spec/e2e_spec.lua
+++ b/test/spec/e2e_spec.lua
@@ -5,6 +5,7 @@ local main = require("null-ls")
 
 local c = require("null-ls.config")
 local u = require("null-ls.utils")
+local s = require("null-ls.state")
 local tu = require("test.utils")
 
 local lsp = vim.lsp
@@ -38,6 +39,7 @@ describe("e2e", function()
         vim.cmd("bufdo! bdelete!")
 
         c.reset()
+        s.reset()
         sources.reset()
     end)
 
@@ -376,6 +378,76 @@ describe("e2e", function()
             actions = get_code_actions()
             null_ls_action = actions[1].result[1]
             assert.equals(null_ls_action.title, "Not cached")
+        end)
+    end)
+
+    describe("local executable", function()
+        before_each(function()
+            sources._reset()
+            tu.edit_test_file("test-file.lua")
+        end)
+
+        describe("prefer_local", function()
+            it("should prefer local executable when available", function()
+                local copy = builtins._test.slow_code_action.with({
+                    command = "cat",
+                    args = {},
+                    prefer_local = true,
+                })
+                sources.register(copy)
+
+                local actions = get_code_actions()
+                lsp_wait()
+
+                assert.equals(vim.tbl_count(actions[1].result), 1)
+                assert.equals(copy._opts._last_command, tu.test_dir .. "/files/cat")
+            end)
+
+            it("should fall back to global executable when local is unavailable", function()
+                local copy = builtins._test.slow_code_action.with({
+                    command = "ls",
+                    args = {},
+                    prefer_local = true,
+                })
+                sources.register(copy)
+
+                local actions = get_code_actions()
+                lsp_wait()
+
+                assert.equals(vim.tbl_count(actions[1].result), 1)
+                assert.equals(copy._opts._last_command, "ls")
+            end)
+        end)
+
+        describe("only_local", function()
+            it("should use local executable when available", function()
+                local copy = builtins._test.slow_code_action.with({
+                    command = "cat",
+                    args = {},
+                    only_local = true,
+                })
+                sources.register(copy)
+
+                local actions = get_code_actions()
+                lsp_wait()
+
+                assert.equals(vim.tbl_count(actions[1].result), 1)
+                assert.equals(copy._opts._last_command, tu.test_dir .. "/files/cat")
+            end)
+
+            it("should not run when local executable is unavailable", function()
+                local copy = builtins._test.slow_code_action.with({
+                    command = "ls",
+                    args = {},
+                    only_local = true,
+                })
+                sources.register(copy)
+
+                local actions = get_code_actions()
+                lsp_wait()
+
+                assert.equals(vim.tbl_count(actions[1].result), 0)
+            end)
         end)
     end)
 

--- a/test/spec/helpers_spec.lua
+++ b/test/spec/helpers_spec.lua
@@ -267,7 +267,7 @@ describe("helpers", function()
             local generator = helpers.generator_factory(generator_args)
             generator.fn({ test_key = "test_val" })
 
-            assert.same(params, { test_key = "test_val", root = root })
+            assert.same(params, { test_key = "test_val", root = root, cwd = vim.loop.cwd() })
         end)
 
         it("should set command from function return value", function()
@@ -349,7 +349,7 @@ describe("helpers", function()
             assert.equals(generator.opts.command, "cat")
         end)
 
-        it("should set _last_args and _last_command from last resolved args and command", function()
+        it("should set _last_args, _last_command, and _last_cwd from last resolved", function()
             generator_args.command = function()
                 return "cat"
             end
@@ -362,6 +362,7 @@ describe("helpers", function()
 
             assert.equals(generator.opts._last_command, "cat")
             assert.same(generator.opts._last_args, { "-b" })
+            assert.same(generator.opts._last_cwd, vim.loop.cwd())
         end)
 
         it("should throw error if from_temp_file = true but to_temp_file is not", function()

--- a/test/spec/helpers_spec.lua
+++ b/test/spec/helpers_spec.lua
@@ -267,7 +267,8 @@ describe("helpers", function()
             local generator = helpers.generator_factory(generator_args)
             generator.fn({ test_key = "test_val" })
 
-            assert.same(params, { test_key = "test_val", root = root, cwd = vim.loop.cwd() })
+            assert.truthy(params)
+            assert.equals(params.test_key, "test_val")
         end)
 
         it("should set command from function return value", function()
@@ -297,17 +298,17 @@ describe("helpers", function()
             assert.equals(count, 1)
         end)
 
-        it("should call dynamic_command with command but not override original command", function()
+        it("should call dynamic_command with params but not override original command", function()
             local original_command
-            generator_args.dynamic_command = function(cmd)
-                original_command = cmd
-                return "cat"
+            generator_args.dynamic_command = function(params)
+                original_command = params.command
+                return "tldr"
             end
 
             local generator = helpers.generator_factory(generator_args)
             generator.fn({})
 
-            assert.equals(loop.spawn.calls[1].refs[1], "cat")
+            assert.equals(loop.spawn.calls[1].refs[1], "tldr")
             assert.equals(generator_args.command, original_command)
             assert.equals(generator_args.command, "cat")
         end)

--- a/test/spec/state_spec.lua
+++ b/test/spec/state_spec.lua
@@ -179,4 +179,41 @@ describe("state", function()
             end)
         end)
     end)
+
+    describe("commands", function()
+        local mock_bufnr = 1
+        local mock_base = "cat"
+        local mock_command = "/my/mock/cwd/cat"
+        local mock_cwd = "/my/mock/cwd"
+
+        describe("set_resolved_command", function()
+            it("should set resolved command and cwd", function()
+                s.set_resolved_command(mock_bufnr, mock_base, { command = mock_command, cwd = mock_cwd })
+
+                assert.truthy(s.get().commands[mock_bufnr])
+                assert.same(s.get().commands[mock_bufnr], { [mock_base] = { command = mock_command, cwd = mock_cwd } })
+            end)
+        end)
+
+        describe("get_resolved_command", function()
+            it("should get resolved command and cwd", function()
+                s.set_resolved_command(mock_bufnr, mock_base, { command = mock_command, cwd = mock_cwd })
+
+                local resolved = s.get_resolved_command(mock_bufnr, mock_base)
+
+                assert.truthy(resolved)
+                assert.same(resolved, { command = mock_command, cwd = mock_cwd })
+            end)
+        end)
+
+        describe("clear_commands", function()
+            it("should clear commands", function()
+                s.set_resolved_command(mock_bufnr, mock_base, { command = mock_command, cwd = mock_cwd })
+
+                s.clear_commands(mock_bufnr)
+
+                assert.falsy(s.get().commands[mock_bufnr])
+            end)
+        end)
+    end)
 end)

--- a/test/spec/utils_spec.lua
+++ b/test/spec/utils_spec.lua
@@ -135,7 +135,7 @@ describe("utils", function()
             assert.stub(has).was_called_with("nvim-0.6.0")
         end)
 
-        it("should return false if has resullt is 0", function()
+        it("should return false if has result is 0", function()
             has.returns(0)
 
             assert.falsy(u.has_version("0.6.0"))
@@ -145,6 +145,42 @@ describe("utils", function()
             has.returns(1)
 
             assert.truthy(u.has_version("0.6.0"))
+        end)
+    end)
+
+    describe("is_executable", function()
+        local executable
+        before_each(function()
+            executable = stub(vim.fn, "executable")
+        end)
+        after_each(function()
+            executable:revert()
+        end)
+
+        it("should call executable with command", function()
+            executable.returns(0)
+
+            u.is_executable("mock-command")
+
+            assert.stub(executable).was_called_with("mock-command")
+        end)
+
+        it("should return true and nil if result is > 0", function()
+            executable.returns(1)
+
+            local is_executable, err_msg = u.is_executable("mock-command")
+
+            assert.truthy(is_executable)
+            assert.falsy(err_msg)
+        end)
+
+        it("should return false and error message if result is 0", function()
+            executable.returns(0)
+
+            local is_executable, err_msg = u.is_executable("mock-command")
+
+            assert.falsy(is_executable)
+            assert.truthy(err_msg:find("is not executable"))
         end)
     end)
 


### PR DESCRIPTION
Closes #289.

This PR adds two new options for built-ins, `prefer_local` and `only_local`. It also exposes the underlying `dynamic_command` mechanism for generators created using `generator_factory`. 

When a source with `prefer_local = true` runs for the first time in a given buffer, null-ls will traverse that buffer's parent directories and try to find a local copy of `command`, stopping once it hits the client's root directory. If not found, it will fall back to a globally-available executable. The results of the search are cached and used whenever the source runs again. `only_local` works the same way without falling back (i.e. it only runs if a local copy is found).

Both options accept a string, which is treated as a prefix (see the documentation for an example).

If found, the `cwd` of the processes will be set to the directory in which the local copy was found (unless specifically set by the user).

There's (at least) one potentially confusing piece of behavior in this PR, which is that when `only_local` is set and no local executable is found, `:NullLsInfo` will still show the source as available for the current buffer. There are workarounds for that, but none of them are pretty, so I'd rather leave it as-is for now.