### PR TITLE
Add a builtin for using `gccdiag`

### DIFF
--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -1374,6 +1374,7 @@ local sources = { null_ls.builtins.formatting.uncrustify }
 ##### About
 
 Formatter for `python` files
+
 - Supports both `textDocument/formatting` and `textDocument/rangeFormatting`.
   - `textDocument/rangeFormatting` is line-based.
 
@@ -2045,6 +2046,16 @@ local sources = { null_ls.builtins.diagnostics.staticcheck }
 - `args = { "-f", "json", "./..." }`
 
 #### [gccdiag](https://gitlab.com/andrejr/gccdiag)
+
+##### About
+
+gccdiag is a wrapper for any C/C++ compiler (gcc, avr-gcc, arm-none-eabi-gcc,
+etc) that automatically uses the correct compiler arguments for a file in your
+project by parsing the `compile_commands.json` file at the root of your
+project.
+
+This builtin will call gccdiag and display the diagnostics like any other LSP
+server.
 
 ##### Usage
 

--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -2044,6 +2044,20 @@ local sources = { null_ls.builtins.diagnostics.staticcheck }
 - `command = "staticcheck"`
 - `args = { "-f", "json", "./..." }`
 
+#### [gccdiag](https://gitlab.com/andrejr/gccdiag)
+
+##### Usage
+
+```lua
+local sources = { null_ls.builtins.diagnostics.gccdiag }
+```
+
+##### Defaults
+
+- `filetypes = { "c", "cpp" }`
+- `command = "gccdiag"`
+- `args = { "--default-args", "-S -x $FILEEXT", "-i", "-fdiagnostics-color", "--", "$FILENAME" }`
+
 ### Code actions
 
 #### [ESLint](https://github.com/eslint/eslint)

--- a/lua/null-ls/builtins/diagnostics/gccdiag.lua
+++ b/lua/null-ls/builtins/diagnostics/gccdiag.lua
@@ -1,0 +1,35 @@
+local h = require("null-ls.helpers")
+local methods = require("null-ls.methods")
+
+return h.make_builtin({
+    method = methods.internal.DIAGNOSTICS_ON_SAVE,
+    filetypes = { "c", "cpp" },
+    factory = h.generator_factory,
+    generator_opts = {
+        command = "gccdiag",
+        args = {
+            "--default-args",
+            "-S -x $FILEEXT",
+            "-i",
+            "-fdiagnostics-color",
+            "--",
+            "$FILENAME",
+        },
+        to_stdin = false,
+        from_stderr = true,
+        format = "line",
+        on_output = h.diagnostics.from_pattern(
+            [[^([^:]+):(%d+):(%d+):%s+([^:]+):%s+(.*)$]],
+            -- [[(%w+):(%d+):(%d+): (%w+): (.*)]],
+            { "file", "row", "col", "severity", "message" },
+            {
+                severities = {
+                    ["fatal error"] = h.diagnostics.severities.error,
+                    ["error"] = h.diagnostics.severities.error,
+                    ["note"] = h.diagnostics.severities.information,
+                    ["warning"] = h.diagnostics.severities.warning,
+                },
+            }
+        ),
+    },
+})


### PR DESCRIPTION
Get diagnostics from gcc with the correct compiler arguments

Requires a `compiler_commands.json` file at the root of the working directory.
