### PR TITLE
fix: Add support for dotted filetypes

### DIFF
--- a/lua/null-ls/sources.lua
+++ b/lua/null-ls/sources.lua
@@ -42,26 +42,48 @@ local register_source = function(source)
     registered.names[source.name] = true
 end
 
+local matches_filetype = function(source, filetype)
+    if filetype:find("%.") then
+        local filetypes = vim.split(filetype, ".", { plain = true })
+        table.insert(filetypes, filetype)
+
+        local is_match = source.filetypes["_all"]
+        for _, ft in ipairs(filetypes) do
+            if source.filetypes[ft] == false then
+                return false
+            end
+
+            is_match = is_match or source.filetypes[ft]
+        end
+
+        return is_match
+    end
+
+    return source.filetypes[filetype] or source.filetypes["_all"] and source.filetypes[filetype] == nil
+end
+
+local matches_method = function(source, method)
+    if source.methods[method] then
+        return true
+    end
+
+    if methods.overrides[method] then
+        for m in pairs(methods.overrides[method]) do
+            if source.methods[m] then
+                return true
+            end
+        end
+    end
+
+    return false
+end
+
 M.is_available = function(source, filetype, method)
     if source._disabled or source.generator._failed then
         return false
     end
 
-    local filetype_matches = not filetype
-        or source.filetypes["_all"] and source.filetypes[filetype] == nil
-        or source.filetypes[filetype] == true
-
-    local method_matches = not method or source.methods[method] == true
-    if not method_matches and methods.overrides[method] then
-        for m in pairs(methods.overrides[method]) do
-            if source.methods[m] then
-                method_matches = true
-                break
-            end
-        end
-    end
-
-    return filetype_matches and method_matches
+    return (not filetype or matches_filetype(source, filetype)) and (not method or matches_method(source, method))
 end
 
 M.get_available = function(filetype, method)

--- a/test/spec/sources_spec.lua
+++ b/test/spec/sources_spec.lua
@@ -60,6 +60,28 @@ describe("sources", function()
             assert.truthy(is_available)
         end)
 
+        it("should return true if multiple filetypes are set and one matches", function()
+            local is_available = sources.is_available(mock_source, "foo.lua.bar")
+
+            assert.truthy(is_available)
+        end)
+
+        it("should return true if a dotted filetype is specified", function()
+            mock_source.filetypes["jinja.html"] = true
+
+            local is_available = sources.is_available(mock_source, "jinja.html")
+
+            assert.truthy(is_available)
+        end)
+
+        it("should return false if multiple filetypes are set and one is disabled", function()
+            mock_source.filetypes["bar"] = false
+
+            local is_available = sources.is_available(mock_source, "foo.lua.bar")
+
+            assert.falsy(is_available)
+        end)
+
         it("should return true if filetype includes _all key", function()
             mock_source.filetypes["_all"] = true
 


### PR DESCRIPTION
Neovim supports setting multiple filetypes through the use of a dot
separator. From `:h 'filetype'`:

    When a dot appears in the value then this separates two filetype
    names.  Example:
        /* vim: set filetype=c.doxygen : */ ~
    This will use the "c" filetype first, then the "doxygen" filetype.
    This works both for filetype plugins and for syntax files.  More than
    one dot may appear.

By respecting this functionality, users can set filetypes such as
`json.openapi` or `yaml.docker-compose` and get out-of-the-box support
for multiple filetype-specific sources in a single file.

Dotted filetypes continue to be supported as a unique filetype for
backward compatibility and cases where sources should only be made
available at the intersection of filetypes.

For files where a source is explicitly configured to be both enabled and
disabled from different filetypes, I opted to give precedence to the
disabled filetype. It's trivial to swap if that behavior is less
desirable. In practice this might never come up.