### PR TITLE
feat(diagnostics): add staticcheck

### DIFF
--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -1971,6 +1971,25 @@ local sources = { null_ls.builtins.diagnostics.golangci_lint }
 - `command = "golangci-lint"`
 - `args = { "run", "--fix=false", "--fast", "--out-format=json", "$DIRNAME", "--path-prefix", "$ROOT" }`
 
+#### [staticcheck](https://staticcheck.io/)
+
+##### About
+
+Advanced Go linter.
+
+##### Usage
+
+```lua
+local sources = { null_ls.builtins.diagnostics.staticcheck }
+```
+
+##### Defaults
+
+- `filetypes = { "go" }`
+- `command = "staticcheck"`
+- `args = { "-f", "json", "./..." }`
+
+
 ### Code actions
 
 #### [gitsigns.nvim](https://github.com/lewis6991/gitsigns.nvim)

--- a/lua/null-ls/builtins/diagnostics/staticcheck.lua
+++ b/lua/null-ls/builtins/diagnostics/staticcheck.lua
@@ -1,0 +1,47 @@
+local h = require("null-ls.helpers")
+local methods = require("null-ls.methods")
+
+local DIAGNOSTICS_ON_SAVE = methods.internal.DIAGNOSTICS_ON_SAVE
+
+local severities = {
+    error = vim.lsp.protocol.DiagnosticSeverity.Error,
+    warning = vim.lsp.protocol.DiagnosticSeverity.Warning,
+    ignored = vim.lsp.protocol.DiagnosticSeverity.Information,
+}
+
+return h.make_builtin({
+    method = DIAGNOSTICS_ON_SAVE,
+    filetypes = { "go" },
+    generator_opts = {
+        command = "staticcheck",
+        to_stdin = false,
+        from_stderr = false,
+        ignore_stderr = false,
+        args = {
+            "-f",
+            "json",
+            "./...",
+        },
+        format = "line",
+        check_exit_code = function(code)
+            return code <= 1
+        end,
+        on_output = function(line, params)
+            local decoded = vim.fn.json_decode(line)
+            if decoded.location.file == params.bufname then
+                return {
+                    row = decoded.location.line,
+                    col = decoded.location.column,
+                    end_row = decoded["end"]["line"],
+                    end_col = decoded["end"]["culumn"],
+                    source = "staticcheck",
+                    code = decoded.code,
+                    message = decoded.message,
+                    severity = severities[decoded.severity],
+                }
+            end
+            return nil
+        end,
+    },
+    factory = h.generator_factory,
+})


### PR DESCRIPTION
This PR will add staticcheck. Compared to the implementation I used for [nvim-lint](https://github.com/mfussenegger/nvim-lint/blob/master/lua/lint/linters/staticcheck.lua), the whole project will be linted instead of a single file. This prevents false positives like `undeclared name`.