### PR TITLE
fix golangci-lint issues

### DIFF
--- a/lua/null-ls/builtins/diagnostics/golangci_lint.lua
+++ b/lua/null-ls/builtins/diagnostics/golangci_lint.lua
@@ -10,6 +10,7 @@ return h.make_builtin({
         command = "golangci-lint",
         to_stdin = true,
         from_stderr = false,
+        ignore_stderr = true,
         args = {
             "run",
             "--fix=false",
@@ -33,6 +34,7 @@ return h.make_builtin({
                             row = d.Pos.Line,
                             col = d.Pos.Column,
                             message = d.Text,
+                            severity = h.diagnostics.severities["warning"],
                         })
                     end
                 end


### PR DESCRIPTION
I had mentioned all of this in code-review comments in #318, for details please have a look there.
Here are the changes I suggested.

It's necessary to ignore stderr from golangci-lint for now as otherwise the deprecation warnings of various linters used by golangci-lint will cause issues.

Also as most of the linters show non-critical issues in the code, settings the default severity to warning makes sense. Otherwise all the warnings will show up as errors.