### PR TITLE
Add nil-value check to handle_single_file_diagnostics

### DIFF
--- a/lua/null-ls/diagnostics.lua
+++ b/lua/null-ls/diagnostics.lua
@@ -70,6 +70,9 @@ local postprocess = function(diagnostic, _, generator)
 end
 
 local handle_single_file_diagnostics = function(namespace, diagnostics, bufnr)
+    if vim.diagnostic == nil then
+        return
+    end
     vim.diagnostic.set(namespace, bufnr, diagnostics)
 end
 


### PR DESCRIPTION
This MR contains a commit that adds nil-value check to the method (line#73) as at some point, for a fraction of a second, `vim.diagnostic` is `nil` resulting in the whole sequence of whatever happening in `diagnostics` file failing. This is happening to me at every buffer open, as well as at saving with format. 

It is worth noting that I'm using nvim 0.5.1, and not 0.6.0 (current version in fedora repos), and I'm not sure if this commit would break anything with nvim 0.6.0, but I assume it should be harmless.