### PR TITLE
feat: add fallback dynamic cmd by default

### DIFF
--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -50,12 +50,12 @@ null_ls.setup({ sources = sources })
 ```
 
 To run built-in sources, the command specified below must be available on your
-`$PATH` and visible to Neovim. For example, to check if `eslint` is available,
+`$PATH` and visible to Neovim. For example, to check if `stylua` is available,
 run the following (Vim, not Lua) command:
 
 ```vim
 " should echo 1 if available (and 0 if not)
-:echo executable("eslint")
+:echo executable("stylua")
 ```
 
 ## Configuration
@@ -661,6 +661,7 @@ local sources = { null_ls.builtins.formatting.eslint }
 - `filetypes = { "javascript", "javascriptreact", "typescript", "typescriptreact", "vue" }`
 - `command = "eslint"`
 - `args = { "--fix-dry-run", "--format", "JSON", "--stdin", "--stdin-filename", "$FILENAME" }`
+- `dynamic_command = require("null-ls.helpers.command_resolver").from_node_modules`
 
 #### [eslint_d](https://github.com/mantoni/eslint_d.js)
 
@@ -679,6 +680,7 @@ local sources = { null_ls.builtins.formatting.eslint_d }
 - `filetypes = { "javascript", "javascriptreact", "typescript", "typescriptreact", "vue" }`
 - `command = "eslint_d"`
 - `args = { "--fix-to-stdout", "--stdin", "--stdin-filepath", "$FILENAME" }`
+- `dynamic_command = require("null-ls.helpers.command_resolver").from_node_modules`
 
 #### [fish_indent](https://linux.die.net/man/1/fish_indent)
 
@@ -1203,6 +1205,7 @@ local sources = { null_ls.builtins.formatting.prettier }
 - `filetypes = { "javascript", "javascriptreact", "typescript", "typescriptreact", "vue", "css", "scss", "less", "html", "json", "yaml", "markdown", "graphql" }`
 - `command = "prettier"`
 - `args = { "--stdin-filepath", "$FILENAME" }`
+- `dynamic_command = require("null-ls.helpers.command_resolver").from_node_modules`
 
 #### [prettier_d_slim](https://github.com/mikew/prettier_d_slim)
 
@@ -1225,6 +1228,7 @@ local sources = { null_ls.builtins.formatting.prettier_d_slim }
 - `filetypes = { "javascript", "javascriptreact", "typescript", "typescriptreact", "vue", "css", "scss", "less", "html", "json", "yaml", "markdown", "graphql" }`
 - `command = "prettier_d_slim"`
 - `args = { "--stdin", "--stdin-filepath", "$FILENAME" }`
+- `dynamic_command = require("null-ls.helpers.command_resolver").from_node_modules`
 
 #### [prettierd](https://github.com/fsouza/prettierd)
 
@@ -1245,6 +1249,7 @@ local sources = { null_ls.builtins.formatting.prettierd }
 - `filetypes = { "javascript", "javascriptreact", "typescript", "typescriptreact", "vue", "css", "scss", "less", "html", "json", "yaml", "markdown", "graphql" }`
 - `command = "prettierd"`
 - `args = { "$FILENAME" }`
+- `dynamic_command = require("null-ls.helpers.command_resolver").from_node_modules`
 
 #### [prettier-standard](https://github.com/sheerun/prettier-standard)
 
@@ -1262,8 +1267,9 @@ local sources = { null_ls.builtins.formatting.prettier_standard }
 ##### Defaults
 
 - `filetypes = { "javascript", "javascriptreact" }`
-- `command = "prettier-standard"`
+- `command = "prettier_standard"`
 - `args = { "--stdin" }`
+- `dynamic_command = require("null-ls.helpers.command_resolver").from_node_modules`
 
 #### [prismaFmt](https://github.com/prisma/prisma-engines)
 
@@ -1396,6 +1402,7 @@ local sources = { null_ls.builtins.formatting.rustywind }
 - `filetypes = { "javascript", "javascriptreact", "typescript", "typescriptreact", "vue", "svelte", "html", }`
 - `command = "rustywind"`
 - `args = { "--stdin" }`
+- `dynamic_command = require("null-ls.helpers.command_resolver").from_node_modules`
 
 #### [scalafmt](https://github.com/scalameta/scalafmt)
 
@@ -1920,6 +1927,7 @@ local sources = { null_ls.builtins.diagnostics.eslint }
 - `filetypes = { "javascript", "javascriptreact", "typescript", "typescriptreact", "vue" }`
 - `command = "eslint"`
 - `args = { "-f", "json", "--stdin", "--stdin-filename", "$FILENAME" }`
+- `dynamic_command = require("null-ls.helpers.command_resolver").from_node_modules`
 
 #### [eslint_d](https://github.com/mantoni/eslint_d.js/)
 
@@ -1938,6 +1946,7 @@ local sources = { null_ls.builtins.diagnostics.eslint_d }
 - `filetypes = { "javascript", "javascriptreact", "typescript", "typescriptreact", "vue" }`
 - `command = "eslint_d"`
 - `args = { "-f", "json", "--stdin", "--stdin-filename", "$FILENAME" }`
+- `dynamic_command = require("null-ls.helpers.command_resolver").from_node_modules`
 
 #### [flake8](https://github.com/PyCQA/flake8)
 
@@ -2290,6 +2299,7 @@ local sources = { null_ls.builtins.diagnostics.standardjs }
 - `filetypes = { "javascript", "javascriptreact" }`
 - `command = "standard"`
 - `args = { "--stdin" }`
+- `dynamic_command = require("null-ls.helpers.command_resolver").from_node_modules`
 
 #### [standardrb](https://github.com/testdouble/standard)
 
@@ -2344,6 +2354,7 @@ local sources = { null_ls.builtins.diagnostics.stylelint }
 - `filetypes = { "scss", "less", "css", "sass" }`
 - `command = "stylelint"`
 - `args = { "--formatter", "json", "--stdin-filename", "$FILENAME" }`
+- `dynamic_command = require("null-ls.helpers.command_resolver").from_node_modules`
 
 #### [teal](https://github.com/teal-language/tl)
 
@@ -2609,6 +2620,7 @@ local sources = { null_ls.builtins.code_actions.eslint }
 - `filetypes = { "javascript", "javascriptreact", "typescript", "typescriptreact", "vue" }`
 - `command = "eslint"`
 - `args = { "-f", "json", "--stdin", "--stdin-filename", "$FILENAME" }`
+- `dynamic_command = require("null-ls.helpers.command_resolver").from_node_modules`
 
 #### [eslint_d](https://github.com/mantoni/eslint_d.js)
 
@@ -2628,6 +2640,7 @@ local sources = { null_ls.builtins.code_actions.eslint_d }
 - `filetypes = { "javascript", "javascriptreact", "typescript", "typescriptreact", "vue" }`
 - `command = "eslint_d"`
 - `args = { "-f", "json", "--stdin", "--stdin-filename", "$FILENAME" }`
+- `dynamic_command = require("null-ls.helpers.command_resolver").from_node_modules`
 
 #### [gitsigns.nvim](https://github.com/lewis6991/gitsigns.nvim)
 

--- a/lua/null-ls/builtins/code_actions/eslint.lua
+++ b/lua/null-ls/builtins/code_actions/eslint.lua
@@ -1,4 +1,5 @@
 local h = require("null-ls.helpers")
+local cmd_resolver = require("null-ls.helpers.command_resolver")
 local methods = require("null-ls.methods")
 
 local CODE_ACTION = methods.internal.CODE_ACTION
@@ -160,6 +161,7 @@ return h.make_builtin({
             params.messages = output[1].messages
             return code_action_handler(params)
         end,
+        dynamic_command = cmd_resolver.from_node_modules,
     },
     factory = h.generator_factory,
 })

--- a/lua/null-ls/builtins/diagnostics/eslint.lua
+++ b/lua/null-ls/builtins/diagnostics/eslint.lua
@@ -1,4 +1,5 @@
 local h = require("null-ls.helpers")
+local cmd_resolver = require("null-ls.helpers.command_resolver")
 local methods = require("null-ls.methods")
 
 local DIAGNOSTICS = methods.internal.DIAGNOSTICS
@@ -36,6 +37,7 @@ return h.make_builtin({
         end,
         use_cache = true,
         on_output = handle_eslint_output,
+        dynamic_command = cmd_resolver.from_node_modules,
     },
     factory = h.generator_factory,
 })

--- a/lua/null-ls/builtins/diagnostics/standardjs.lua
+++ b/lua/null-ls/builtins/diagnostics/standardjs.lua
@@ -1,4 +1,5 @@
 local h = require("null-ls.helpers")
+local cmd_resolver = require("null-ls.helpers.command_resolver")
 local methods = require("null-ls.methods")
 
 local DIAGNOSTICS = methods.internal.DIAGNOSTICS
@@ -36,6 +37,7 @@ return h.make_builtin({
                 },
             },
         }),
+        dynamic_command = cmd_resolver.from_node_modules,
     },
     factory = h.generator_factory,
 })

--- a/lua/null-ls/builtins/formatting/eslint.lua
+++ b/lua/null-ls/builtins/formatting/eslint.lua
@@ -1,4 +1,5 @@
 local h = require("null-ls.helpers")
+local cmd_resolver = require("null-ls.helpers.command_resolver")
 local methods = require("null-ls.methods")
 
 local FORMATTING = methods.internal.FORMATTING
@@ -33,5 +34,6 @@ return h.make_builtin({
                     },
                 }
         end,
+        dynamic_command = cmd_resolver.from_node_modules,
     },
 })

--- a/lua/null-ls/builtins/formatting/prettier.lua
+++ b/lua/null-ls/builtins/formatting/prettier.lua
@@ -1,4 +1,5 @@
 local h = require("null-ls.helpers")
+local cmd_resolver = require("null-ls.helpers.command_resolver")
 local methods = require("null-ls.methods")
 
 local FORMATTING = methods.internal.FORMATTING
@@ -26,6 +27,7 @@ return h.make_builtin({
         command = "prettier",
         args = h.range_formatting_args_factory({ "--stdin-filepath", "$FILENAME" }),
         to_stdin = true,
+        dynamic_command = cmd_resolver.from_node_modules,
     },
     factory = h.formatter_factory,
 })

--- a/lua/null-ls/builtins/formatting/prettier_d_slim.lua
+++ b/lua/null-ls/builtins/formatting/prettier_d_slim.lua
@@ -1,4 +1,5 @@
 local h = require("null-ls.helpers")
+local cmd_resolver = require("null-ls.helpers.command_resolver")
 local methods = require("null-ls.methods")
 
 local FORMATTING = methods.internal.FORMATTING
@@ -26,6 +27,7 @@ return h.make_builtin({
         command = "prettier_d_slim",
         args = h.range_formatting_args_factory({ "--stdin", "--stdin-filepath", "$FILENAME" }),
         to_stdin = true,
+        dynamic_command = cmd_resolver.from_node_modules,
     },
     factory = h.formatter_factory,
 })

--- a/lua/null-ls/builtins/formatting/prettier_standard.lua
+++ b/lua/null-ls/builtins/formatting/prettier_standard.lua
@@ -1,4 +1,5 @@
 local h = require("null-ls.helpers")
+local cmd_resolver = require("null-ls.helpers.command_resolver")
 local methods = require("null-ls.methods")
 
 local FORMATTING = methods.internal.FORMATTING
@@ -11,6 +12,7 @@ return h.make_builtin({
         command = "prettier-standard",
         args = { "--stdin" },
         to_stdin = true,
+        dynamic_command = cmd_resolver.from_node_modules,
     },
     factory = h.formatter_factory,
 })

--- a/lua/null-ls/builtins/formatting/prettierd.lua
+++ b/lua/null-ls/builtins/formatting/prettierd.lua
@@ -1,4 +1,5 @@
 local h = require("null-ls.helpers")
+local cmd_resolver = require("null-ls.helpers.command_resolver")
 local methods = require("null-ls.methods")
 
 local FORMATTING = methods.internal.FORMATTING
@@ -24,6 +25,7 @@ return h.make_builtin({
     generator_opts = {
         command = "prettierd",
         args = { "$FILENAME" },
+        dynamic_command = cmd_resolver.from_node_modules,
         to_stdin = true,
     },
     factory = h.formatter_factory,

--- a/lua/null-ls/builtins/formatting/rustywind.lua
+++ b/lua/null-ls/builtins/formatting/rustywind.lua
@@ -1,4 +1,5 @@
 local h = require("null-ls.helpers")
+local cmd_resolver = require("null-ls.helpers.command_resolver")
 local methods = require("null-ls.methods")
 
 local FORMATTING = methods.internal.FORMATTING
@@ -19,6 +20,7 @@ return h.make_builtin({
         command = "rustywind",
         args = { "--stdin" },
         to_stdin = true,
+        dynamic_command = cmd_resolver.from_node_modules,
     },
     factory = h.formatter_factory,
 })

--- a/lua/null-ls/builtins/formatting/stylelint.lua
+++ b/lua/null-ls/builtins/formatting/stylelint.lua
@@ -1,4 +1,5 @@
 local h = require("null-ls.helpers")
+local cmd_resolver = require("null-ls.helpers.command_resolver")
 local methods = require("null-ls.methods")
 
 local FORMATTING = methods.internal.FORMATTING
@@ -11,6 +12,7 @@ return h.make_builtin({
         command = "stylelint",
         args = { "--fix", "--stdin", "--stdin-filename", "$FILENAME" },
         to_stdin = true,
+        dynamic_command = cmd_resolver.from_node_modules,
     },
     factory = h.formatter_factory,
 })

--- a/lua/null-ls/helpers/command_resolver.lua
+++ b/lua/null-ls/helpers/command_resolver.lua
@@ -1,0 +1,54 @@
+local log = require("null-ls.logger")
+local s = require("null-ls.state")
+local u = require("null-ls.utils")
+local fmt = string.format
+
+local M = {}
+
+M.generic = function(params, prefix)
+    local resolved = s.get_resolved_command(params.bufnr, params.command)
+    if resolved then
+        if resolved.command then
+            log:debug(fmt("Using cached value [%s] as the resolved command for [%s]", resolved.command, params.command))
+        end
+        return resolved.command
+    end
+
+    local executable_to_find = prefix and u.path.join(prefix, params.command) or params.command
+    log:debug("attempting to find local executable " .. executable_to_find)
+
+    local root = u.get_root()
+
+    resolved = {}
+
+    u.path.traverse_parents(params.bufname, function(dir)
+        local command = u.path.join(dir, executable_to_find)
+        if u.is_executable(command) then
+            log:trace(fmt("resolved dynamic command for [%s] with cwd=%s", executable_to_find, dir))
+            resolved.command = command
+            resolved.cwd = dir
+            return true
+        end
+
+        -- use cwd as a stopping point to avoid scanning the entire file system
+        if dir == root then
+            return true
+        end
+    end)
+
+    if not resolved.command then
+        log:debug(fmt("Unable to resolve command [%s], skipping further lookups", executable_to_find))
+    end
+
+    s.set_resolved_command(params.bufnr, params.command, { command = resolved.command or false, cwd = resolved.cwd })
+    return resolved.command
+end
+
+M.from_node_modules = function(params)
+    -- try the local one first by default but always fallback on the pre-defined command
+    -- this needs to be done here to avoid constant lookups
+    -- we're checking if the global is executable to avoid spawning an invalid command
+    return M.generic(params, u.path.join("node_modules", ".bin")) or u.is_executable(params.command) and params.command
+end
+
+return M

--- a/lua/null-ls/helpers/generator_factory.lua
+++ b/lua/null-ls/helpers/generator_factory.lua
@@ -277,6 +277,7 @@ return function(opts)
             local resolved_command
             if dynamic_command then
                 resolved_command = dynamic_command(params)
+                log:debug(string.format("Using dynamic command for [%s], got: %s", params.command, resolved_command))
             else
                 resolved_command = command
             end
@@ -330,7 +331,14 @@ return function(opts)
             opts._last_args = resolved_args
             opts._last_cwd = resolved_cwd
 
-            log:debug(string.format("spawning command [%s] with args %s", resolved_command, vim.inspect(resolved_args)))
+            log:debug(
+                string.format(
+                    "spawning command [%s] at %s with args %s",
+                    resolved_command,
+                    resolved_cwd,
+                    vim.inspect(resolved_args)
+                )
+            )
             loop.spawn(resolved_command, resolved_args, spawn_opts)
         end,
         filetypes = opts.filetypes,

--- a/lua/null-ls/utils.lua
+++ b/lua/null-ls/utils.lua
@@ -62,8 +62,7 @@ M.has_version = function(ver)
 end
 
 M.is_executable = function(cmd)
-    local is_executable = vim.fn.executable(cmd) > 0
-    if is_executable then
+    if cmd and vim.fn.executable(cmd) == 1 then
         return true
     end
 


### PR DESCRIPTION
Make use of `dynamic_command` as a fallback when the base command isn't found. This is particularly useful for node_modules, for example: `prettier`.

```lua
generator_opts = {
    command = "prettier",
    args = h.range_formatting_args_factory({ "--stdin-filepath", "$FILENAME" }),
    to_stdin = true,
    dynamic_command = require("null-ls.helpers.command_resolver").from_node_modules
}
```

Related discussion: https://github.com/jose-elias-alvarez/null-ls.nvim/pull/349#pullrequestreview-807707808
