### PR TITLE
Pass STDERR to check_exit_code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: test
 test:
-	nvim --headless -u test/minimal.vim -c "lua require(\"plenary.test_harness\").test_directory_command('test/spec {minimal_init = \"test/minimal.vim\"}')"
+	nvim --headless --noplugin -u test/minimal.vim -c "lua require(\"plenary.test_harness\").test_directory_command('test/spec {minimal_init = \"test/minimal.vim\"}')"
 
 .PHONY: test-file
 test-file:

--- a/README.md
+++ b/README.md
@@ -149,8 +149,16 @@ local markdownlint = {
         from_stderr = true,
         -- choose an output format (raw, json, or line)
         format = "line",
-        check_exit_code = function(code)
-            return code <= 1
+        check_exit_code = function(code, stderr)
+            local success = code <= 1
+
+            if not success then
+              -- can be noisy for things that run often (e.g. diagnostics), but can
+              -- be useful for things that run on demand (e.g. formatting)
+              print(stderr)
+            end
+
+            return success
         end,
         -- use helpers to parse the output from string matchers,
         -- or parse it manually with a function

--- a/doc/HELPERS.md
+++ b/doc/HELPERS.md
@@ -136,9 +136,13 @@ Sends the current buffer's content to the spawned command via `stdin`.
 ### check_exit_code
 
 Can either be a table of valid exit codes (numbers) or a callback that receives
-one argument, `code`, which containing the exit code from the spawned command as
-a number. The callback should return a boolean value indicating whether the code
-indicates success.
+two arguments:
+
+`code`: contains the exit code from the spawned command as a number
+`stderr`: error output from the job as a string
+
+The callback should return a boolean value indicating whether the code
+indicates _success_.
 
 If not specified, null-ls will assume that a non-zero exit code indicates
 failure.

--- a/lua/null-ls/loop.lua
+++ b/lua/null-ls/loop.lua
@@ -74,17 +74,9 @@ M.spawn = function(cmd, args, opts)
 
     local handle
     local on_close = function(code)
-        local exit_ok
-        if code == TIMEOUT_EXIT_CODE then
-            exit_ok = false
-        elseif check_exit_code then
-            exit_ok = check_exit_code(code)
-        else
-            exit_ok = code == 0
-        end
-
         stdout:read_stop()
         stderr:read_stop()
+
         if on_stdout_end then
             on_stdout_end()
         end
@@ -93,6 +85,16 @@ M.spawn = function(cmd, args, opts)
         close_handle(stdout)
         close_handle(stderr)
         close_handle(handle)
+
+        local exit_ok
+        if code == TIMEOUT_EXIT_CODE then
+            exit_ok = false
+        elseif check_exit_code then
+            exit_ok = check_exit_code(code, error_output)
+        else
+            exit_ok = code == 0
+        end
+
         done(exit_ok, code == TIMEOUT_EXIT_CODE)
     end
 

--- a/test/spec/loop_spec.lua
+++ b/test/spec/loop_spec.lua
@@ -274,7 +274,7 @@ describe("loop", function()
                 local on_close = uv.spawn.calls[1].refs[3]
                 on_close(255)
 
-                assert.stub(check_exit_code).was_called_with(255)
+                assert.stub(check_exit_code).was_called_with(255, "")
                 assert.stub(done).was_called_with(false, false)
             end)
 


### PR DESCRIPTION
Obviously this is not super useful for things like diagnostics, but for something that doesn't run as often (like formatters) it is useful to be able to do something like:

```lua
local function check_exit_code(code, stderr)
  local success = code == 0
  if not success then
    vim.notify({ "Formatting failed", stderr })
  end
  
  return success
end
```

to know _why_ the operation failed. There are other things that could be passed here (e.g. `stdout`) but I only really see a use case for `stderr`.