### PR TITLE
fix(builtins): mypy output pattern

### DIFF
--- a/lua/null-ls/builtins/diagnostics/mypy.lua
+++ b/lua/null-ls/builtins/diagnostics/mypy.lua
@@ -24,7 +24,7 @@ return h.make_builtin({
             return code <= 2
         end,
         on_output = h.diagnostics.from_pattern(
-            "<string>:(%d+):(%d+): (%a+): (.*)  %[([%a-]+)%]", --
+            "[^:]+:(%d+):(%d+): (%a+): (.*)  %[([%a-]+)%]", --
             { "row", "col", "severity", "message", "code" },
             {
                 severities = {


### PR DESCRIPTION
<string> doesn't work to catch filepath before the first `:`, uses
`[^:]+` instead.