### PR TITLE
fix(credo): use callback instead of returning value

### DIFF
--- a/lua/null-ls/builtins/diagnostics/credo.lua
+++ b/lua/null-ls/builtins/diagnostics/credo.lua
@@ -31,7 +31,7 @@ return h.make_builtin({
         format = "raw",
         to_stdin = true,
         from_stderr = true,
-        on_output = function(params)
+        on_output = function(params, done)
             local issues = {}
 
             -- report any unexpected errors, such as partial file attempts
@@ -93,7 +93,7 @@ return h.make_builtin({
                 table.insert(issues, err)
             end
 
-            return issues
+            done(issues)
         end,
     },
     factory = h.generator_factory,

--- a/lua/null-ls/builtins/diagnostics/credo.lua
+++ b/lua/null-ls/builtins/diagnostics/credo.lua
@@ -41,7 +41,7 @@ return h.make_builtin({
 
             -- if no output to parse, stop
             if not params.output then
-                return issues
+                return done(issues)
             end
 
             local json_index, _ = params.output:find("{")
@@ -50,7 +50,7 @@ return h.make_builtin({
             if not json_index then
                 table.insert(issues, generic_issue(params.output))
 
-                return issues
+                return done(issues)
             end
 
             local maybe_json_string = params.output:sub(json_index)
@@ -61,7 +61,7 @@ return h.make_builtin({
             if not ok then
                 table.insert(issues, generic_issue(params.output))
 
-                return issues
+                return done(issues)
             end
 
             for _, issue in ipairs(decoded.issues or {}) do

--- a/test/spec/builtins/diagnostics_spec.lua
+++ b/test/spec/builtins/diagnostics_spec.lua
@@ -27,6 +27,13 @@ describe("diagnostics", function()
     describe("credo", function()
         local linter = diagnostics.credo
         local parser = linter._opts.on_output
+        local diagnostics
+        local done = function(_diagnostics)
+            diagnostics = _diagnostics
+        end
+        after_each(function()
+            diagnostics = nil
+        end)
 
         it("should create a diagnostic with error severity", function()
             local output = [[
@@ -46,7 +53,7 @@ describe("diagnostics", function()
                 }
               ]
             } ]]
-            local diagnostic = parser({ output = output })
+            parser({ output = output }, done)
             assert.are.same({
                 {
                     source = "credo",
@@ -56,7 +63,7 @@ describe("diagnostics", function()
                     end_col = nil,
                     severity = 1,
                 },
-            }, diagnostic)
+            }, diagnostics)
         end)
         it("should create a diagnostic with warning severity", function()
             local output = [[
@@ -74,7 +81,7 @@ describe("diagnostics", function()
                 "trigger": "@impl true"
               }]
             } ]]
-            local diagnostic = parser({ output = output })
+            parser({ output = output }, done)
             assert.are.same({
                 {
                     source = "credo",
@@ -84,7 +91,7 @@ describe("diagnostics", function()
                     end_col = 13,
                     severity = 2,
                 },
-            }, diagnostic)
+            }, diagnostics)
         end)
         it("should create a diagnostic with information severity", function()
             local output = [[
@@ -102,7 +109,7 @@ describe("diagnostics", function()
                 "trigger": "TODO: implement check"
               }]
             } ]]
-            local diagnostic = parser({ output = output })
+            parser({ output = output }, done)
             assert.are.same({
                 {
                     source = "credo",
@@ -112,7 +119,7 @@ describe("diagnostics", function()
                     end_col = nil,
                     severity = 3,
                 },
-            }, diagnostic)
+            }, diagnostics)
         end)
         it("should create a diagnostic falling back to hint severity", function()
             local output = [[
@@ -130,7 +137,7 @@ describe("diagnostics", function()
                 "trigger": "|>"
               }]
             } ]]
-            local diagnostic = parser({ output = output })
+            parser({ output = output }, done)
             assert.are.same({
                 {
                     source = "credo",
@@ -140,19 +147,19 @@ describe("diagnostics", function()
                     end_col = nil,
                     severity = 4,
                 },
-            }, diagnostic)
+            }, diagnostics)
         end)
         it("returns errors as diagnostics", function()
             local error =
                 [[** (Mix) The task "credo" could not be found\nNote no mix.exs was found in the current directory]]
-            local diagnostic = parser({ err = error })
+            parser({ err = error }, done)
             assert.are.same({
                 {
                     source = "credo",
                     message = error,
                     row = 1,
                 },
-            }, diagnostic)
+            }, diagnostics)
         end)
         it("should handle compile warnings preceeding output", function()
             local output = [[
@@ -174,7 +181,7 @@ describe("diagnostics", function()
                 }
               ]
             } ]]
-            local diagnostic = parser({ output = output })
+            parser({ output = output }, done)
             assert.are.same({
                 {
                     source = "credo",
@@ -184,29 +191,29 @@ describe("diagnostics", function()
                     end_col = nil,
                     severity = 1,
                 },
-            }, diagnostic)
+            }, diagnostics)
         end)
         it("should handle messages with incomplete json", function()
             local output = [[Some incomplete message that shouldn't really happen { "issues": ]]
-            local diagnostic = parser({ output = output })
+            parser({ output = output }, done)
             assert.are.same({
                 {
                     source = "credo",
                     message = output,
                     row = 1,
                 },
-            }, diagnostic)
+            }, diagnostics)
         end)
         it("should handle messages without json", function()
             local output = [[Another message that shouldn't really happen]]
-            local diagnostic = parser({ output = output })
+            parser({ output = output }, done)
             assert.are.same({
                 {
                     source = "credo",
                     message = output,
                     row = 1,
                 },
-            }, diagnostic)
+            }, diagnostics)
         end)
     end)
 


### PR DESCRIPTION
I thought I was going crazy when I simply couldn't get Credo to show error results after I got ESLint working pretty effortlessly. But I think I accidentally stumbled on some code that was broken by a recent refactor.