### PR TITLE
fix(diagnostics): Use raw substring for credo

### DIFF
--- a/lua/null-ls/builtins/_meta/completion.lua
+++ b/lua/null-ls/builtins/_meta/completion.lua
@@ -1,6 +1,9 @@
 -- THIS FILE IS GENERATED. DO NOT EDIT MANUALLY.
 -- stylua: ignore
 return {
+  luasnip = {
+    filetypes = {}
+  },
   spell = {
     filetypes = {}
   },

--- a/lua/null-ls/builtins/_meta/diagnostics.lua
+++ b/lua/null-ls/builtins/_meta/diagnostics.lua
@@ -17,7 +17,7 @@ return {
     filetypes = { "elixir" }
   },
   cspell = {
-    filetypes = { "markdown" }
+    filetypes = {}
   },
   eslint = {
     filetypes = { "javascript", "javascriptreact", "typescript", "typescriptreact", "vue" }
@@ -49,6 +49,9 @@ return {
   mypy = {
     filetypes = { "python" }
   },
+  php = {
+    filetypes = { "php" }
+  },
   phpcs = {
     filetypes = { "php" }
   },
@@ -70,6 +73,9 @@ return {
   qmllint = {
     filetypes = { "qml" }
   },
+  revive = {
+    filetypes = { "go" }
+  },
   rubocop = {
     filetypes = { "ruby" }
   },
@@ -81,6 +87,9 @@ return {
   },
   standardrb = {
     filetypes = { "ruby" }
+  },
+  staticcheck = {
+    filetypes = { "go" }
   },
   statix = {
     filetypes = { "nix" }

--- a/lua/null-ls/builtins/_meta/filetype_map.lua
+++ b/lua/null-ls/builtins/_meta/filetype_map.lua
@@ -26,13 +26,16 @@ return {
   },
   css = {
     diagnostics = { "stylelint" },
-    formatting = { "prettier", "prettier_d_slim", "prettierd", "stylelint" }
+    formatting = { "prettier", "prettierd", "prettier_d_slim", "stylelint" }
   },
   d = {
     formatting = { "dfmt" }
   },
   dart = {
     formatting = { "dart_format" }
+  },
+  django = {
+    formatting = { "djhtml" }
   },
   dockerfile = {
     diagnostics = { "hadolint" }
@@ -60,40 +63,49 @@ return {
     formatting = { "fprettify" }
   },
   go = {
-    diagnostics = { "golangci_lint" },
+    diagnostics = { "golangci_lint", "revive", "staticcheck" },
     formatting = { "gofmt", "gofumpt", "goimports", "golines" }
   },
   graphql = {
-    formatting = { "prettier", "prettier_d_slim", "prettierd" }
+    formatting = { "prettier", "prettierd", "prettier_d_slim" }
+  },
+  haskell = {
+    formatting = { "brittany" }
   },
   html = {
-    formatting = { "prettier", "prettier_d_slim", "prettierd", "rustywind" }
+    formatting = { "prettier", "prettierd", "prettier_d_slim", "rustywind" }
+  },
+  htmldjango = {
+    formatting = { "djhtml" }
   },
   java = {
     formatting = { "clang_format", "google_java_format", "uncrustify" }
   },
   javascript = {
     diagnostics = { "eslint", "eslint_d" },
-    formatting = { "deno_fmt", "eslint", "eslint_d", "prettier", "prettier_d_slim", "prettierd", "rustywind" }
+    formatting = { "deno_fmt", "eslint", "eslint_d", "prettier", "prettierd", "prettier_d_slim", "rustywind" }
   },
   javascriptreact = {
     diagnostics = { "eslint", "eslint_d" },
-    formatting = { "deno_fmt", "eslint", "eslint_d", "prettier", "prettier_d_slim", "prettierd", "rustywind" }
+    formatting = { "deno_fmt", "eslint", "eslint_d", "prettier", "prettierd", "prettier_d_slim", "rustywind" }
+  },
+  ["jinja.html"] = {
+    formatting = { "djhtml" }
   },
   json = {
-    formatting = { "fixjson", "json_tool", "prettier", "prettier_d_slim", "prettierd" }
+    formatting = { "fixjson", "json_tool", "prettier", "prettierd", "prettier_d_slim" }
   },
   less = {
     diagnostics = { "stylelint" },
-    formatting = { "prettier", "prettier_d_slim", "prettierd", "stylelint" }
+    formatting = { "prettier", "prettierd", "prettier_d_slim", "stylelint" }
   },
   lua = {
     diagnostics = { "luacheck", "selene" },
     formatting = { "lua_format", "stylua" }
   },
   markdown = {
-    diagnostics = { "cspell", "markdownlint", "proselint", "vale", "write_good" },
-    formatting = { "markdownlint", "prettier", "prettier_d_slim", "prettierd" },
+    diagnostics = { "markdownlint", "proselint", "vale", "write_good" },
+    formatting = { "markdownlint", "prettier", "prettierd", "prettier_d_slim" },
     hover = { "dictionary" }
   },
   nginx = {
@@ -107,7 +119,7 @@ return {
     formatting = { "perltidy" }
   },
   php = {
-    diagnostics = { "phpcs", "phpstan", "psalm" },
+    diagnostics = { "php", "phpcs", "phpstan", "psalm" },
     formatting = { "phpcbf", "phpcsfixer" }
   },
   prisma = {
@@ -143,7 +155,7 @@ return {
   },
   scss = {
     diagnostics = { "stylelint" },
-    formatting = { "prettier", "prettier_d_slim", "prettierd", "stylelint" }
+    formatting = { "prettier", "prettierd", "prettier_d_slim", "stylelint" }
   },
   sh = {
     diagnostics = { "shellcheck" },
@@ -181,22 +193,22 @@ return {
   },
   typescript = {
     diagnostics = { "eslint", "eslint_d", "tsc" },
-    formatting = { "deno_fmt", "eslint", "eslint_d", "prettier", "prettier_d_slim", "prettierd", "rustywind" }
+    formatting = { "deno_fmt", "eslint", "eslint_d", "prettier", "prettierd", "prettier_d_slim", "rustywind" }
   },
   typescriptreact = {
     diagnostics = { "eslint", "eslint_d", "tsc" },
-    formatting = { "deno_fmt", "eslint", "eslint_d", "prettier", "prettier_d_slim", "prettierd", "rustywind" }
+    formatting = { "deno_fmt", "eslint", "eslint_d", "prettier", "prettierd", "prettier_d_slim", "rustywind" }
   },
   vim = {
     diagnostics = { "vint" }
   },
   vue = {
     diagnostics = { "eslint", "eslint_d" },
-    formatting = { "eslint", "eslint_d", "prettier", "prettier_d_slim", "prettierd", "rustywind" }
+    formatting = { "eslint", "eslint_d", "prettier", "prettierd", "prettier_d_slim", "rustywind" }
   },
   yaml = {
     diagnostics = { "ansiblelint", "yamllint" },
-    formatting = { "prettier", "prettier_d_slim", "prettierd" }
+    formatting = { "prettier", "prettierd", "prettier_d_slim" }
   },
   zig = {
     formatting = { "zigfmt" }

--- a/lua/null-ls/builtins/_meta/formatting.lua
+++ b/lua/null-ls/builtins/_meta/formatting.lua
@@ -13,6 +13,9 @@ return {
   black = {
     filetypes = { "python" }
   },
+  brittany = {
+    filetypes = { "haskell" }
+  },
   clang_format = {
     filetypes = { "c", "cpp", "cs", "java" }
   },
@@ -33,6 +36,9 @@ return {
   },
   dfmt = {
     filetypes = { "d" }
+  },
+  djhtml = {
+    filetypes = { "django", "jinja.html", "htmldjango" }
   },
   elm_format = {
     filetypes = { "elm" }

--- a/lua/null-ls/builtins/diagnostics/credo.lua
+++ b/lua/null-ls/builtins/diagnostics/credo.lua
@@ -3,6 +3,14 @@ local methods = require("null-ls.methods")
 
 local DIAGNOSTICS = methods.internal.DIAGNOSTICS
 
+local function generic_issue(message)
+    return {
+        message = message,
+        row = 1,
+        source = "credo",
+    }
+end
+
 return h.make_builtin({
     name = "credo",
     method = DIAGNOSTICS,
@@ -20,64 +28,69 @@ return h.make_builtin({
             end
         end,
         args = { "credo", "suggest", "--format", "json", "--read-from-stdin", "$FILENAME" },
-        format = "json_raw",
+        format = "raw",
         to_stdin = true,
         from_stderr = true,
         on_output = function(params)
             local issues = {}
 
-            if params.err and params.err:find("{") then
-                local i, _ = params.err:find("{")
-                local maybe_json_string = params.err:sub(i)
-
-                local ok, decoded = pcall(vim.json.decode, maybe_json_string)
-
-                if ok then
-                    params.output = decoded
-                    params.err = nil
-                end
-            end
-
-            if params.output and params.output.issues then
-                for _, issue in ipairs(params.output.issues) do
-                    local err = {
-                        message = issue.message,
-                        row = issue.line_no,
-                        source = "credo",
-                    }
-
-                    --NOTE: priority is dynamic, ranges are from credo source
-                    --could use `from_json` helper if mapped to same severity
-                    if issue.priority >= 10 then
-                        err.severity = h.diagnostics.severities.error
-                    elseif issue.priority >= 0 then
-                        err.severity = h.diagnostics.severities.warning
-                    elseif issue.priority >= -10 then
-                        err.severity = h.diagnostics.severities.information
-                    else
-                        err.severity = h.diagnostics.severities.hint
-                    end
-
-                    if issue.column and issue.column ~= vim.NIL then
-                        err.col = issue.column
-                    end
-
-                    if issue.column_end and issue.column_end ~= vim.NIL then
-                        err.end_col = issue.column_end
-                    end
-
-                    table.insert(issues, err)
-                end
-            end
-
-            --NOTE: by using stdin, partial files get sent that won't compile but
-            --it can be reported for feedback in case any other errors occur as well
+            -- report any unexpected errors, such as partial file attempts
             if params.err then
-                table.insert(issues, {
-                    message = params.err,
-                    row = 1,
+                table.insert(issues, generic_issue(params.err))
+            end
+
+            -- if no output to parse, stop
+            if not params.output then
+                return issues
+            end
+
+            local json_index, _ = params.output:find("{")
+
+            -- if no json included, something went wrong and nothing to parse
+            if not json_index then
+                table.insert(issues, generic_issue(params.output))
+
+                return issues
+            end
+
+            local maybe_json_string = params.output:sub(json_index)
+
+            local ok, decoded = pcall(vim.json.decode, maybe_json_string)
+
+            -- decoding broke, so give up and return the original output
+            if not ok then
+                table.insert(issues, generic_issue(params.output))
+
+                return issues
+            end
+
+            for _, issue in ipairs(decoded.issues or {}) do
+                local err = {
+                    message = issue.message,
+                    row = issue.line_no,
                     source = "credo",
-                })
+                }
+
+                -- using the dynamic priority ranges from credo source
+                if issue.priority >= 10 then
+                    err.severity = h.diagnostics.severities.error
+                elseif issue.priority >= 0 then
+                    err.severity = h.diagnostics.severities.warning
+                elseif issue.priority >= -10 then
+                    err.severity = h.diagnostics.severities.information
+                else
+                    err.severity = h.diagnostics.severities.hint
+                end
+
+                if issue.column and issue.column ~= vim.NIL then
+                    err.col = issue.column
+                end
+
+                if issue.column_end and issue.column_end ~= vim.NIL then
+                    err.end_col = issue.column_end
+                end
+
+                table.insert(issues, err)
             end
 
             return issues

--- a/test/spec/builtins/diagnostics_spec.lua
+++ b/test/spec/builtins/diagnostics_spec.lua
@@ -29,7 +29,7 @@ describe("diagnostics", function()
         local parser = linter._opts.on_output
 
         it("should create a diagnostic with error severity", function()
-            local output = vim.json.decode([[
+            local output = [[
             {
               "issues": [
                 {
@@ -45,7 +45,7 @@ describe("diagnostics", function()
                   "trigger": "( c"
                 }
               ]
-            } ]])
+            } ]]
             local diagnostic = parser({ output = output })
             assert.are.same({
                 {
@@ -59,7 +59,7 @@ describe("diagnostics", function()
             }, diagnostic)
         end)
         it("should create a diagnostic with warning severity", function()
-            local output = vim.json.decode([[
+            local output = [[
             {
               "issues": [{
                 "category": "readability",
@@ -73,7 +73,7 @@ describe("diagnostics", function()
                 "scope": null,
                 "trigger": "@impl true"
               }]
-            } ]])
+            } ]]
             local diagnostic = parser({ output = output })
             assert.are.same({
                 {
@@ -87,7 +87,7 @@ describe("diagnostics", function()
             }, diagnostic)
         end)
         it("should create a diagnostic with information severity", function()
-            local output = vim.json.decode([[
+            local output = [[
             {
               "issues": [{
                 "category": "design",
@@ -101,7 +101,7 @@ describe("diagnostics", function()
                 "scope": null,
                 "trigger": "TODO: implement check"
               }]
-            } ]])
+            } ]]
             local diagnostic = parser({ output = output })
             assert.are.same({
                 {
@@ -115,7 +115,7 @@ describe("diagnostics", function()
             }, diagnostic)
         end)
         it("should create a diagnostic falling back to hint severity", function()
-            local output = vim.json.decode([[
+            local output = [[
             {
               "issues": [{
                 "category": "refactor",
@@ -129,7 +129,7 @@ describe("diagnostics", function()
                 "scope": null,
                 "trigger": "|>"
               }]
-            } ]])
+            } ]]
             local diagnostic = parser({ output = output })
             assert.are.same({
                 {
@@ -155,8 +155,8 @@ describe("diagnostics", function()
             }, diagnostic)
         end)
         it("should handle compile warnings preceeding output", function()
-            local error = [[
-            [warn] IMPORTING DEV.SECRET
+            local output = [[
+            00:00:00.000 [warn] IMPORTING DEV.SECRET
 
             {
               "issues": [
@@ -174,7 +174,7 @@ describe("diagnostics", function()
                 }
               ]
             } ]]
-            local diagnostic = parser({ err = error })
+            local diagnostic = parser({ output = output })
             assert.are.same({
                 {
                     source = "credo",
@@ -183,6 +183,28 @@ describe("diagnostics", function()
                     col = nil,
                     end_col = nil,
                     severity = 1,
+                },
+            }, diagnostic)
+        end)
+        it("should handle messages with incomplete json", function()
+            local output = [[Some incomplete message that shouldn't really happen { "issues": ]]
+            local diagnostic = parser({ output = output })
+            assert.are.same({
+                {
+                    source = "credo",
+                    message = output,
+                    row = 1,
+                },
+            }, diagnostic)
+        end)
+        it("should handle messages without json", function()
+            local output = [[Another message that shouldn't really happen]]
+            local diagnostic = parser({ output = output })
+            assert.are.same({
+                {
+                    source = "credo",
+                    message = output,
+                    row = 1,
                 },
             }, diagnostic)
         end)


### PR DESCRIPTION
Instead of attempting to decode json and falling back to a substring,
try to find json in the raw output first. This should also hopefully
solve some occasional errors when the output having some values that the
decode doesn't like.

Also tried to get rid of the nested conditionals with some early
returns.

Closes #443