### PR TITLE
fix: pass 'null' to vim.json.decode() when there is no output.

### DIFF
--- a/lua/null-ls/helpers.lua
+++ b/lua/null-ls/helpers.lua
@@ -57,7 +57,7 @@ local parse_args = function(args, params)
 end
 
 local json_output_wrapper = function(params, done, on_output, format)
-    local ok, decoded = pcall(vim.json.decode, params.output)
+    local ok, decoded = pcall(vim.json.decode, params.output or "null")
     if decoded == vim.NIL or decoded == "" then
         decoded = nil
     end


### PR DESCRIPTION
After updating to the most recent version of null-ls, I get the following error when `vint` doesn't return any errors:

```
[null-ls] [WARN  10:24:30] .../pack/packer/opt/null-ls.nvim/lua/null-ls/generators.lua:39: failed to run generator: ...ite/pack/packer/opt/null-ls.nvim/lua/null-ls/helpe
rs.lua:67: failed to decode json: bad argument #1 to '?' (string expected, got nil)
```

It's because passing `nil` to `vim.json.decode()` produces the above error. This seems to fix the problem.