### PR TITLE
feat(diagnostics): add ansible-lint

### DIFF
--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -1409,6 +1409,24 @@ local sources = { null_ls.builtins.formatting.zigfmt }
 
 ### Diagnostics
 
+#### [ansible-lint](https://github.com/ansible-community/ansible-lint)
+
+##### About
+
+Linter for Ansible playbooks, roles and collections.
+
+##### Usage
+
+```lua
+local sources = { null_ls.builtins.diagnostics.ansiblelint }
+```
+
+##### Defaults
+
+- `filetypes = { "yaml" }`
+- `command = "ansible-lint"`
+- `args = { "--parseable-severity", "-q", "--nocolor", "$FILENAME" }`
+
 #### [chktex](https://www.nongnu.org/chktex/)
 
 ##### About

--- a/lua/null-ls/builtins/diagnostics/ansiblelint.lua
+++ b/lua/null-ls/builtins/diagnostics/ansiblelint.lua
@@ -1,0 +1,34 @@
+local h = require("null-ls.helpers")
+local methods = require("null-ls.methods")
+
+local DIAGNOSTICS = methods.internal.DIAGNOSTICS
+
+return h.make_builtin({
+    method = DIAGNOSTICS,
+    filetypes = { "yaml" },
+    generator_opts = {
+        command = "ansible-lint",
+        to_stdin = true,
+        ignore_stderr = true,
+        args = { "--parseable-severity", "-q", "--nocolor", "$FILENAME" },
+        format = "line",
+        check_exit_code = function(code)
+            return code <= 2
+        end,
+        on_output = h.diagnostics.from_pattern(
+            [[^[^:]+:(%d+): %[[%w-]+%] %[([%w]+)%] (.*)$]],
+            { "row", "severity", "message" },
+            {
+                severities = {
+                    ["VERY_HIGH"] = h.diagnostics.severities.error,
+                    ["HIGH"] = h.diagnostics.severities.error,
+                    ["MEDIUM"] = h.diagnostics.severities.warning,
+                    ["LOW"] = h.diagnostics.severities.warning,
+                    ["VERY_LOW"] = h.diagnostics.severities.information,
+                    ["INFO"] = h.diagnostics.severities.hint,
+                },
+            }
+        ),
+    },
+    factory = h.generator_factory,
+})


### PR DESCRIPTION
Tihs PR adds [ansible-lint](https://github.com/ansible-community/ansible-lint) as a diagnostic source.

It should respect `.ansible-lint` as well.
