### PR TITLE
feat: Add `joker` formatter for Clojure

### DIFF
--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -764,6 +764,24 @@ local sources = { null_ls.builtins.formatting.isort }
 - `command = "isort"`
 - `args = { "--stdout", "--profile", "black", "-" }`
 
+#### [joker](https://github.com/candid82/joker)
+
+##### About
+
+`joker` is a small Clojure interpreter, linter and formatter written in Go.
+
+##### Usage
+
+```lua
+local sources = { null_ls.builtins.formatting.joker }
+```
+
+##### Defaults
+
+- `filetypes = { "clj" }`
+- `command = "joker"`
+- `args = { "--format", "-" }`
+
 #### [reorder_python_imports](https://github.com/asottile/reorder_python_imports)
 
 ##### About

--- a/lua/null-ls/builtins/formatting/joker.lua
+++ b/lua/null-ls/builtins/formatting/joker.lua
@@ -1,0 +1,15 @@
+local h = require("null-ls.helpers")
+local methods = require("null-ls.methods")
+
+local FORMATTING = methods.internal.FORMATTING
+
+return h.make_builtin({
+    method = FORMATTING,
+    filetypes = { "clj" },
+    generator_opts = {
+        command = "joker",
+        args = { "--format", "-" },
+        to_stdin = true,
+    },
+    factory = h.formatter_factory,
+})


### PR DESCRIPTION
[joker](https://github.com/candid82/joker)

> `joker --format -` - read Clojure source code from standard input, format it and print the result to standard output.

There's no open issues to resolve.
