### PR TITLE
feat: Improve cspell

### DIFF
--- a/lua/null-ls/builtins/diagnostics/cspell.lua
+++ b/lua/null-ls/builtins/diagnostics/cspell.lua
@@ -3,28 +3,26 @@ local methods = require("null-ls.methods")
 
 local DIAGNOSTICS = methods.internal.DIAGNOSTICS
 
-return h.make_builtin(
-  {
+return h.make_builtin({
     method = DIAGNOSTICS,
     filetypes = {},
     generator_opts = {
-      command = "cspell",
-      args = {"stdin"},
-      to_stdin = true,
-      ignore_stderr = true,
-      format = "line",
-      check_exit_code = function(code)
-        return code <= 1
-      end,
-      on_output = h.diagnostics.from_pattern(
-        [[.*:(%d+):(%d+)%s*-%s*(.*%((.*)%))]],
-        {"row", "col", "message", "_quote"},
-        {
-          adapters = {h.diagnostics.adapters.end_col.from_quote},
-          offsets = {end_col = 1}
-        }
-      )
+        command = "cspell",
+        args = { "stdin" },
+        to_stdin = true,
+        ignore_stderr = true,
+        format = "line",
+        check_exit_code = function(code)
+            return code <= 1
+        end,
+        on_output = h.diagnostics.from_pattern(
+            [[.*:(%d+):(%d+)%s*-%s*(.*%((.*)%))]],
+            { "row", "col", "message", "_quote" },
+            {
+              adapters = { h.diagnostics.adapters.end_col.from_quote },
+              offsets = { end_col = 1 }
+            }
+        )
     },
-    factory = h.generator_factory
-  }
-)
+    factory = h.generator_factory,
+})

--- a/lua/null-ls/builtins/diagnostics/cspell.lua
+++ b/lua/null-ls/builtins/diagnostics/cspell.lua
@@ -3,19 +3,28 @@ local methods = require("null-ls.methods")
 
 local DIAGNOSTICS = methods.internal.DIAGNOSTICS
 
-return h.make_builtin({
+return h.make_builtin(
+  {
     method = DIAGNOSTICS,
-    filetypes = { "markdown" },
+    filetypes = {},
     generator_opts = {
-        command = "cspell",
-        args = { "stdin" },
-        to_stdin = true,
-        ignore_stderr = true,
-        format = "line",
-        check_exit_code = function(code)
-            return code <= 1
-        end,
-        on_output = h.diagnostics.from_pattern([[.*:(%d+):(%d+)%s*-%s*(.*)]], { "row", "col", "message" }),
+      command = "cspell",
+      args = {"stdin"},
+      to_stdin = true,
+      ignore_stderr = true,
+      format = "line",
+      check_exit_code = function(code)
+        return code <= 1
+      end,
+      on_output = h.diagnostics.from_pattern(
+        [[.*:(%d+):(%d+)%s*-%s*(.*%((.*)%))]],
+        {"row", "col", "message", "_quote"},
+        {
+          adapters = {h.diagnostics.adapters.end_col.from_quote},
+          offsets = {end_col = 1}
+        }
+      )
     },
-    factory = h.generator_factory,
-})
+    factory = h.generator_factory
+  }
+)

--- a/lua/null-ls/builtins/diagnostics/cspell.lua
+++ b/lua/null-ls/builtins/diagnostics/cspell.lua
@@ -20,9 +20,9 @@ return h.make_builtin({
             { "row", "col", "message", "_quote" },
             {
               adapters = { h.diagnostics.adapters.end_col.from_quote },
-              offsets = { end_col = 1 }
+              offsets = { end_col = 1 },
             }
-        )
+        ),
     },
     factory = h.generator_factory,
 })

--- a/lua/null-ls/builtins/diagnostics/cspell.lua
+++ b/lua/null-ls/builtins/diagnostics/cspell.lua
@@ -19,8 +19,8 @@ return h.make_builtin({
             [[.*:(%d+):(%d+)%s*-%s*(.*%((.*)%))]],
             { "row", "col", "message", "_quote" },
             {
-              adapters = { h.diagnostics.adapters.end_col.from_quote },
-              offsets = { end_col = 1 },
+                adapters = { h.diagnostics.adapters.end_col.from_quote },
+                offsets = { end_col = 1 },
             }
         ),
     },


### PR DESCRIPTION
1. Activate cspell on all files (as indicated in BUILTINS.md)
2. Only underline the incorrect word, and not the entire line from the
   word on