### PR TITLE
fix(utils): escape wildcard characters in folder path

### DIFF
--- a/lua/null-ls/utils.lua
+++ b/lua/null-ls/utils.lua
@@ -319,6 +319,9 @@ end
 M.root_pattern = function(...)
     local patterns = vim.tbl_flatten({ ... })
     local function matcher(path)
+        -- Escape wildcard characters in the path so that it itself is not treated like a glob.
+        path = vim.fn.escape(path, "?*[]")
+
         for _, pattern in ipairs(patterns) do
             for _, p in ipairs(vim.fn.glob(M.path.join(path, pattern), true, true)) do
                 if M.path.exists(p) then


### PR DESCRIPTION
If a folder has a wildcard in it's path, the plugin gives a `Reverse range in character class` error. I had the same problem in the past with another plugin: https://github.com/airblade/vim-rooter/issues/122. The solution is simple: escape any wildcard characters.

Here is a small snippet to reproduce my error: `folder_name="[u-a]" && mkdir -p "$folder_name" && touch "$folder_name/readme.md" && nvim "$folder_name/readme.md"`. 