### PR TITLE
feat: add :checkhealth support (WIP)

### DIFF
--- a/lua/null-ls/health.lua
+++ b/lua/null-ls/health.lua
@@ -13,8 +13,8 @@ local messages = {
 
 local function report(source)
     local name = source.name
-    local only_local = source.generator.opts.only_local
-    local command = source.generator.opts.command
+    local only_local = source.generator.opts and source.generator.opts.only_local
+    local command = source.generator.opts and source.generator.opts.command
 
     if type(command) ~= "string" then
         health.report_info(string.format(messages["unable"], name, command))

--- a/lua/null-ls/health.lua
+++ b/lua/null-ls/health.lua
@@ -1,0 +1,43 @@
+local health = require("health")
+local sources = require("null-ls.sources")
+local utils = require("null-ls.utils")
+
+local M = {}
+
+local messages = {
+    ["executable"] = [[%s: the command "%s" is executable.]],
+    ["not-executable"] = [[%s: the command "%s" is not executable.]],
+    ["unable"] = [[%s: cannot verify if the command is an executable.]],
+    ["executable-local"] = [[%s: the command "%s" is not globally executable, but it may be available locally.]],
+}
+
+local function report(source)
+    local name = source.name
+    local only_local = source.generator.opts.only_local
+    local command = source.generator.opts.command
+
+    if type(command) ~= "string" then
+        health.report_info(string.format(messages["unable"], name, command))
+        return
+    end
+
+    if utils.is_executable(command) then
+        health.report_ok(string.format(messages["executable"], name, command))
+        return
+    end
+
+    if only_local then
+        health.report_warn(string.format(messages["executable-local"], name, command))
+        return
+    end
+
+    health.report_error(string.format(messages["not-executable"], name, command))
+end
+
+M.check = function()
+    for _, source in ipairs(sources.get({})) do
+        report(source)
+    end
+end
+
+return M


### PR DESCRIPTION
This is a basic implementation of the `:checkhealth` functionality.

Closes #392.

I used the following `Dockerfile` and `init.lua` to test the functionality. Inside the Docker container I just opened `nvim` and executed `:checkhealth null-ls`.


<details>
<summary><code>Dockerfile</code></summary>

```Dockerfile
FROM debian:buster-slim
FROM rust:latest

# Install dependencies
RUN apt-get update && apt-get install -y curl git nodejs npm python3 python3-pip
RUN cargo install stylua
RUN pip3 install black
RUN npm i -g prettier @fsouza/prettierd markdownlint-cli

# Install Neovim
WORKDIR /tmp
RUN curl -LO https://github.com/neovim/neovim/releases/download/v0.6.0/nvim-linux64.tar.gz
RUN tar xzf nvim-linux64.tar.gz -C /opt
ENV PATH /opt/nvim-linux64/bin:$PATH

# Install plugins
WORKDIR /root/.local/share/nvim/site/pack/packer/start
RUN git clone https://github.com/nvim-lua/plenary.nvim
RUN git clone https://github.com/neovim/nvim-lspconfig

# Deploy plugin
COPY . /root/.local/share/nvim/site/pack/packer/start/null-ls.nvim/
COPY test-init.lua /root/.config/nvim/init.lua

# Finish
WORKDIR /root
```

</details>

<details>
<summary><code>init.lua</code></summary>

```lua
require("null-ls").config({
    sources = {
        require("null-ls").builtins.formatting.stylua,
        require("null-ls").builtins.formatting.prettierd,
        require("null-ls").builtins.formatting.markdownlint,
        require("null-ls").builtins.formatting.black,
        require("null-ls").builtins.formatting.sqlformat,
        require("null-ls").builtins.completion.spell,
        require("null-ls").builtins.code_actions.gitsigns,
    },
})

require("lspconfig")["null-ls"].setup({})
```

</details>


## TODO list

- [x] Add `:checkhealth` command support.
- [x] Add support for when command is an string.
- [x] Add support for when command is a function.
- [X] Add support for when command is nil.
- [x] Add support for `prefer_local` and `only_local`.
- [ ] add the flag to check if it should check executable.

I don't know how to support `prefer_local` or `only_local`, I would need guidance with that.

**Note:** do you have any builtin that uses the command as a function?, haven't found any to test it yet.