### PR TITLE
fix(rustfmt): remove edition in default arguments

### DIFF
--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -910,17 +910,7 @@ local sources = { null_ls.builtins.diagnostics.mypy }
 
 - `filetypes = { "python" }`
 - `command = "mypy"`
-- `args = {
-            "--hide-error-codes",
-            "--hide-error-context",
-            "--no-color-output",
-            "--show-column-numbers",
-            "--show-error-codes",
-            "--no-error-summary",
-            "--no-pretty",
-            "--command",
-            "$TEXT",
-        }`
+- `args = { "--hide-error-codes", "--hide-error-context", "--no-color-output", "--show-column-numbers", "--show-error-codes", "--no-error-summary", "--no-pretty", "--command", "$TEXT", }`
 
 #### [nginxbeautifier](https://github.com/vasilevich/nginxbeautifier)
 
@@ -1192,6 +1182,11 @@ local sources = { null_ls.builtins.formatting.rufo }
 ##### About
 
 A tool for formatting `rust` code according to style guidelines.
+
+- `--edition` defaults to `2015`. To set a different edition, use `extra_args`.
+- See [the
+  wiki](https://github.com/jose-elias-alvarez/null-ls.nvim/wiki/Source-specific-Configuration#rustfmt)
+  for other workarounds.
 
 ##### Usage
 
@@ -1563,7 +1558,7 @@ local sources = { null_ls.builtins.formatting.nimpretty }
 
 ##### About
 
-The FPC Pascal configurable source beautifier. Name means "Pascal-TO-Pascal". 
+The FPC Pascal configurable source beautifier. Name means "Pascal-TO-Pascal".
 
 ##### Usage
 

--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -1203,7 +1203,7 @@ local sources = { null_ls.builtins.formatting.rustfmt }
 
 - `filetypes = { "rust" }`
 - `command = "rustfmt"`
-- `args = { "--emit=stdout", "--edition=2018" }`
+- `args = { "--emit=stdout" }`
 
 #### [rustywind](https://github.com/avencera/rustywind)
 

--- a/lua/null-ls/builtins/formatting/rustfmt.lua
+++ b/lua/null-ls/builtins/formatting/rustfmt.lua
@@ -8,7 +8,7 @@ return h.make_builtin({
     filetypes = { "rust" },
     generator_opts = {
         command = "rustfmt",
-        args = { "--emit=stdout", "--edition=2018" },
+        args = { "--emit=stdout" },
         to_stdin = true,
     },
     factory = h.formatter_factory,


### PR DESCRIPTION
The Rust 2021 edition has been released. So I think it would be better to use 2021 edition for rustfmt.

related: https://github.com/rust-lang/rustfmt/pull/4847