### PR TITLE
fix(teal): avoid duplicate registration

### DIFF
--- a/lua/null-ls/builtins/diagnostics/teal.lua
+++ b/lua/null-ls/builtins/diagnostics/teal.lua
@@ -4,6 +4,7 @@ local methods = require("null-ls.methods")
 local DIAGNOSTICS = methods.internal.DIAGNOSTICS
 
 return h.make_builtin({
+    name = "teal",
     method = DIAGNOSTICS,
     filetypes = { "teal" },
     generator_opts = {


### PR DESCRIPTION
Previously, the command is `tl` while the filename is `teal.lua`.
So it results in duplicate registration.
This PR fixes it by setting its name to `teal`