### PR TITLE
Specify filename when calling isort

### DIFF
--- a/lua/null-ls/builtins/formatting/isort.lua
+++ b/lua/null-ls/builtins/formatting/isort.lua
@@ -10,6 +10,8 @@ return h.make_builtin({
         command = "isort",
         args = {
             "--stdout",
+            "--filename",
+            "$FILENAME",
             "-",
         },
         to_stdin = true,


### PR DESCRIPTION
Currently `isort` is formatting stub files (`.pyi` extension) incorrectly because it doesn't know whether the input is a stub file or a regular Python file. This PR fixes that problem by specifying the filename when calling `isort`.