### PR TITLE
Make shellharden overwrite rather than output to stdout

### DIFF
--- a/lua/null-ls/builtins/formatting/shellharden.lua
+++ b/lua/null-ls/builtins/formatting/shellharden.lua
@@ -10,8 +10,8 @@ return h.make_builtin({
     },
     generator_opts = {
         command = "shellharden",
-        args = { "--transform", "$FILENAME" },
-        to_stdin = false,
+        args = { "--transform", "" },
+        to_stdin = true,
     },
     factory = h.formatter_factory,
 })


### PR DESCRIPTION
When I enable the shellharden builtin, I encounter a bug whereby any modifications I make to a file are reverted when saving the file.

I found that I could work around this by modifying the parameters given to shellharden when configuring null-ls; this change makes those the default.