### PR TITLE
feat(builtin): Add `cue fmt` based formatter

### DIFF
--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -414,6 +414,24 @@ local sources = { null_ls.builtins.formatting.crystal_format }
 - `command = "crystal"`
 - `args = { "tool", "format" }`
 
+#### [cue fmt](https://cuelang.org/)
+
+##### About
+
+A CUE language formatter.
+
+##### Usage
+
+```lua
+local sources = { null_ls.builtins.formatting.cue_fmt }
+```
+
+##### Defaults
+
+- `filetypes = { "cue" }`
+- `command = "cue"`
+- `args = { "fmt", "$FILENAME" }`
+
 #### [dart-format](https://dart.dev/tools/dart-format)
 
 ##### About

--- a/lua/null-ls/builtins/formatting/cue_fmt.lua
+++ b/lua/null-ls/builtins/formatting/cue_fmt.lua
@@ -1,0 +1,19 @@
+local h = require("null-ls.helpers")
+local methods = require("null-ls.methods")
+
+local FORMATTING = methods.internal.FORMATTING
+
+return h.make_builtin({
+    method = FORMATTING,
+    filetypes = { "cue" },
+    generator_opts = {
+        command = "cue",
+        args = {
+            "fmt",
+            "$FILENAME",
+        },
+        to_stdin = false,
+        to_temp_file = true,
+    },
+    factory = h.formatter_factory,
+})


### PR DESCRIPTION
Uses the `fmt` command of the `cue` CLI tool to format [CUE lang](https://cuelang.org/) files.
