### PR TITLE
feat: standardjs fine grained severities

### DIFF
--- a/lua/null-ls/builtins/diagnostics/standardjs.lua
+++ b/lua/null-ls/builtins/diagnostics/standardjs.lua
@@ -15,9 +15,24 @@ return h.make_builtin({
         check_exit_code = function(c)
             return c <= 1
         end,
-        on_output = h.diagnostics.from_pattern(":(%d+):(%d+): (.*)", { "row", "col", "message" }, {
-            diagnostic = {
-                severity = h.diagnostics.severities.error,
+        on_output = h.diagnostics.from_patterns({
+            {
+                pattern = ":(%d+):(%d+): Parsing error: (.*)",
+                groups = { "row", "col", "message" },
+                overrides = {
+                    diagnostic = {
+                        severity = h.diagnostics.severities.error,
+                    },
+                },
+            },
+            {
+                pattern = ":(%d+):(%d+): (.*)",
+                groups = { "row", "col", "message" },
+                overrides = {
+                    diagnostic = {
+                        severity = h.diagnostics.severities.warning,
+                    },
+                },
             },
         }),
     },

--- a/test/spec/builtins/diagnostics_spec.lua
+++ b/test/spec/builtins/diagnostics_spec.lua
@@ -541,17 +541,30 @@ describe("diagnostics", function()
     describe("standardjs", function()
         local linter = diagnostics.standardjs
         local parser = linter._opts.on_output
-        local file = {
-            [[export const foo = () => { return "hello" }]],
-        }
 
-        it("should create a diagnostic", function()
+        it("should create a diagnostic with error severity", function()
+            local file = {
+                [[export const foo = () => { return 'hello']],
+            }
+            local output = [[rules.js:1:2: Parsing error: Unexpected token]]
+            local diagnostic = parser(output, { content = file })
+            assert.are.same({
+                row = "1", --
+                col = "2",
+                severity = 1,
+                message = "Unexpected token",
+            }, diagnostic)
+        end)
+        it("should create a diagnostic with warning severity", function()
+            local file = {
+                [[export const foo = () => { return "hello" }]],
+            }
             local output = [[rules.js:1:35: Strings must use singlequote.]]
             local diagnostic = parser(output, { content = file })
             assert.are.same({
                 row = "1", --
                 col = "35",
-                severity = 1,
+                severity = 2,
                 message = "Strings must use singlequote.",
             }, diagnostic)
         end)


### PR DESCRIPTION
My initial integration of standardjs to null-ls treated all diagnostics emitted as errors.

However, standardjs does distinguish between syntax errors (denoted by "Parsing error") and warnings (usually code-style).

An example of a syntax error:

  /home/fred/foo.js:2:1: Parsing error: Unexpected token

And an example of a code-style warning:

  /home/fred/foo.js:1:35: Strings must use singlequote.

The null-ls integration of standardjs now accounts for errors as against warnings.