### PR TITLE
add nimpretty Nim code formatter to builtins

### DIFF
--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -1523,6 +1523,24 @@ local sources = { null_ls.builtins.formatting.zigfmt }
 - `command = "zig"`
 - `args = { "fmt", "--stdin" }`
 
+#### [nimpretty](https://nim-lang.org/docs/tools.html)
+
+##### About
+
+`nimpretty` is a `Nim` source code beautifier, to format code according to the official style guide.
+
+##### Usage
+
+```lua
+local sources = { null_ls.builtins.formatting.nimpretty }
+```
+
+##### Defaults
+
+- `filetypes = { "nim" }`
+- `command = "nimpretty"`
+- `args = { "$FILENAME" }`
+
 ### Diagnostics
 
 #### [ansible-lint](https://github.com/ansible-community/ansible-lint)

--- a/lua/null-ls/builtins/formatting/nimpretty.lua
+++ b/lua/null-ls/builtins/formatting/nimpretty.lua
@@ -1,0 +1,15 @@
+local h = require("null-ls.helpers")
+local methods = require("null-ls.methods")
+
+local FORMATTING = methods.internal.FORMATTING
+
+return h.make_builtin({
+    method = FORMATTING,
+    filetypes = { "nim" },
+    generator_opts = {
+        command = "nimpretty",
+        args = { "$FILENAME" },
+        to_temp_file = true,
+    },
+    factory = h.formatter_factory,
+})


### PR DESCRIPTION
Hello,

this pull requests adds the `nimpretty` formatter for `Nim` code.
I successfully tested it on some Nim projects.
If there are some suggestions or changes I will gladly apply them and report back.