### PR TITLE
feat(gitrebase): introduce gitrebase builtin

### DIFF
--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -2024,7 +2024,6 @@ local sources = { null_ls.builtins.diagnostics.staticcheck }
 - `command = "staticcheck"`
 - `args = { "-f", "json", "./..." }`
 
-
 ### Code actions
 
 #### [ESLint](https://github.com/eslint/eslint)
@@ -2080,6 +2079,22 @@ local sources = { null_ls.builtins.code_actions.gitsigns }
 ##### Defaults
 
 - `filetypes = {}`
+
+#### gitrebase
+
+##### About
+
+Inject actions to change gitrebase command. (eg. using `squash` instead of `pick`).
+
+##### Usage
+
+```lua
+local sources = { null_ls.builtins.code_actions.gitrebase }
+```
+
+##### Defaults
+
+- `filetypes = { "gitrebase" }`
 
 #### [proselint](https://github.com/amperser/proselint)
 

--- a/lua/null-ls/builtins/code_actions/gitrebase.lua
+++ b/lua/null-ls/builtins/code_actions/gitrebase.lua
@@ -1,0 +1,51 @@
+local h = require("null-ls.helpers")
+local methods = require("null-ls.methods")
+
+local CODE_ACTION = methods.internal.CODE_ACTION
+local ACTIONS = {
+    p = "pick",
+    r = "reword",
+    e = "edit",
+    s = "squash",
+    f = "fixup",
+    x = "exec",
+    b = "break",
+    d = "drop",
+}
+
+return h.make_builtin({
+    name = "gitrebase",
+    method = CODE_ACTION,
+    filetypes = { "gitrebase" },
+    generator = {
+        fn = function(params)
+            local lines = vim.api.nvim_buf_get_lines(params.bufnr, params.range.row - 1, params.range.row, true)
+            local line = lines[1]
+            local type = line:match("^(%a+)")
+
+            local found = false
+            local code_actions = {}
+            for short, full in pairs(ACTIONS) do
+                if short == type or full == type then
+                    found = true
+                else
+                    table.insert(code_actions, {
+                        title = full,
+                        action = function()
+                            local replacement = line:gsub("^(%a+)", full)
+                            vim.api.nvim_buf_set_lines(
+                                params.bufnr,
+                                params.range.row - 1,
+                                params.range.row,
+                                true,
+                                { replacement }
+                            )
+                        end,
+                    })
+                end
+            end
+
+            return found and code_actions or {}
+        end,
+    },
+})


### PR DESCRIPTION
Wrote this for me but I think it could be interesting as a builtin.

This introduce a code action to change the command of a line in an interactive git rebase.

Eg. this will switch from `pick abcede feat(gitrebase): introduce gitrebase builtin` to `fixup abcede feat(gitrebase): introduce gitrebase builtin`

Feel free to merge or decline ;)