### PR TITLE
Add djhtml formatter

### DIFF
--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -443,6 +443,24 @@ local sources = { null_ls.builtins.formatting.dfmt }
 - `command = "dfmt"`
 - `args = {}`
 
+#### [djhtml](https://github.com/rtts/djhtml)
+
+##### About
+
+A pure-Python Django/Jinja template indenter without dependencies.
+
+##### Usage
+
+```lua
+local sources = { null_ls.builtins.formatting.djhtml }
+```
+
+##### Defaults
+
+- `filetypes = { "django", "jinja.html", "htmldjango" }`
+- `command = "djhtml"`
+- `args = {}`
+
 #### [elm-format](https://github.com/avh4/elm-format)
 
 ##### About

--- a/lua/null-ls/builtins/formatting/djhtml.lua
+++ b/lua/null-ls/builtins/formatting/djhtml.lua
@@ -1,0 +1,14 @@
+local h = require("null-ls.helpers")
+local methods = require("null-ls.methods")
+
+local FORMATTING = methods.internal.FORMATTING
+
+return h.make_builtin({
+    method = FORMATTING,
+    filetypes = { "django", "jinja.html", "htmldjango" },
+    generator_opts = {
+        command = "djhtml",
+        to_stdin = true,
+    },
+    factory = h.formatter_factory,
+})


### PR DESCRIPTION
Add [djhtml](https://github.com/rtts/djhtml) as formatting source.

I tried to run the tests but they broke in my face with some error that didn't found a module `plenary.test_harness`, checking out other PRs that add new sources I see they don't add any test so I guess this part of the code doesn't require tests at the time being, if they do let me know.