### PR TITLE
Fix: url for Flake8 in BUILTINS.md

### DIFF
--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -1606,7 +1606,7 @@ local sources = { null_ls.builtins.diagnostics.eslint_d }
 - `command = "eslint_d"`
 - `args = { "-f", "json", "--stdin", "--stdin-filename", "$FILENAME" }`
 
-#### [flake8](https://github.com/PyCGA/flake8)
+#### [flake8](https://github.com/PyCQA/flake8)
 
 ##### About
 


### PR DESCRIPTION
Just fixing the link to the Flake8 Github page.