### PR TITLE
feat(hadolint): remove Dockerfile from filetypes

### DIFF
--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -1568,7 +1568,7 @@ local sources = { null_ls.builtins.diagnostics.hadolint }
 
 ##### Defaults
 
-- `filetypes = { "Dockerfile", "dockerfile" }`
+- `filetypes = { "dockerfile" }`
 - `command = "hadolint"`
 - `args = { "--no-fail", "--format=json", "$FILENAME" }`
 

--- a/lua/null-ls/builtins/diagnostics/hadolint.lua
+++ b/lua/null-ls/builtins/diagnostics/hadolint.lua
@@ -5,7 +5,7 @@ local DIAGNOSTICS = methods.internal.DIAGNOSTICS
 
 return h.make_builtin({
     method = DIAGNOSTICS,
-    filetypes = { "Dockerfile", "dockerfile" },
+    filetypes = { "dockerfile" },
     generator_opts = {
         command = "hadolint",
         format = "json",


### PR DESCRIPTION
This was removed from lsp-config, so my initial reason for adding it is
now invalid. See:
https://github.com/neovim/nvim-lspconfig/pull/1358

Reverts 7852d82f3904a6a70620d328e6e44f9bbc8e4a27

Original PR:
https://github.com/jose-elias-alvarez/null-ls.nvim/pull/271