### PR TITLE
add ptop Pascal code formatter to builtins

### DIFF
--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -1541,6 +1541,24 @@ local sources = { null_ls.builtins.formatting.nimpretty }
 - `command = "nimpretty"`
 - `args = { "$FILENAME" }`
 
+#### [ptop](https://www.freepascal.org/tools/ptop.html)
+
+##### About
+
+The FPC Pascal configurable source beautifier. Name means "Pascal-TO-Pascal". 
+
+##### Usage
+
+```lua
+local sources = { null_ls.builtins.formatting.ptop }
+```
+
+##### Defaults
+
+- `filetypes = { "pascal" }`
+- `command = "ptop"`
+- `args = { "$FILENAME", "$FILENAME" }`
+
 ### Diagnostics
 
 #### [ansible-lint](https://github.com/ansible-community/ansible-lint)

--- a/lua/null-ls/builtins/formatting/ptop.lua
+++ b/lua/null-ls/builtins/formatting/ptop.lua
@@ -1,0 +1,15 @@
+local h = require("null-ls.helpers")
+local methods = require("null-ls.methods")
+
+local FORMATTING = methods.internal.FORMATTING
+
+return h.make_builtin({
+    method = FORMATTING,
+    filetypes = { "pascal", "delphi" },
+    generator_opts = {
+        command = "ptop",
+        args = { "$FILENAME", "$FILENAME" },
+        to_temp_file = true,
+    },
+    factory = h.formatter_factory,
+})


### PR DESCRIPTION
Hello,

this pull requests adds the `ptop` formatter for `Pascal` code.
I successfully tested it on some `Pascal` projects.
If there are some suggestions or changes I will gladly apply them and report back.