### PR TITLE
feat(formatting): add google-java-format

### DIFF
--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -641,6 +641,34 @@ local sources = { null_ls.builtins.formatting.golines }
 - `command = "golines"`
 - `args = {}`
 
+#### [google-java-format](https://github.com/google/google-java-format)
+
+##### About
+
+Reformats Java source code to comply with Google Java Style.
+
+##### Usage
+
+```lua
+local sources = { null_ls.builtins.formatting.google_java_format }
+```
+
+If you want 4 space indentation use:
+
+```lua
+local sources = {
+  null_ls.builtins.formatting.google_java_format.with({
+    extra_args = { "--aosp" },
+  }),
+}
+```
+
+##### Defaults
+
+- `filetypes = { "java" }`
+- `command = "google-java-format"`
+- `args = { "-" }`
+
 #### [isort](https://github.com/PyCQA/isort)
 
 ##### About

--- a/lua/null-ls/builtins/formatting/google_java_format.lua
+++ b/lua/null-ls/builtins/formatting/google_java_format.lua
@@ -1,0 +1,17 @@
+local h = require("null-ls.helpers")
+local methods = require("null-ls.methods")
+
+local FORMATTING = methods.internal.FORMATTING
+
+return h.make_builtin({
+    method = FORMATTING,
+    filetypes = { "java" },
+    generator_opts = {
+        command = "google-java-format",
+        args = {
+            "-",
+        },
+        to_stdin = true,
+    },
+    factory = h.formatter_factory,
+})


### PR DESCRIPTION
This PR adds a builtin formatting source for [google-java-format](https://github.com/google/google-java-format).

I believe I've followed the format for documentation properly, the only thing that might be a little out of the ordinary is that I added another section inside usage showing how to use it with the `--aosp` option since I think many people will want to do that. If there's a different heading that should go under, lmk!