### PR TITLE
Update MAIN.md

### DIFF
--- a/doc/MAIN.md
+++ b/doc/MAIN.md
@@ -73,7 +73,7 @@ my_source.method = null_ls.methods.FORMATTING
 my_source.method = null_ls.methods.HOVER
 
 -- source will run on LSP completion request
-my_source.method = null_ls.methods.completion
+my_source.method = null_ls.methods.COMPLETION
 ```
 
 ### Filetypes


### PR DESCRIPTION
I was following the MAIN.md doc to create a completion source, the doc shows a lowercase `completion` when all other methods are all caps...the lowercase variety was giving an error so I tried uppercasing it which worked. 