### PR TITLE
fix(builtins): mypy replace --command by --shadow-file

### DIFF
--- a/lua/null-ls/builtins/diagnostics/mypy.lua
+++ b/lua/null-ls/builtins/diagnostics/mypy.lua
@@ -8,17 +8,22 @@ return h.make_builtin({
     filetypes = { "python" },
     generator_opts = {
         command = "mypy",
-        args = {
-            "--hide-error-codes",
-            "--hide-error-context",
-            "--no-color-output",
-            "--show-column-numbers",
-            "--show-error-codes",
-            "--no-error-summary",
-            "--no-pretty",
-            "--command",
-            "$TEXT",
-        },
+        args = function(params)
+            return {
+                "--hide-error-codes",
+                "--hide-error-context",
+                "--no-color-output",
+                "--show-column-numbers",
+                "--show-error-codes",
+                "--no-error-summary",
+                "--no-pretty",
+                "--shadow-file",
+                params.bufname,
+                params.temp_path,
+                params.bufname,
+            }
+        end,
+        to_temp_file = true,
         format = "line",
         check_exit_code = function(code)
             return code <= 2


### PR DESCRIPTION
Using --command $TEXT even if the text looks correctly escaped mypy
sometimes we pass multiple arguments to --command and fail with:

output: usage: mypy [-h] [-v] [-V] [more options; see below]
[-m MODULE] [-p PACKAGE] [-c PROGRAM_TEXT] [files ...]
mypy: error: May only specify one of: module/package, files, or command.

This change uses directly --shadow-file $ORIGINAL_FILENAME $FILENAME
$REAL_FILENAME instead of --command $TEXT to avoid this.
