### PR TITLE
refactor!: remove 0.5.1 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ for external processes.
 null-ls is in **beta status**. Please see below for steps to follow if something
 doesn't work the way you expect (or doesn't work at all).
 
-At the moment, null-is is compatible with Neovim 0.5.1 (stable) and 0.6 (head),
+At the moment, null-is is compatible with Neovim 0.6.0 (stable) and 0.7 (head),
 but some features and performance improvements are exclusive to the latest
 version.
 

--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -1374,6 +1374,7 @@ local sources = { null_ls.builtins.formatting.uncrustify }
 ##### About
 
 Formatter for `python` files
+
 - Supports both `textDocument/formatting` and `textDocument/rangeFormatting`.
   - `textDocument/rangeFormatting` is line-based.
 
@@ -1973,11 +1974,9 @@ local sources = { null_ls.builtins.diagnostics.yamllint }
 
 ### Diagnostics on save
 
-**NOTE**: These sources depend on Neovim version 0.6.0 and are not compatible
-with previous versions.
-
-These sources run **only** on save, meaning that the diagnostics you see will
-not reflect changes to the buffer until you write the changes to the disk.
+**NOTE**: These sources run **only** on save, meaning that the diagnostics you
+see will not reflect changes to the buffer until you write the changes to the
+disk.
 
 You can configure built-in diagnostic sources to run on save by overriding
 `method`:

--- a/doc/SOURCES.md
+++ b/doc/SOURCES.md
@@ -122,9 +122,6 @@ Disables all sources matching `query`, preventing them from running under any
 conditions. See `get_source(query)` above for information about the structure of
 `query`.
 
-On Neovim versions >= 0.6.0, this will also clear diagnostics from disabled
-sources (you'll have to make a change to trigger an update on lower versions).
-
 ## enable(query)
 
 Enables all disabled sources matching `query`, allowing them to run again as

--- a/lua/null-ls/config.lua
+++ b/lua/null-ls/config.lua
@@ -19,8 +19,6 @@ local defaults = {
     },
     -- prevent double setup
     _setup = false,
-    -- force using LSP handler, even when native API is available (e.g diagnostics)
-    _use_lsp_handler = false,
 }
 
 local config = vim.deepcopy(defaults)

--- a/lua/null-ls/handlers.lua
+++ b/lua/null-ls/handlers.lua
@@ -1,38 +1,6 @@
-local u = require("null-ls.utils")
 local methods = require("null-ls.methods")
 
 local M = {}
-
-function M.setup()
-    -- code action batching is merged into master
-    if u.has_version("0.6.0") then
-        return
-    end
-
-    M.code_action_handler = M.combine(methods.lsp.CODE_ACTION)
-end
-
--- this will override a handler, batch results and debounce them
-function M.combine(method, ms)
-    ms = ms or 100
-
-    local orig = u.resolve_handler(method)
-    local all_results = {}
-
-    local handler = u.debounce(ms, function()
-        if #all_results > 0 then
-            pcall(orig, nil, all_results)
-            all_results = {}
-        end
-    end)
-
-    vim.lsp.handlers[method] = function(_, results)
-        vim.list_extend(all_results, results or {})
-        handler()
-    end
-
-    return vim.lsp.handlers[method]
-end
 
 M.setup_client = function(client)
     if client._null_ls_setup then

--- a/lua/null-ls/init.lua
+++ b/lua/null-ls/init.lua
@@ -30,7 +30,6 @@ M.config = function(user_config)
     c.setup(user_config or {})
     require("null-ls.lspconfig").setup()
     require("null-ls.rpc").setup()
-    require("null-ls.handlers").setup()
 
     vim.cmd("command! NullLsInfo lua require('null-ls').null_ls_info()")
     vim.cmd("command! NullLsLog lua vim.fn.execute('edit ' .. require('null-ls.logger').get_path())")

--- a/lua/null-ls/lspconfig.lua
+++ b/lua/null-ls/lspconfig.lua
@@ -18,12 +18,6 @@ local should_attach = function(bufnr)
     end
 
     local ft = api.nvim_buf_get_option(bufnr, "filetype")
-    -- writing and immediately deleting a buffer (e.g. :wq from a git commit)
-    -- triggers a bug on 0.5.1 which is fixed on master
-    if ft == "gitcommit" and not u.has_version("0.6.0") then
-        return false
-    end
-
     for _, source in ipairs(all_sources) do
         if sources.is_available(source, ft) then
             return true

