### PR TITLE
feat: forward on_exit callback from lsp client

### DIFF
--- a/doc/CONFIG.md
+++ b/doc/CONFIG.md
@@ -57,6 +57,7 @@ local defaults = {
     },
     on_attach = nil,
     on_init = nil,
+    on_exit = nil,
     root_dir = u.root_pattern(".null-ls-root", "Makefile", ".git"),
     sources = nil,
     update_in_insert = false,
@@ -161,6 +162,10 @@ here, use a custom callback for null-ls, or leave this undefined.
 Defines an `on_init` callback to run when null-ls initializes. From here, you
 can make changes to the client (the first argument) or `initialize_result` (the
 second argument, which as of now is not used).
+
+### on_exit (function, optional)
+
+Defines an `on_exit` callback to run when null-ls is stopped.
 
 ### root_dir (function)
 

--- a/lua/null-ls/client.lua
+++ b/lua/null-ls/client.lua
@@ -48,7 +48,10 @@ local on_init = function(new_client, initialize_result)
     client = new_client
 end
 
-local on_exit = function()
+local on_exit = function(...)
+    if c.get().on_exit then
+        c.get().on_exit(...)
+    end
     client = nil
     id = nil
 end

--- a/lua/null-ls/config.lua
+++ b/lua/null-ls/config.lua
@@ -30,6 +30,7 @@ local config = vim.deepcopy(defaults)
 local type_overrides = {
     on_attach = { "function", "nil" },
     on_init = { "function", "nil" },
+    on_exit = { "function", "nil" },
     sources = { "table", "nil" },
 }
 


### PR DESCRIPTION
Adds on_exit callback.

I'm setting some stuff up in on_init and on_attach that needs to be cleaned up in on_exit.