### PR TITLE
doc: use formatting_seq_sync() instead of formatting_sync()

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ Please **do not** link to or post your entire Neovim configuration.
 ### How do I format files?
 
 null-ls formatters run when you call `vim.lsp.buf.formatting()` or
-`vim.lsp.buf.formatting_sync()`. If a source supports it, you can run range
+`vim.lsp.buf.formatting_seq_sync()`. If a source supports it, you can run range
 formatting by visually selecting part of the buffer and calling
 `vim.lsp.buf.range_formatting()`.
 
@@ -216,7 +216,7 @@ require("null-ls").setup({
     -- you can reuse a shared lspconfig on_attach callback here
     on_attach = function(client)
         if client.resolved_capabilities.document_formatting then
-            vim.cmd("autocmd BufWritePre <buffer> lua vim.lsp.buf.formatting_sync()")
+            vim.cmd("autocmd BufWritePre <buffer> lua vim.lsp.buf.formatting_seq_sync()")
         end
     end,
 })


### PR DESCRIPTION
I had different formatters for one filetype  (whitespace and trailing new lines and golang). If I used your autocommand in doc, nvim always asked which lsp source I want to use:

```console
Select a Language Server:
(1) lsp, (2) null-ls:
```

This was pretty annoying. There is a better way: `vim.lsp.buf.formatting_seq_sync()` instead of `vim.lsp.buf.formatting_sync()`.

More info on [stackoverflow](https://stackoverflow.com/questions/67550082/neovim-select-a-language-prompt).