--- a/lua/null-ls/rpc.lua
+++ b/lua/null-ls/rpc.lua
@@ -42,7 +42,7 @@ local capabilities = {
     textDocumentSync = {
         change = 1, -- prompt LSP client to send full document text on didOpen and didChange
         openClose = true,
-        save = u.has_version("0.6.0"),
+        save = true,
     },
 }
 

--- a/lua/null-ls/sources.lua
+++ b/lua/null-ls/sources.lua
@@ -1,6 +1,5 @@
 local methods = require("null-ls.methods")
 local diagnostics = require("null-ls.diagnostics")
-local u = require("null-ls.utils")
 
 local validate = vim.validate
 
@@ -195,11 +194,6 @@ M.validate_and_transform = function(source)
             },
         })
         method_map[method] = true
-    end
-
-    if method_map[methods.internal.DIAGNOSTICS_ON_SAVE] and not u.has_version("0.6.0") then
-        u.echo("WarningMsg", string.format("source %s is not supported on nvim versions < 0.6.0", name))
-        return
     end
 
     return {

--- a/test/spec/init_spec.lua
+++ b/test/spec/init_spec.lua
@@ -1,7 +1,6 @@
 local stub = require("luassert.stub")
 
 local config = require("null-ls.config")
-local handlers = require("null-ls.handlers")
 local rpc = require("null-ls.rpc")
 local lspconfig = require("null-ls.lspconfig")
 
@@ -24,14 +23,12 @@ describe("init", function()
             stub(config, "setup")
             stub(rpc, "setup")
             stub(lspconfig, "setup")
-            stub(handlers, "setup")
         end)
 
         after_each(function()
             config.setup:revert()
             rpc.setup:revert()
             lspconfig.setup:revert()
-            handlers.setup:revert()
 
             config.reset()
             vim.g.null_ls_disable = nil
@@ -60,7 +57,6 @@ describe("init", function()
             assert.stub(config.setup).was_called()
             assert.stub(rpc.setup).was_called()
             assert.stub(lspconfig.setup).was_called()
-            assert.stub(handlers.setup).was_called()
 
             assert.equals(vim.fn.exists(":NullLsInfo") > 0, true)
             assert.equals(vim.fn.exists(":NullLsLog") > 0, true)

--- a/test/spec/lspconfig_spec.lua
+++ b/test/spec/lspconfig_spec.lua
@@ -99,7 +99,6 @@ describe("lspconfig", function()
     end)
 
     describe("try_add", function()
-        local has_version = stub(u, "has_version")
         local try_add = stub.new()
         require("lspconfig")["null-ls"].manager = { try_add = try_add }
 
@@ -112,8 +111,6 @@ describe("lspconfig", function()
             vim.bo.buftype = ""
             vim.bo.filetype = ""
             try_add:clear()
-            u.has_version:clear()
-            u.has_version.returns(nil)
         end)
 
         it("should attach when source matches", function()
@@ -155,25 +152,6 @@ describe("lspconfig", function()
             lspconfig.try_add()
 
             assert.stub(try_add).was_not_called()
-        end)
-
-        it("should not attach when filetype is gitcommit and version is < 0.6.0", function()
-            vim.bo.filetype = "gitcommit"
-            sources.register(require("null-ls.builtins")._test.toggle_line_comment)
-
-            lspconfig.try_add()
-
-            assert.stub(try_add).was_not_called()
-        end)
-
-        it("should attach when filetype is gitcommit and version is >= 0.6.0", function()
-            sources.register(require("null-ls.builtins")._test.toggle_line_comment)
-            vim.bo.filetype = "gitcommit"
-            has_version.returns(true)
-
-            lspconfig.try_add()
-
-            assert.stub(try_add).was_called_with(vim.api.nvim_get_current_buf())
         end)
     end)
 end)

--- a/test/spec/sources_spec.lua
+++ b/test/spec/sources_spec.lua
@@ -384,17 +384,12 @@ describe("sources", function()
     describe("validate_and_transform", function()
         local mock_source
         before_each(function()
-            u.has_version.returns(true)
             mock_source = {
                 generator = { fn = function() end, opts = {}, async = false },
                 name = "mock generator",
                 filetypes = { "lua" },
                 method = methods.internal.FORMATTING,
             }
-        end)
-
-        after_each(function()
-            u.has_version:clear()
         end)
 
         it("should validate and return transformed source", function()
@@ -459,15 +454,6 @@ describe("sources", function()
             local validated = sources.validate_and_transform(function()
                 return nil
             end)
-
-            assert.falsy(validated)
-        end)
-
-        it("should return nil if nvim version does not support method", function()
-            mock_source.method = methods.internal.DIAGNOSTICS_ON_SAVE
-            u.has_version.returns(false)
-
-            local validated = sources.validate_and_transform(mock_source)
 
             assert.falsy(validated)
         end)

--- a/test/spec/utils_spec.lua
+++ b/test/spec/utils_spec.lua
@@ -330,85 +330,37 @@ describe("utils", function()
             end)
 
             describe("non-unix style line endings", function()
-                local has_version = stub(u, "has_version")
-                after_each(function()
-                    has_version:clear()
+                it("should content from params on DID_OPEN", function()
+                    vim.bo.fileformat = "dos"
+
+                    local params = u.make_params({
+                        method = methods.lsp.DID_OPEN,
+                        textDocument = { text = mock_content },
+                    }, mock_method)
+
+                    assert.same(params.content, { mock_content })
                 end)
 
-                describe("0.6", function()
-                    has_version.returns(true)
+                it("should get content from params on DID_CHANGE", function()
+                    vim.bo.fileformat = "dos"
 
-                    it("should content from params on DID_OPEN", function()
-                        vim.bo.fileformat = "dos"
+                    local params = u.make_params({
+                        method = methods.lsp.DID_CHANGE,
+                        contentChanges = { { text = mock_content } },
+                    }, mock_method)
 
-                        local params = u.make_params({
-                            method = methods.lsp.DID_OPEN,
-                            textDocument = { text = mock_content },
-                        }, mock_method)
-
-                        assert.same(params.content, { mock_content })
-                    end)
-
-                    it("should get content from params on DID_CHANGE", function()
-                        vim.bo.fileformat = "dos"
-
-                        local params = u.make_params({
-                            method = methods.lsp.DID_CHANGE,
-                            contentChanges = { { text = mock_content } },
-                        }, mock_method)
-
-                        assert.same(params.content, { mock_content })
-                    end)
-
-                    it("should directly get content from buffer if method does not match", function()
-                        vim.bo.fileformat = "dos"
-
-                        local params = u.make_params({
-                            method = "otherMethod",
-                            contentChanges = { { text = mock_content } },
-                        }, mock_method)
-
-                        assert.same(params.content, { 'print("I am a test file!")', "" })
-                    end)
+                    assert.same(params.content, { mock_content })
                 end)
 
-                describe("0.5.1", function()
-                    before_each(function()
-                        has_version.returns(false)
-                    end)
+                it("should directly get content from buffer if method does not match", function()
+                    vim.bo.fileformat = "dos"
 
-                    it("should directly get content from buffer on DID_OPEN", function()
-                        vim.bo.fileformat = "dos"
+                    local params = u.make_params({
+                        method = "otherMethod",
+                        contentChanges = { { text = mock_content } },
+                    }, mock_method)
 
-                        local params = u.make_params({
-                            method = methods.lsp.DID_OPEN,
-                            textDocument = { text = mock_content },
-                        }, mock_method)
-
-                        assert.same(params.content, { 'print("I am a test file!")', "" })
-                    end)
-
-                    it("should directly get content from buffer on DID_CHANGE", function()
-                        vim.bo.fileformat = "dos"
-
-                        local params = u.make_params({
-                            method = methods.lsp.DID_CHANGE,
-                            contentChanges = { { text = mock_content } },
-                        }, mock_method)
-
-                        assert.same(params.content, { 'print("I am a test file!")', "" })
-                    end)
-
-                    it("should directly get content from buffer if method does not match", function()
-                        vim.bo.fileformat = "dos"
-
-                        local params = u.make_params({
-                            method = "otherMethod",
-                            contentChanges = { { text = mock_content } },
-                        }, mock_method)
-
-                        assert.same(params.content, { 'print("I am a test file!")', "" })
-                    end)
+                    assert.same(params.content, { 'print("I am a test file!")', "" })
                 end)
             end)
         end)


### PR DESCRIPTION
This PR removes support for Neovim 0.5.1, which simplifies the code base and enables new 0.6-exclusive features (e.g. #376). The goal is to merge this in a couple of weeks once the new version is more widespread and keep a branch pinned at the last commit before merging (with the caveat that I will no longer write or merge fixes for 0.5.1). 