### PR TITLE
feat(builtins): add shellcheck code actions

### DIFF
--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -2134,6 +2134,24 @@ local sources = { null_ls.builtins.code_actions.refactoring }
 
 - `filetypes = { "go", "javascript", "lua", "python", "typescript" }`
 
+#### [shellcheck](https://www.shellcheck.net)
+
+##### About
+
+A shell script static analysis tool.
+
+##### Usage
+
+```lua
+local sources = { null_ls.builtins.code_actions.shellcheck }
+```
+
+##### Defaults
+
+- `filetypes = { "sh" }`
+- `command = "shellcheck"`
+- `args = { "--format", "json1", "-" }`
+
 #### [statix](https://github.com/nerdypepper/statix)
 
 ##### About

--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -1796,7 +1796,7 @@ local sources = { null_ls.builtins.diagnostics.shellcheck }
 
 - `filetypes = { "sh" }`
 - `command = "shellcheck"`
-- `args = { "--format", "json1", "-" }`
+- `args = { "--format", "json1", "--source-path=$DIRNAME", "--external-sources", "-" }`
 
 #### [standardrb](https://github.com/testdouble/standard)
 
@@ -2150,7 +2150,7 @@ local sources = { null_ls.builtins.code_actions.shellcheck }
 
 - `filetypes = { "sh" }`
 - `command = "shellcheck"`
-- `args = { "--format", "json1", "-" }`
+- `args = { "--format", "json1", "--source-path=$DIRNAME", "--external-sources", "-" }`
 
 #### [statix](https://github.com/nerdypepper/statix)
 

--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -2138,7 +2138,21 @@ local sources = { null_ls.builtins.code_actions.refactoring }
 
 ##### About
 
