### PR TITLE
Fix broken mypy link

### DIFF
--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -994,7 +994,7 @@ local sources = { null_ls.builtins.formatting.mix }
 - `command = "mix"`
 - `args = { "format", "-" }`
 
-#### [mypy](mypy-lang.org)
+#### [mypy](https://github.com/python/mypy)
 
 ##### About
 


### PR DESCRIPTION
Previous link target was not handled as a web adress, but instead linked to [https://github.com/jose-elias-alvarez/null-ls.nvim/blob/main/doc/mypy-lang.org](https://github.com/jose-elias-alvarez/null-ls.nvim/blob/main/doc/mypy-lang.org), which does not exist. I added in the link to the [official mypy github repo](https://github.com/python/mypy).