-A shell script static analysis tool.
+Provides actions to disable ShellCheck errors/warnings, either for the
+current line or for the entire file.
+
+- Running the action to disable a rule for the current line adds a disable
+  directive above the line or appends the rule to an existing disable directive
+  for that line.
+- Running the action to disable a rule for the current file adds a disable
+  directive at the top of the file or appends the rule to an existing file
+  disable directive.
+- Note: the first non-comment line in a script is not eligible for a line-level
+  disable directive.
+  See [shellcheck#1877](https://github.com/koalaman/shellcheck/issues/1877).
+
+Consult the [ShellCheck wiki](https://github.com/koalaman/shellcheck/wiki/Ignore)
+for more information on disable directives.
 
 ##### Usage
 

--- a/lua/null-ls/builtins/code_actions/shellcheck.lua
+++ b/lua/null-ls/builtins/code_actions/shellcheck.lua
@@ -5,7 +5,7 @@ local CODE_ACTION = methods.internal.CODE_ACTION
 
 local blank_or_comment_line_regex = vim.regex([[^\s*\(#.*\)\?$]])
 local shebang_regex = vim.regex([[^#!]])
-local shellcheck_disable_regex = vim.regex([[^\s*#\s*shellcheck\s\+disable=\(\(SC\)\?\d\+\)\(,\(SC\)\?\d\+\)*\s*$]])
+local shellcheck_disable_regex = vim.regex([[^\s*#\s*shellcheck\s\+disable=\(\(SC\)\?\d\+\)\([,-]\(SC\)\?\d\+\)*\s*$]])
 local shellcheck_disable_pattern = "^%s*#%s*shellcheck%s+disable=([^%s]*)%s*$"
 
 -- Searches a region of the buffer `bufnr` for `regex`, returning the first match.

--- a/lua/null-ls/builtins/code_actions/shellcheck.lua
+++ b/lua/null-ls/builtins/code_actions/shellcheck.lua
@@ -1,0 +1,109 @@
+local h = require("null-ls.helpers")
+local methods = require("null-ls.methods")
+
+local CODE_ACTION = methods.internal.CODE_ACTION
+
+local shellcheck_disable_regex = vim.regex([[^\s*#\s*shellcheck\s\+disable=\(\(SC\)\?\d\+\)\(,\(SC\)\?\d\+\)*\s*$]])
+local shellcheck_disable_pattern = "^%s*#%s*shellcheck%s+disable=([^%s]*)%s*$"
+
+-- get_existing_disable gets a shellcheck disable string from linenr
+-- linenr is 1-indexed
+-- returns a string containing the disabled rules or nil
+--
+-- For example, given the following directive:
+-- # shellcheck disable=SC1234,4321
+--
+-- get_existing_disable would return SC1234,4321
+--
+-- TODO: handle blank lines between code and line
+local get_existing_disable = function(buf, linenr)
+    local line = vim.api.nvim_buf_get_lines(buf, linenr - 1, linenr, false)[1]
+    if not line or line == "" or not shellcheck_disable_regex:match_str(line) then
+        return
+    end
+    return ({ line:match(shellcheck_disable_pattern) })[1]
+end
+
+local generate_edit_line_action = function(title, bufnr, opts)
+    return {
+        title = title,
+        action = function()
+            local res = type(opts) == "function" and opts() or opts
+            vim.api.nvim_buf_set_lines(bufnr, res.first - 1, res.last - 1, false, { res.text })
+        end,
+    }
+end
+
+local generate_disable_actions = function(bufnr, code, row, indentation)
+    local actions = {}
+
+    local file_dest_line = 1
+    if vim.api.nvim_buf_get_lines(bufnr, 0, 1, false)[1]:match("^#!") then
+        -- Put the file disable comment after the shebang
+        file_dest_line = 2
+    end
+
+    local file_title = "Disable ShellCheck rule SC" .. code .. " for the entire file"
+
+    table.insert(
+        actions,
+        generate_edit_line_action(file_title, bufnr, function()
+            local file_existing_disable = get_existing_disable(bufnr, file_dest_line)
+            local file_codes = file_existing_disable and (file_existing_disable .. ",") or ""
+            return {
+                text = "# shellcheck disable=" .. file_codes .. code,
+                first = file_dest_line,
+                last = file_dest_line + (file_codes == "" and 0 or 1),
+            }
+        end)
+    )
+
+    local line_title = "Disable ShellCheck rule SC" .. code .. " for this line"
+
+    table.insert(
+        actions,
+        generate_edit_line_action(line_title, bufnr, function()
+            local line_existing_disable = get_existing_disable(bufnr, row - 1)
+            local line_codes = line_existing_disable and (line_existing_disable .. ",") or ""
+            return {
+                text = indentation .. "# shellcheck disable=" .. line_codes .. code,
+                first = row - (line_codes == "" and 0 or 1),
+                last = row,
+            }
+        end)
+    )
+
+    return actions
+end
+
+local handler = function(params)
+    local actions = {}
+
+    local row = params.row
+    local indentation = params.content[row]:match("^%s+") or ""
+
+    for _, comment in ipairs(params.output.comments) do
+        if row == comment.line then
+            vim.list_extend(actions, generate_disable_actions(params.bufnr, comment.code, params.row, indentation))
+        end
+    end
+
+    return actions
+end
+
+return h.make_builtin({
+    method = CODE_ACTION,
+    filetypes = { "sh" },
+    generator_opts = {
+        command = "shellcheck",
+        args = { "--format", "json1", "--source-path=$DIRNAME", "--external-sources", "-" },
+        to_stdin = true,
+        format = "json",
+        use_cache = true,
+        check_exit_code = function(code)
+            return code <= 1
+        end,
+        on_output = handler,
+    },
+    factory = h.generator_factory,
+})

--- a/lua/null-ls/builtins/code_actions/shellcheck.lua
+++ b/lua/null-ls/builtins/code_actions/shellcheck.lua
@@ -3,91 +3,115 @@ local methods = require("null-ls.methods")
 
 local CODE_ACTION = methods.internal.CODE_ACTION
 
+local blank_or_comment_line_regex = vim.regex([[^\s*\(#.*\)\?$]])
+local shebang_regex = vim.regex([[^#!]])
 local shellcheck_disable_regex = vim.regex([[^\s*#\s*shellcheck\s\+disable=\(\(SC\)\?\d\+\)\(,\(SC\)\?\d\+\)*\s*$]])
 local shellcheck_disable_pattern = "^%s*#%s*shellcheck%s+disable=([^%s]*)%s*$"
 
--- get_existing_disable gets a shellcheck disable string from linenr
--- linenr is 1-indexed
--- returns a string containing the disabled rules or nil
---
--- For example, given the following directive:
--- # shellcheck disable=SC1234,4321
---
--- get_existing_disable would return SC1234,4321
---
--- TODO: handle blank lines between code and line
-local get_existing_disable = function(buf, linenr)
-    local line = vim.api.nvim_buf_get_lines(buf, linenr - 1, linenr, false)[1]
-    if not line or line == "" or not shellcheck_disable_regex:match_str(line) then
-        return
+-- Searches a region of the buffer `bufnr` for a ShellCheck disable directive.
+-- The search proceeds from `row_start` to `row_end`.
+-- If `row_start` is greater than `row_end`, the region is effectively searched in reverse.
+-- A table representing first directive that's found is returned, otherwise nil.
+local find_disable_directive = function(bufnr, row_start, row_end)
+    local region_start, region_end
+    local idx_start, idx_end, step
+    if row_start > row_end then
+        region_start = row_end
+        region_end = row_start
+        idx_start = row_start - row_end
+        idx_end = 1
+        step = -1
+    else
+        region_start = row_start
+        region_end = row_end
+        idx_start = 1
+        idx_end = row_end - row_start
+        step = 1
     end
-    return ({ line:match(shellcheck_disable_pattern) })[1]
+    local lines = vim.api.nvim_buf_get_lines(bufnr, region_start, region_end, false)
+    for i = idx_start, idx_end, step do
+        local line = lines[i]
+        if line == nil then
+            return
+        end
+        if shellcheck_disable_regex:match_str(line) then
+            return {
+                codes = line:match(shellcheck_disable_pattern),
+                row = i + (step == 1 and row_start or row_end),
+            }
+        end
+        if not blank_or_comment_line_regex:match_str(line) then
+            return
+        end
+    end
 end
 
-local generate_edit_line_action = function(title, bufnr, opts)
+local get_first_non_shebang_row = function(bufnr)
+    return shebang_regex:match_line(bufnr, 0) and 1 or 0
+end
+
+local get_file_directive = function(bufnr)
+    local row_start = get_first_non_shebang_row(bufnr)
+    local row_end = vim.api.nvim_buf_line_count(bufnr)
+    return find_disable_directive(bufnr, row_start, row_end)
+end
+
+local get_line_directive = function(bufnr, row)
+    local file_directive = get_file_directive(bufnr)
+    local row_start = row - 1
+    local row_end = file_directive and file_directive.row or get_first_non_shebang_row(bufnr)
+    return find_disable_directive(bufnr, row_start, row_end)
+end
+
+local disable_action = function(bufnr, existing_directive, default_line, code, indentation)
+    local codes = code
+    local row_start = default_line - 1
+    local row_end = default_line - 1
+    if existing_directive then
+        codes = existing_directive.codes .. "," .. codes
+        row_start = existing_directive.row - 1
+        row_end = existing_directive.row
+    end
+    local directive = indentation .. "# shellcheck disable=" .. codes
+    vim.api.nvim_buf_set_lines(bufnr, row_start, row_end, false, { directive })
+end
+
+local generate_file_disable_action = function(bufnr, code)
     return {
-        title = title,
+        title = "Disable ShellCheck rule " .. code .. " for the entire file",
         action = function()
-            local res = type(opts) == "function" and opts() or opts
-            vim.api.nvim_buf_set_lines(bufnr, res.first - 1, res.last - 1, false, { res.text })
+            return disable_action(bufnr, get_file_directive(bufnr), get_first_non_shebang_row(bufnr) + 1, code, "")
+        end,
+    }
+end
+
+local generate_line_disable_action = function(bufnr, row, code, indentation)
+    return {
+        title = "Disable ShellCheck rule " .. code .. " for this line",
+        action = function()
+            return disable_action(bufnr, get_line_directive(bufnr, row), row, code, indentation)
         end,
     }
 end
 
 local generate_disable_actions = function(bufnr, code, row, indentation)
-    local actions = {}
-
-    local file_dest_line = 1
-    if vim.api.nvim_buf_get_lines(bufnr, 0, 1, false)[1]:match("^#!") then
-        -- Put the file disable comment after the shebang
-        file_dest_line = 2
-    end
-
-    local file_title = "Disable ShellCheck rule SC" .. code .. " for the entire file"
-
-    table.insert(
-        actions,
-        generate_edit_line_action(file_title, bufnr, function()
-            local file_existing_disable = get_existing_disable(bufnr, file_dest_line)
-            local file_codes = file_existing_disable and (file_existing_disable .. ",") or ""
-            return {
-                text = "# shellcheck disable=" .. file_codes .. code,
-                first = file_dest_line,
-                last = file_dest_line + (file_codes == "" and 0 or 1),
-            }
-        end)
-    )
-
-    local line_title = "Disable ShellCheck rule SC" .. code .. " for this line"
-
-    table.insert(
-        actions,
-        generate_edit_line_action(line_title, bufnr, function()
-            local line_existing_disable = get_existing_disable(bufnr, row - 1)
-            local line_codes = line_existing_disable and (line_existing_disable .. ",") or ""
-            return {
-                text = indentation .. "# shellcheck disable=" .. line_codes .. code,
-                first = row - (line_codes == "" and 0 or 1),
-                last = row,
-            }
-        end)
-    )
-
-    return actions
+    return {
+        generate_file_disable_action(bufnr, code),
+        generate_line_disable_action(bufnr, row, code, indentation),
+    }
 end
 
-local handler = function(params)
+local code_action_handler = function(params)
+    if not (params.output and params.output.comments) then
+        return
+    end
     local actions = {}
-
-    local row = params.row
-    local indentation = params.content[row]:match("^%s+") or ""
-
+    local indentation = params.content[params.row]:match("^%s+") or ""
     for _, comment in ipairs(params.output.comments) do
-        if row == comment.line then
+        if params.row == comment.line then
             vim.list_extend(actions, generate_disable_actions(params.bufnr, comment.code, params.row, indentation))
         end
     end
-
     return actions
 end
 
@@ -103,7 +127,7 @@ return h.make_builtin({
         check_exit_code = function(code)
             return code <= 1
         end,
-        on_output = handler,
+        on_output = code_action_handler,
     },
     factory = h.generator_factory,
 })


### PR DESCRIPTION
Adds shellcheck code actions to disable the rule under the cursor, either at the line level or the file level. If a `disable=` directive already exists, the rule’s code is appended to it.

Note: Shellcheck allows arbitrary blank lines between line directives and the target line or the shebang/BOF and the file-level directive. This case is currently not handled intelligently; a new directive is added rather than updating the existing one.

I didn't add tests because I don't see any tests for other code actions builtins. 