### PR TITLE
chore: add source names to all builtins

### DIFF
--- a/lua/null-ls/builtins/code_actions/eslint.lua
+++ b/lua/null-ls/builtins/code_actions/eslint.lua
@@ -154,6 +154,7 @@ local code_action_handler = function(params)
 end
 
 return h.make_builtin({
+    name = "eslint",
     method = CODE_ACTION,
     filetypes = { "javascript", "javascriptreact", "typescript", "typescriptreact", "vue" },
     generator_opts = {

--- a/lua/null-ls/builtins/code_actions/eslint_d.lua
+++ b/lua/null-ls/builtins/code_actions/eslint_d.lua
@@ -141,6 +141,7 @@ local handler = function(params)
 end
 
 return h.make_builtin({
+    name = "eslint_d",
     method = CODE_ACTION,
     filetypes = { "javascript", "javascriptreact", "typescript", "typescriptreact", "vue" },
     generator_opts = {

--- a/lua/null-ls/builtins/code_actions/shellcheck.lua
+++ b/lua/null-ls/builtins/code_actions/shellcheck.lua
@@ -139,6 +139,7 @@ local code_action_handler = function(params)
 end
 
 return h.make_builtin({
+    name = "shellcheck",
     method = CODE_ACTION,
     filetypes = { "sh" },
     generator_opts = {

--- a/lua/null-ls/builtins/completion/luasnip.lua
+++ b/lua/null-ls/builtins/completion/luasnip.lua
@@ -13,8 +13,8 @@ local function get_documentation(snip, data)
 end
 
 return h.make_builtin({
-    method = COMPLETION,
     name = "luasnip",
+    method = COMPLETION,
     filetypes = {},
     generator = {
         fn = function(params, done)

--- a/lua/null-ls/builtins/completion/spell.lua
+++ b/lua/null-ls/builtins/completion/spell.lua
@@ -4,9 +4,9 @@ local methods = require("null-ls.methods")
 local COMPLETION = methods.internal.COMPLETION
 
 return h.make_builtin({
+    name = "spell",
     method = COMPLETION,
     filetypes = {},
-    name = "spell",
     generator = {
         fn = function(params, done)
             local get_candidates = function(entries)

--- a/lua/null-ls/builtins/completion/tags.lua
+++ b/lua/null-ls/builtins/completion/tags.lua
@@ -5,9 +5,9 @@ local utils = require("null-ls.utils")
 local COMPLETION = methods.internal.COMPLETION
 
 return h.make_builtin({
+    name = "tags",
     method = COMPLETION,
     filetypes = {},
-    name = "tags",
     generator_opts = {
         runtime_condition = function(_)
             return #vim.fn.tagfiles() > 0

--- a/lua/null-ls/builtins/completion/vsnip.lua
+++ b/lua/null-ls/builtins/completion/vsnip.lua
@@ -4,9 +4,9 @@ local methods = require("null-ls.methods")
 local COMPLETION = methods.internal.COMPLETION
 
 return h.make_builtin({
+    name = "vsnip",
     method = COMPLETION,
     filetypes = {},
-    name = "vsnip",
     generator = {
         fn = function(params, done)
             local items = {}

--- a/lua/null-ls/builtins/diagnostics/ansiblelint.lua
+++ b/lua/null-ls/builtins/diagnostics/ansiblelint.lua
@@ -4,6 +4,7 @@ local methods = require("null-ls.methods")
 local DIAGNOSTICS = methods.internal.DIAGNOSTICS
 
 return h.make_builtin({
+    name = "ansiblelint",
     method = DIAGNOSTICS,
     filetypes = { "yaml" },
     generator_opts = {

--- a/lua/null-ls/builtins/diagnostics/chktex.lua
+++ b/lua/null-ls/builtins/diagnostics/chktex.lua
@@ -4,6 +4,7 @@ local methods = require("null-ls.methods")
 local DIAGNOSTICS = methods.internal.DIAGNOSTICS
 
 return h.make_builtin({
+    name = "chktex",
     method = DIAGNOSTICS,
     filetypes = { "tex" },
     generator_opts = {

--- a/lua/null-ls/builtins/diagnostics/codespell.lua
+++ b/lua/null-ls/builtins/diagnostics/codespell.lua
@@ -4,6 +4,7 @@ local methods = require("null-ls.methods")
 local DIAGNOSTICS = methods.internal.DIAGNOSTICS
 
 return h.make_builtin({
+    name = "codespell",
     method = DIAGNOSTICS,
     filetypes = {},
     generator_opts = {

--- a/lua/null-ls/builtins/diagnostics/cppcheck.lua
+++ b/lua/null-ls/builtins/diagnostics/cppcheck.lua
@@ -4,6 +4,7 @@ local methods = require("null-ls.methods")
 local DIAGNOSTICS = methods.internal.DIAGNOSTICS
 
 return h.make_builtin({
+    name = "cppcheck",
     method = DIAGNOSTICS,
     filetypes = { "cpp", "c" },
     generator_opts = {

--- a/lua/null-ls/builtins/diagnostics/cspell.lua
+++ b/lua/null-ls/builtins/diagnostics/cspell.lua
@@ -4,6 +4,7 @@ local methods = require("null-ls.methods")
 local DIAGNOSTICS = methods.internal.DIAGNOSTICS
 
 return h.make_builtin({
+    name = "cspell",
     method = DIAGNOSTICS,
     filetypes = {},
     generator_opts = {

--- a/lua/null-ls/builtins/diagnostics/editorconfig_checker.lua
+++ b/lua/null-ls/builtins/diagnostics/editorconfig_checker.lua
@@ -4,6 +4,7 @@ local methods = require("null-ls.methods")
 local DIAGNOSTICS = methods.internal.DIAGNOSTICS
 
 return h.make_builtin({
+    name = "editorconfig_checker",
     method = DIAGNOSTICS,
     filetypes = {},
     generator_opts = {

--- a/lua/null-ls/builtins/diagnostics/eslint.lua
+++ b/lua/null-ls/builtins/diagnostics/eslint.lua
@@ -24,6 +24,7 @@ local handle_eslint_output = function(params)
 end
 
 return h.make_builtin({
+    name = "eslint",
     method = DIAGNOSTICS,
     filetypes = { "javascript", "javascriptreact", "typescript", "typescriptreact", "vue" },
     generator_opts = {

--- a/lua/null-ls/builtins/diagnostics/eslint_d.lua
+++ b/lua/null-ls/builtins/diagnostics/eslint_d.lua
@@ -24,6 +24,7 @@ local handle_eslint_output = function(params)
 end
 
 return h.make_builtin({
+    name = "eslint_d",
     method = DIAGNOSTICS,
     filetypes = { "javascript", "javascriptreact", "typescript", "typescriptreact", "vue" },
     generator_opts = {

--- a/lua/null-ls/builtins/diagnostics/flake8.lua
+++ b/lua/null-ls/builtins/diagnostics/flake8.lua
@@ -4,6 +4,7 @@ local methods = require("null-ls.methods")
 local DIAGNOSTICS = methods.internal.DIAGNOSTICS
 
 return h.make_builtin({
+    name = "flake8",
     method = DIAGNOSTICS,
     filetypes = { "python" },
     generator_opts = {

--- a/lua/null-ls/builtins/diagnostics/gccdiag.lua
+++ b/lua/null-ls/builtins/diagnostics/gccdiag.lua
@@ -2,6 +2,7 @@ local h = require("null-ls.helpers")
 local methods = require("null-ls.methods")
 
 return h.make_builtin({
+    name = "gccdiag",
     method = methods.internal.DIAGNOSTICS_ON_SAVE,
     filetypes = { "c", "cpp" },
     factory = h.generator_factory,

--- a/lua/null-ls/builtins/diagnostics/golangci_lint.lua
+++ b/lua/null-ls/builtins/diagnostics/golangci_lint.lua
@@ -4,6 +4,7 @@ local methods = require("null-ls.methods")
 local DIAGNOSTICS_ON_SAVE = methods.internal.DIAGNOSTICS_ON_SAVE
 
 return h.make_builtin({
+    name = "golangci_lint",
     method = DIAGNOSTICS_ON_SAVE,
     filetypes = { "go" },
     generator_opts = {

--- a/lua/null-ls/builtins/diagnostics/hadolint.lua
+++ b/lua/null-ls/builtins/diagnostics/hadolint.lua
@@ -4,6 +4,7 @@ local methods = require("null-ls.methods")
 local DIAGNOSTICS = methods.internal.DIAGNOSTICS
 
 return h.make_builtin({
+    name = "hadolint",
     method = DIAGNOSTICS,
     filetypes = { "dockerfile" },
     generator_opts = {

--- a/lua/null-ls/builtins/diagnostics/jsonlint.lua
+++ b/lua/null-ls/builtins/diagnostics/jsonlint.lua
@@ -4,6 +4,7 @@ local methods = require("null-ls.methods")
 local DIAGNOSTICS = methods.internal.DIAGNOSTICS
 
 return h.make_builtin({
+    name = "jsonlint",
     method = DIAGNOSTICS,
     filetypes = { "json" },
     generator_opts = {

--- a/lua/null-ls/builtins/diagnostics/luacheck.lua
+++ b/lua/null-ls/builtins/diagnostics/luacheck.lua
@@ -4,6 +4,7 @@ local methods = require("null-ls.methods")
 local DIAGNOSTICS = methods.internal.DIAGNOSTICS
 
 return h.make_builtin({
+    name = "luacheck",
     method = DIAGNOSTICS,
     filetypes = { "lua" },
     generator_opts = {

--- a/lua/null-ls/builtins/diagnostics/markdownlint.lua
+++ b/lua/null-ls/builtins/diagnostics/markdownlint.lua
@@ -4,6 +4,7 @@ local methods = require("null-ls.methods")
 local DIAGNOSTICS = methods.internal.DIAGNOSTICS
 
 return h.make_builtin({
+    name = "markdownlint",
     method = DIAGNOSTICS,
     filetypes = { "markdown" },
     generator_opts = {

--- a/lua/null-ls/builtins/diagnostics/mdl.lua
+++ b/lua/null-ls/builtins/diagnostics/mdl.lua
@@ -4,6 +4,7 @@ local methods = require("null-ls.methods")
 local DIAGNOSTICS = methods.internal.DIAGNOSTICS
 
 return h.make_builtin({
+    name = "mdl",
     method = DIAGNOSTICS,
     filetypes = { "markdown" },
     generator_opts = {

--- a/lua/null-ls/builtins/diagnostics/misspell.lua
+++ b/lua/null-ls/builtins/diagnostics/misspell.lua
@@ -4,6 +4,7 @@ local methods = require("null-ls.methods")
 local DIAGNOSTICS = methods.internal.DIAGNOSTICS
 
 return h.make_builtin({
+    name = "misspell",
     method = DIAGNOSTICS,
     filetypes = {},
     generator_opts = {

--- a/lua/null-ls/builtins/diagnostics/mypy.lua
+++ b/lua/null-ls/builtins/diagnostics/mypy.lua
@@ -4,6 +4,7 @@ local methods = require("null-ls.methods")
 local DIAGNOSTICS = methods.internal.DIAGNOSTICS
 
 return h.make_builtin({
+    name = "mypy",
     method = DIAGNOSTICS,
     filetypes = { "python" },
     generator_opts = {

--- a/lua/null-ls/builtins/diagnostics/php.lua
+++ b/lua/null-ls/builtins/diagnostics/php.lua
@@ -5,6 +5,7 @@ local methods = require("null-ls.methods")
 local DIAGNOSTICS = methods.internal.DIAGNOSTICS
 
 return h.make_builtin({
+    name = "php",
     method = DIAGNOSTICS,
     filetypes = { "php" },
     generator_opts = {

--- a/lua/null-ls/builtins/diagnostics/phpcs.lua
+++ b/lua/null-ls/builtins/diagnostics/phpcs.lua
@@ -4,6 +4,7 @@ local methods = require("null-ls.methods")
 local DIAGNOSTICS = methods.internal.DIAGNOSTICS
 
 return h.make_builtin({
+    name = "phpcs",
     method = DIAGNOSTICS,
     filetypes = { "php" },
     generator_opts = {

--- a/lua/null-ls/builtins/diagnostics/phpstan.lua
+++ b/lua/null-ls/builtins/diagnostics/phpstan.lua
@@ -4,6 +4,7 @@ local methods = require("null-ls.methods")
 local DIAGNOSTICS = methods.internal.DIAGNOSTICS
 
 return h.make_builtin({
+    name = "phpstan",
     method = DIAGNOSTICS,
     filetypes = { "php" },
     generator_opts = {

--- a/lua/null-ls/builtins/diagnostics/proselint.lua
+++ b/lua/null-ls/builtins/diagnostics/proselint.lua
@@ -4,6 +4,7 @@ local methods = require("null-ls.methods")
 local DIAGNOSTICS = methods.internal.DIAGNOSTICS
 
 return h.make_builtin({
+    name = "proselint",
     method = DIAGNOSTICS,
     filetypes = { "markdown", "tex" },
     generator_opts = {

--- a/lua/null-ls/builtins/diagnostics/psalm.lua
+++ b/lua/null-ls/builtins/diagnostics/psalm.lua
@@ -4,6 +4,7 @@ local methods = require("null-ls.methods")
 local DIAGNOSTICS = methods.internal.DIAGNOSTICS
 
 return h.make_builtin({
+    name = "psalm",
     method = DIAGNOSTICS,
     filetypes = { "php" },
     generator_opts = {

--- a/lua/null-ls/builtins/diagnostics/pylama.lua
+++ b/lua/null-ls/builtins/diagnostics/pylama.lua
@@ -2,6 +2,7 @@ local h = require("null-ls.helpers")
 local methods = require("null-ls.methods")
 
 return h.make_builtin({
+    name = "pylama",
     method = methods.internal.DIAGNOSTICS,
     filetypes = { "python" },
     factory = h.generator_factory,

--- a/lua/null-ls/builtins/diagnostics/pylint.lua
+++ b/lua/null-ls/builtins/diagnostics/pylint.lua
@@ -4,6 +4,7 @@ local methods = require("null-ls.methods")
 local DIAGNOSTICS = methods.internal.DIAGNOSTICS
 
 return h.make_builtin({
+    name = "pylint",
     method = DIAGNOSTICS,
     filetypes = { "python" },
     generator_opts = {

--- a/lua/null-ls/builtins/diagnostics/qmllint.lua
+++ b/lua/null-ls/builtins/diagnostics/qmllint.lua
@@ -4,6 +4,7 @@ local methods = require("null-ls.methods")
 local DIAGNOSTICS = methods.internal.DIAGNOSTICS
 
 return h.make_builtin({
+    name = "qmllint",
     method = DIAGNOSTICS,
     filetypes = { "qml" },
     generator_opts = {

--- a/lua/null-ls/builtins/diagnostics/revive.lua
+++ b/lua/null-ls/builtins/diagnostics/revive.lua
@@ -8,6 +8,7 @@ local severities = {
 }
 
 return h.make_builtin({
+    name = "revive",
     method = methods.internal.DIAGNOSTICS_ON_SAVE,
     filetypes = { "go" },
     generator_opts = {

--- a/lua/null-ls/builtins/diagnostics/rubocop.lua
+++ b/lua/null-ls/builtins/diagnostics/rubocop.lua
@@ -39,6 +39,7 @@ local handle_rubocop_output = function(params)
 end
 
 return h.make_builtin({
+    name = "rubocop",
     method = DIAGNOSTICS,
     filetypes = { "ruby" },
     generator_opts = {

--- a/lua/null-ls/builtins/diagnostics/selene.lua
+++ b/lua/null-ls/builtins/diagnostics/selene.lua
@@ -4,6 +4,7 @@ local methods = require("null-ls.methods")
 local DIAGNOSTICS = methods.internal.DIAGNOSTICS
 
 return h.make_builtin({
+    name = "selene",
     method = DIAGNOSTICS,
     filetypes = { "lua" },
     generator_opts = {

--- a/lua/null-ls/builtins/diagnostics/shellcheck.lua
+++ b/lua/null-ls/builtins/diagnostics/shellcheck.lua
@@ -4,6 +4,7 @@ local methods = require("null-ls.methods")
 local DIAGNOSTICS = methods.internal.DIAGNOSTICS
 
 return h.make_builtin({
+    name = "shellcheck",
     method = DIAGNOSTICS,
     filetypes = { "sh" },
     generator_opts = {

--- a/lua/null-ls/builtins/diagnostics/standardjs.lua
+++ b/lua/null-ls/builtins/diagnostics/standardjs.lua
@@ -4,6 +4,7 @@ local methods = require("null-ls.methods")
 local DIAGNOSTICS = methods.internal.DIAGNOSTICS
 
 return h.make_builtin({
+    name = "standardjs",
     method = DIAGNOSTICS,
     filetypes = { "javascript", "javascriptreact" },
     generator_opts = {

--- a/lua/null-ls/builtins/diagnostics/standardrb.lua
+++ b/lua/null-ls/builtins/diagnostics/standardrb.lua
@@ -39,6 +39,7 @@ local handle_rubocop_output = function(params)
 end
 
 return h.make_builtin({
+    name = "standardrb",
     method = DIAGNOSTICS,
     filetypes = { "ruby" },
     generator_opts = {

--- a/lua/null-ls/builtins/diagnostics/staticcheck.lua
+++ b/lua/null-ls/builtins/diagnostics/staticcheck.lua
@@ -10,6 +10,7 @@ local severities = {
 }
 
 return h.make_builtin({
+    name = "staticcheck",
     method = DIAGNOSTICS_ON_SAVE,
     filetypes = { "go" },
     generator_opts = {

--- a/lua/null-ls/builtins/diagnostics/statix.lua
+++ b/lua/null-ls/builtins/diagnostics/statix.lua
@@ -4,6 +4,7 @@ local methods = require("null-ls.methods")
 local DIAGNOSTICS = methods.internal.DIAGNOSTICS
 
 return h.make_builtin({
+    name = "statix",
     method = DIAGNOSTICS,
     filetypes = { "nix" },
     generator_opts = {

--- a/lua/null-ls/builtins/diagnostics/stylelint.lua
+++ b/lua/null-ls/builtins/diagnostics/stylelint.lua
@@ -4,6 +4,7 @@ local methods = require("null-ls.methods")
 local DIAGNOSTICS = methods.internal.DIAGNOSTICS
 
 return h.make_builtin({
+    name = "stylelint",
     method = DIAGNOSTICS,
     filetypes = { "scss", "less", "css", "sass" },
     generator_opts = {

--- a/lua/null-ls/builtins/diagnostics/tsc.lua
+++ b/lua/null-ls/builtins/diagnostics/tsc.lua
@@ -12,6 +12,7 @@ local get_client = function()
 end
 
 return h.make_builtin({
+    name = "tsc",
     method = methods.internal.DIAGNOSTICS_ON_SAVE,
     filetypes = { "typescript", "typescriptreact" },
     generator_opts = {

--- a/lua/null-ls/builtins/diagnostics/vale.lua
+++ b/lua/null-ls/builtins/diagnostics/vale.lua
@@ -4,6 +4,7 @@ local methods = require("null-ls.methods")
 local DIAGNOSTICS = methods.internal.DIAGNOSTICS
 
 return h.make_builtin({
+    name = "vale",
     method = DIAGNOSTICS,
     filetypes = { "markdown", "tex" },
     generator_opts = {

--- a/lua/null-ls/builtins/diagnostics/vint.lua
+++ b/lua/null-ls/builtins/diagnostics/vint.lua
@@ -4,6 +4,7 @@ local methods = require("null-ls.methods")
 local DIAGNOSTICS = methods.internal.DIAGNOSTICS
 
 return h.make_builtin({
+    name = "vint",
     method = DIAGNOSTICS,
     filetypes = { "vim" },
     generator_opts = {

--- a/lua/null-ls/builtins/diagnostics/write_good.lua
+++ b/lua/null-ls/builtins/diagnostics/write_good.lua
@@ -4,6 +4,7 @@ local methods = require("null-ls.methods")
 local DIAGNOSTICS = methods.internal.DIAGNOSTICS
 
 return h.make_builtin({
+    name = "write_good",
     method = DIAGNOSTICS,
     filetypes = { "markdown" },
     generator_opts = {

--- a/lua/null-ls/builtins/diagnostics/yamllint.lua
+++ b/lua/null-ls/builtins/diagnostics/yamllint.lua
@@ -4,6 +4,7 @@ local methods = require("null-ls.methods")
 local DIAGNOSTICS = methods.internal.DIAGNOSTICS
 
 return h.make_builtin({
+    name = "yamllint",
     method = DIAGNOSTICS,
     filetypes = { "yaml" },
     generator_opts = {

--- a/lua/null-ls/builtins/formatting/asmfmt.lua
+++ b/lua/null-ls/builtins/formatting/asmfmt.lua
@@ -4,6 +4,7 @@ local methods = require("null-ls.methods")
 local FORMATTING = methods.internal.FORMATTING
 
 return h.make_builtin({
+    name = "asmfmt",
     method = FORMATTING,
     filetypes = { "asm" },
     generator_opts = {

--- a/lua/null-ls/builtins/formatting/autopep8.lua
+++ b/lua/null-ls/builtins/formatting/autopep8.lua
@@ -4,6 +4,7 @@ local methods = require("null-ls.methods")
 local FORMATTING = methods.internal.FORMATTING
 
 return h.make_builtin({
+    name = "autopep8",
     method = FORMATTING,
     filetypes = { "python" },
     generator_opts = {

--- a/lua/null-ls/builtins/formatting/bean_format.lua
+++ b/lua/null-ls/builtins/formatting/bean_format.lua
@@ -4,6 +4,7 @@ local methods = require("null-ls.methods")
 local FORMATTING = methods.internal.FORMATTING
 
 return h.make_builtin({
+    name = "bean_format",
     method = FORMATTING,
     filetypes = { "beancount" },
     generator_opts = {

--- a/lua/null-ls/builtins/formatting/black.lua
+++ b/lua/null-ls/builtins/formatting/black.lua
@@ -4,6 +4,7 @@ local methods = require("null-ls.methods")
 local FORMATTING = methods.internal.FORMATTING
 
 return h.make_builtin({
+    name = "black",
     method = FORMATTING,
     filetypes = { "python" },
     generator_opts = {

--- a/lua/null-ls/builtins/formatting/brittany.lua
+++ b/lua/null-ls/builtins/formatting/brittany.lua
@@ -4,6 +4,7 @@ local methods = require("null-ls.methods")
 local FORMATTING = methods.internal.FORMATTING
 
 return h.make_builtin({
+    name = "brittany",
     method = FORMATTING,
     filetypes = { "haskell" },
     generator_opts = {

--- a/lua/null-ls/builtins/formatting/buildifier.lua
+++ b/lua/null-ls/builtins/formatting/buildifier.lua
@@ -4,6 +4,7 @@ local methods = require("null-ls.methods")
 local FORMATTING = methods.internal.FORMATTING
 
 return h.make_builtin({
+    name = "buildifier",
     method = FORMATTING,
     filetypes = { "bzl" },
     generator_opts = {

--- a/lua/null-ls/builtins/formatting/clang_format.lua
+++ b/lua/null-ls/builtins/formatting/clang_format.lua
@@ -4,6 +4,7 @@ local methods = require("null-ls.methods")
 local FORMATTING = methods.internal.FORMATTING
 
 return h.make_builtin({
+    name = "clang_format",
     method = FORMATTING,
     filetypes = { "c", "cpp", "cs", "java" },
     generator_opts = {

--- a/lua/null-ls/builtins/formatting/cmake_format.lua
+++ b/lua/null-ls/builtins/formatting/cmake_format.lua
@@ -4,6 +4,7 @@ local methods = require("null-ls.methods")
 local FORMATTING = methods.internal.FORMATTING
 
 return h.make_builtin({
+    name = "cmake_format",
     method = FORMATTING,
     filetypes = { "cmake" },
     generator_opts = {

--- a/lua/null-ls/builtins/formatting/codespell.lua
+++ b/lua/null-ls/builtins/formatting/codespell.lua
@@ -4,6 +4,7 @@ local methods = require("null-ls.methods")
 local FORMATTING = methods.internal.FORMATTING
 
 return h.make_builtin({
+    name = "codespell",
     method = FORMATTING,
     filetypes = {},
     generator_opts = {

--- a/lua/null-ls/builtins/formatting/crystal_format.lua
+++ b/lua/null-ls/builtins/formatting/crystal_format.lua
@@ -4,6 +4,7 @@ local methods = require("null-ls.methods")
 local FORMATTING = methods.internal.FORMATTING
 
 return h.make_builtin({
+    name = "crystal_format",
     method = FORMATTING,
     filetypes = { "crystal" },
     generator_opts = {

--- a/lua/null-ls/builtins/formatting/cue_fmt.lua
+++ b/lua/null-ls/builtins/formatting/cue_fmt.lua
@@ -4,6 +4,7 @@ local methods = require("null-ls.methods")
 local FORMATTING = methods.internal.FORMATTING
 
 return h.make_builtin({
+    name = "cue_fmt",
     method = FORMATTING,
     filetypes = { "cue" },
     generator_opts = {

--- a/lua/null-ls/builtins/formatting/dart_format.lua
+++ b/lua/null-ls/builtins/formatting/dart_format.lua
@@ -4,6 +4,7 @@ local methods = require("null-ls.methods")
 local FORMATTING = methods.internal.FORMATTING
 
 return h.make_builtin({
+    name = "dart_format",
     method = FORMATTING,
     filetypes = { "dart" },
     generator_opts = {

--- a/lua/null-ls/builtins/formatting/deno_fmt.lua
+++ b/lua/null-ls/builtins/formatting/deno_fmt.lua
@@ -4,6 +4,7 @@ local methods = require("null-ls.methods")
 local FORMATTING = methods.internal.FORMATTING
 
 return h.make_builtin({
+    name = "deno_fmt",
     method = FORMATTING,
     filetypes = {
         "javascript",

--- a/lua/null-ls/builtins/formatting/dfmt.lua
+++ b/lua/null-ls/builtins/formatting/dfmt.lua
@@ -4,6 +4,7 @@ local methods = require("null-ls.methods")
 local FORMATTING = methods.internal.FORMATTING
 
 return h.make_builtin({
+    name = "dfmt",
     method = FORMATTING,
     filetypes = { "d" },
     generator_opts = {

--- a/lua/null-ls/builtins/formatting/djhtml.lua
+++ b/lua/null-ls/builtins/formatting/djhtml.lua
@@ -4,6 +4,7 @@ local methods = require("null-ls.methods")
 local FORMATTING = methods.internal.FORMATTING
 
 return h.make_builtin({
+    name = "djhtml",
     method = FORMATTING,
     filetypes = { "django", "jinja.html", "htmldjango" },
     generator_opts = {

--- a/lua/null-ls/builtins/formatting/elm_format.lua
+++ b/lua/null-ls/builtins/formatting/elm_format.lua
@@ -4,6 +4,7 @@ local methods = require("null-ls.methods")
 local FORMATTING = methods.internal.FORMATTING
 
 return h.make_builtin({
+    name = "elm_format",
     method = FORMATTING,
     filetypes = { "elm" },
     generator_opts = {

--- a/lua/null-ls/builtins/formatting/erlfmt.lua
+++ b/lua/null-ls/builtins/formatting/erlfmt.lua
@@ -4,6 +4,7 @@ local methods = require("null-ls.methods")
 local FORMATTING = methods.internal.FORMATTING
 
 return h.make_builtin({
+    name = "erlfmt",
     method = FORMATTING,
     filetypes = { "erlang" },
     generator_opts = {

--- a/lua/null-ls/builtins/formatting/eslint.lua
+++ b/lua/null-ls/builtins/formatting/eslint.lua
@@ -4,6 +4,7 @@ local methods = require("null-ls.methods")
 local FORMATTING = methods.internal.FORMATTING
 
 return h.make_builtin({
+    name = "eslint",
     method = FORMATTING,
     filetypes = {
         "javascript",

--- a/lua/null-ls/builtins/formatting/eslint_d.lua
+++ b/lua/null-ls/builtins/formatting/eslint_d.lua
@@ -4,6 +4,7 @@ local methods = require("null-ls.methods")
 local FORMATTING = methods.internal.FORMATTING
 
 return h.make_builtin({
+    name = "eslint_d",
     method = FORMATTING,
     filetypes = {
         "javascript",

--- a/lua/null-ls/builtins/formatting/fish_indent.lua
+++ b/lua/null-ls/builtins/formatting/fish_indent.lua
@@ -4,6 +4,7 @@ local methods = require("null-ls.methods")
 local FORMATTING = methods.internal.FORMATTING
 
 return h.make_builtin({
+    name = "fish_indent",
     method = FORMATTING,
     filetypes = { "fish" },
     generator_opts = {

--- a/lua/null-ls/builtins/formatting/fixjson.lua
+++ b/lua/null-ls/builtins/formatting/fixjson.lua
@@ -4,6 +4,7 @@ local methods = require("null-ls.methods")
 local FORMATTING = methods.internal.FORMATTING
 
 return h.make_builtin({
+    name = "fixjson",
     method = FORMATTING,
     filetypes = { "json" },
     generator_opts = {

--- a/lua/null-ls/builtins/formatting/fnlfmt.lua
+++ b/lua/null-ls/builtins/formatting/fnlfmt.lua
@@ -4,6 +4,7 @@ local methods = require("null-ls.methods")
 local FORMATTING = methods.internal.FORMATTING
 
 return h.make_builtin({
+    name = "fnlfmt",
     method = FORMATTING,
     filetypes = { "fennel", "fnl" },
     generator_opts = {

--- a/lua/null-ls/builtins/formatting/format_r.lua
+++ b/lua/null-ls/builtins/formatting/format_r.lua
@@ -4,6 +4,7 @@ local methods = require("null-ls.methods")
 local FORMATTING = methods.internal.FORMATTING
 
 return h.make_builtin({
+    name = "format_r",
     method = FORMATTING,
     filetypes = { "r", "rmd" },
     generator_opts = {

--- a/lua/null-ls/builtins/formatting/fourmolu.lua
+++ b/lua/null-ls/builtins/formatting/fourmolu.lua
@@ -4,6 +4,7 @@ local methods = require("null-ls.methods")
 local FORMATTING = methods.internal.FORMATTING
 
 return h.make_builtin({
+    name = "fourmolu",
     method = FORMATTING,
     filetypes = { "haskell" },
     generator_opts = {

--- a/lua/null-ls/builtins/formatting/fprettify.lua
+++ b/lua/null-ls/builtins/formatting/fprettify.lua
@@ -4,6 +4,7 @@ local methods = require("null-ls.methods")
 local FORMATTING = methods.internal.FORMATTING
 
 return h.make_builtin({
+    name = "fprettify",
     method = FORMATTING,
     filetypes = { "fortran" },
     generator_opts = {

--- a/lua/null-ls/builtins/formatting/gofmt.lua
+++ b/lua/null-ls/builtins/formatting/gofmt.lua
@@ -4,6 +4,7 @@ local methods = require("null-ls.methods")
 local FORMATTING = methods.internal.FORMATTING
 
 return h.make_builtin({
+    name = "gofmt",
     method = FORMATTING,
     filetypes = { "go" },
     generator_opts = {

--- a/lua/null-ls/builtins/formatting/gofumpt.lua
+++ b/lua/null-ls/builtins/formatting/gofumpt.lua
@@ -4,6 +4,7 @@ local methods = require("null-ls.methods")
 local FORMATTING = methods.internal.FORMATTING
 
 return h.make_builtin({
+    name = "gofumpt",
     method = FORMATTING,
     filetypes = { "go" },
     generator_opts = {

--- a/lua/null-ls/builtins/formatting/goimports.lua
+++ b/lua/null-ls/builtins/formatting/goimports.lua
@@ -4,6 +4,7 @@ local methods = require("null-ls.methods")
 local FORMATTING = methods.internal.FORMATTING
 
 return h.make_builtin({
+    name = "goimports",
     method = FORMATTING,
     filetypes = { "go" },
     generator_opts = {

--- a/lua/null-ls/builtins/formatting/golines.lua
+++ b/lua/null-ls/builtins/formatting/golines.lua
@@ -4,6 +4,7 @@ local methods = require("null-ls.methods")
 local FORMATTING = methods.internal.FORMATTING
 
 return h.make_builtin({
+    name = "golines",
     method = FORMATTING,
     filetypes = { "go" },
     generator_opts = {

--- a/lua/null-ls/builtins/formatting/google_java_format.lua
+++ b/lua/null-ls/builtins/formatting/google_java_format.lua
@@ -4,6 +4,7 @@ local methods = require("null-ls.methods")
 local FORMATTING = methods.internal.FORMATTING
 
 return h.make_builtin({
+    name = "google_java_format",
     method = FORMATTING,
     filetypes = { "java" },
     generator_opts = {

--- a/lua/null-ls/builtins/formatting/isort.lua
+++ b/lua/null-ls/builtins/formatting/isort.lua
@@ -4,6 +4,7 @@ local methods = require("null-ls.methods")
 local FORMATTING = methods.internal.FORMATTING
 
 return h.make_builtin({
+    name = "isort",
     method = FORMATTING,
     filetypes = { "python" },
     generator_opts = {

--- a/lua/null-ls/builtins/formatting/joker.lua
+++ b/lua/null-ls/builtins/formatting/joker.lua
@@ -4,6 +4,7 @@ local methods = require("null-ls.methods")
 local FORMATTING = methods.internal.FORMATTING
 
 return h.make_builtin({
+    name = "joker",
     method = FORMATTING,
     filetypes = { "clj" },
     generator_opts = {

--- a/lua/null-ls/builtins/formatting/json_tool.lua
+++ b/lua/null-ls/builtins/formatting/json_tool.lua
@@ -4,6 +4,7 @@ local methods = require("null-ls.methods")
 local FORMATTING = methods.internal.FORMATTING
 
 return h.make_builtin({
+    name = "json_tool",
     method = FORMATTING,
     filetypes = { "json" },
     generator_opts = {

--- a/lua/null-ls/builtins/formatting/latexindent.lua
+++ b/lua/null-ls/builtins/formatting/latexindent.lua
@@ -4,6 +4,7 @@ local methods = require("null-ls.methods")
 local FORMATTING = methods.internal.FORMATTING
 
 return h.make_builtin({
+    name = "latexindent",
     method = FORMATTING,
     filetypes = { "tex" },
     generator_opts = { command = "latexindent", args = { "-" }, to_stdin = true },

--- a/lua/null-ls/builtins/formatting/lua_format.lua
+++ b/lua/null-ls/builtins/formatting/lua_format.lua
@@ -4,6 +4,7 @@ local methods = require("null-ls.methods")
 local FORMATTING = methods.internal.FORMATTING
 
 return h.make_builtin({
+    name = "lua_format",
     method = FORMATTING,
     filetypes = { "lua" },
     generator_opts = {

--- a/lua/null-ls/builtins/formatting/markdownlint.lua
+++ b/lua/null-ls/builtins/formatting/markdownlint.lua
@@ -4,6 +4,7 @@ local methods = require("null-ls.methods")
 local FORMATTING = methods.internal.FORMATTING
 
 return h.make_builtin({
+    name = "markdownlint",
     method = FORMATTING,
     filetypes = { "markdown" },
     generator_opts = {

--- a/lua/null-ls/builtins/formatting/mix.lua
+++ b/lua/null-ls/builtins/formatting/mix.lua
@@ -4,6 +4,7 @@ local methods = require("null-ls.methods")
 local FORMATTING = methods.internal.FORMATTING
 
 return h.make_builtin({
+    name = "mix",
     method = FORMATTING,
     filetypes = { "elixir" },
     generator_opts = {

--- a/lua/null-ls/builtins/formatting/nginx_beautifier.lua
+++ b/lua/null-ls/builtins/formatting/nginx_beautifier.lua
@@ -4,6 +4,7 @@ local methods = require("null-ls.methods")
 local FORMATTING = methods.internal.FORMATTING
 
 return h.make_builtin({
+    name = "nginx_beautifier",
     method = FORMATTING,
     filetypes = { "nginx" },
     generator_opts = {

--- a/lua/null-ls/builtins/formatting/nimpretty.lua
+++ b/lua/null-ls/builtins/formatting/nimpretty.lua
@@ -4,6 +4,7 @@ local methods = require("null-ls.methods")
 local FORMATTING = methods.internal.FORMATTING
 
 return h.make_builtin({
+    name = "nimpretty",
     method = FORMATTING,
     filetypes = { "nim" },
     generator_opts = {

--- a/lua/null-ls/builtins/formatting/nixfmt.lua
+++ b/lua/null-ls/builtins/formatting/nixfmt.lua
@@ -4,6 +4,7 @@ local methods = require("null-ls.methods")
 local FORMATTING = methods.internal.FORMATTING
 
 return h.make_builtin({
+    name = "nixfmt",
     method = FORMATTING,
     filetypes = { "nix" },
     generator_opts = {

--- a/lua/null-ls/builtins/formatting/perltidy.lua
+++ b/lua/null-ls/builtins/formatting/perltidy.lua
@@ -4,6 +4,7 @@ local methods = require("null-ls.methods")
 local FORMATTING = methods.internal.FORMATTING
 
 return h.make_builtin({
+    name = "perltidy",
     method = FORMATTING,
     filetypes = { "perl" },
     generator_opts = {

--- a/lua/null-ls/builtins/formatting/phpcbf.lua
+++ b/lua/null-ls/builtins/formatting/phpcbf.lua
@@ -4,6 +4,7 @@ local methods = require("null-ls.methods")
 local FORMATTING = methods.internal.FORMATTING
 
 return h.make_builtin({
+    name = "phpcbf",
     method = FORMATTING,
     filetypes = { "php" },
     generator_opts = {

--- a/lua/null-ls/builtins/formatting/phpcsfixer.lua
+++ b/lua/null-ls/builtins/formatting/phpcsfixer.lua
@@ -4,6 +4,7 @@ local methods = require("null-ls.methods")
 local FORMATTING = methods.internal.FORMATTING
 
 return h.make_builtin({
+    name = "phpcsfixer",
     method = FORMATTING,
     filetypes = { "php" },
     generator_opts = {

--- a/lua/null-ls/builtins/formatting/prettier.lua
+++ b/lua/null-ls/builtins/formatting/prettier.lua
@@ -5,6 +5,7 @@ local FORMATTING = methods.internal.FORMATTING
 local RANGE_FORMATTING = methods.internal.RANGE_FORMATTING
 
 return h.make_builtin({
+    name = "prettier",
     method = { FORMATTING, RANGE_FORMATTING },
     filetypes = {
         "javascript",

--- a/lua/null-ls/builtins/formatting/prettier_d_slim.lua
+++ b/lua/null-ls/builtins/formatting/prettier_d_slim.lua
@@ -5,6 +5,7 @@ local FORMATTING = methods.internal.FORMATTING
 local RANGE_FORMATTING = methods.internal.RANGE_FORMATTING
 
 return h.make_builtin({
+    name = "prettier_d_slim",
     method = { FORMATTING, RANGE_FORMATTING },
     filetypes = {
         "javascript",

--- a/lua/null-ls/builtins/formatting/prettier_standard.lua
+++ b/lua/null-ls/builtins/formatting/prettier_standard.lua
@@ -4,6 +4,7 @@ local methods = require("null-ls.methods")
 local FORMATTING = methods.internal.FORMATTING
 
 return h.make_builtin({
+    name = "prettier_standard",
     method = FORMATTING,
     filetypes = { "javascript", "javascriptreact" },
     generator_opts = {

--- a/lua/null-ls/builtins/formatting/prettierd.lua
+++ b/lua/null-ls/builtins/formatting/prettierd.lua
@@ -4,6 +4,7 @@ local methods = require("null-ls.methods")
 local FORMATTING = methods.internal.FORMATTING
 
 return h.make_builtin({
+    name = "prettierd",
     method = FORMATTING,
     filetypes = {
         "javascript",

--- a/lua/null-ls/builtins/formatting/prismaFmt.lua
+++ b/lua/null-ls/builtins/formatting/prismaFmt.lua
@@ -4,6 +4,7 @@ local methods = require("null-ls.methods")
 local FORMATTING = methods.internal.FORMATTING
 
 return h.make_builtin({
+    name = "prismaFmt",
     method = FORMATTING,
     filetypes = { "prisma" },
     generator_opts = {

--- a/lua/null-ls/builtins/formatting/ptop.lua
+++ b/lua/null-ls/builtins/formatting/ptop.lua
@@ -4,6 +4,7 @@ local methods = require("null-ls.methods")
 local FORMATTING = methods.internal.FORMATTING
 
 return h.make_builtin({
+    name = "ptop",
     method = FORMATTING,
     filetypes = { "pascal", "delphi" },
     generator_opts = {

--- a/lua/null-ls/builtins/formatting/qmlformat.lua
+++ b/lua/null-ls/builtins/formatting/qmlformat.lua
@@ -4,6 +4,7 @@ local methods = require("null-ls.methods")
 local FORMATTING = methods.internal.FORMATTING
 
 return h.make_builtin({
+    name = "qmlformat",
     method = FORMATTING,
     filetypes = { "qml" },
     generator_opts = {

--- a/lua/null-ls/builtins/formatting/reorder_python_imports.lua
+++ b/lua/null-ls/builtins/formatting/reorder_python_imports.lua
@@ -4,6 +4,7 @@ local methods = require("null-ls.methods")
 local FORMATTING = methods.internal.FORMATTING
 
 return h.make_builtin({
+    name = "reorder_python_imports",
     method = FORMATTING,
     filetypes = { "python" },
     generator_opts = {

--- a/lua/null-ls/builtins/formatting/rubocop.lua
+++ b/lua/null-ls/builtins/formatting/rubocop.lua
@@ -4,6 +4,7 @@ local methods = require("null-ls.methods")
 local FORMATTING = methods.internal.FORMATTING
 
 return h.make_builtin({
+    name = "rubocop",
     method = FORMATTING,
     filetypes = { "ruby" },
     generator_opts = {

--- a/lua/null-ls/builtins/formatting/rufo.lua
+++ b/lua/null-ls/builtins/formatting/rufo.lua
@@ -4,6 +4,7 @@ local methods = require("null-ls.methods")
 local FORMATTING = methods.internal.FORMATTING
 
 return h.make_builtin({
+    name = "rufo",
     method = FORMATTING,
     filetypes = { "ruby" },
     generator_opts = {

--- a/lua/null-ls/builtins/formatting/rustfmt.lua
+++ b/lua/null-ls/builtins/formatting/rustfmt.lua
@@ -4,6 +4,7 @@ local methods = require("null-ls.methods")
 local FORMATTING = methods.internal.FORMATTING
 
 return h.make_builtin({
+    name = "rustfmt",
     method = FORMATTING,
     filetypes = { "rust" },
     generator_opts = {

--- a/lua/null-ls/builtins/formatting/rustywind.lua
+++ b/lua/null-ls/builtins/formatting/rustywind.lua
@@ -4,6 +4,7 @@ local methods = require("null-ls.methods")
 local FORMATTING = methods.internal.FORMATTING
 
 return h.make_builtin({
+    name = "rustywind",
     method = FORMATTING,
     filetypes = {
         "javascript",

--- a/lua/null-ls/builtins/formatting/scalafmt.lua
+++ b/lua/null-ls/builtins/formatting/scalafmt.lua
@@ -4,6 +4,7 @@ local methods = require("null-ls.methods")
 local FORMATTING = methods.internal.FORMATTING
 
 return h.make_builtin({
+    name = "scalafmt",
     method = FORMATTING,
     filetypes = { "scala" },
     generator_opts = {

--- a/lua/null-ls/builtins/formatting/shellharden.lua
+++ b/lua/null-ls/builtins/formatting/shellharden.lua
@@ -4,6 +4,7 @@ local methods = require("null-ls.methods")
 local FORMATTING = methods.internal.FORMATTING
 
 return h.make_builtin({
+    name = "shellharden",
     method = FORMATTING,
     filetypes = {
         "sh",

--- a/lua/null-ls/builtins/formatting/shfmt.lua
+++ b/lua/null-ls/builtins/formatting/shfmt.lua
@@ -4,6 +4,7 @@ local methods = require("null-ls.methods")
 local FORMATTING = methods.internal.FORMATTING
 
 return h.make_builtin({
+    name = "shfmt",
     method = FORMATTING,
     filetypes = { "sh" },
     generator_opts = {

--- a/lua/null-ls/builtins/formatting/sqlformat.lua
+++ b/lua/null-ls/builtins/formatting/sqlformat.lua
@@ -4,6 +4,7 @@ local methods = require("null-ls.methods")
 local FORMATTING = methods.internal.FORMATTING
 
 return h.make_builtin({
+    name = "sqlformat",
     method = FORMATTING,
     filetypes = { "sql" },
     generator_opts = {

--- a/lua/null-ls/builtins/formatting/standardrb.lua
+++ b/lua/null-ls/builtins/formatting/standardrb.lua
@@ -4,6 +4,7 @@ local methods = require("null-ls.methods")
 local FORMATTING = methods.internal.FORMATTING
 
 return h.make_builtin({
+    name = "standardrb",
     method = FORMATTING,
     filetypes = { "ruby" },
     generator_opts = {

--- a/lua/null-ls/builtins/formatting/stylelint.lua
+++ b/lua/null-ls/builtins/formatting/stylelint.lua
@@ -4,6 +4,7 @@ local methods = require("null-ls.methods")
 local FORMATTING = methods.internal.FORMATTING
 
 return h.make_builtin({
+    name = "stylelint",
     method = FORMATTING,
     filetypes = { "scss", "less", "css", "sass" },
     generator_opts = {

--- a/lua/null-ls/builtins/formatting/styler.lua
+++ b/lua/null-ls/builtins/formatting/styler.lua
@@ -4,6 +4,7 @@ local methods = require("null-ls.methods")
 local FORMATTING = methods.internal.FORMATTING
 
 return h.make_builtin({
+    name = "styler",
     method = FORMATTING,
     filetypes = { "r", "rmd" },
     generator_opts = {

--- a/lua/null-ls/builtins/formatting/stylua.lua
+++ b/lua/null-ls/builtins/formatting/stylua.lua
@@ -5,6 +5,7 @@ local FORMATTING = methods.internal.FORMATTING
 local RANGE_FORMATTING = methods.internal.RANGE_FORMATTING
 
 return h.make_builtin({
+    name = "stylua",
     method = { FORMATTING, RANGE_FORMATTING },
     filetypes = { "lua" },
     generator_opts = {

--- a/lua/null-ls/builtins/formatting/surface.lua
+++ b/lua/null-ls/builtins/formatting/surface.lua
@@ -4,6 +4,7 @@ local methods = require("null-ls.methods")
 local FORMATTING = methods.internal.FORMATTING
 
 return h.make_builtin({
+    name = "surface",
     method = FORMATTING,
     filetypes = { "elixir", "surface" },
     generator_opts = {

--- a/lua/null-ls/builtins/formatting/swiftformat.lua
+++ b/lua/null-ls/builtins/formatting/swiftformat.lua
@@ -4,6 +4,7 @@ local methods = require("null-ls.methods")
 local FORMATTING = methods.internal.FORMATTING
 
 return h.make_builtin({
+    name = "swiftformat",
     method = FORMATTING,
     filetypes = { "swift" },
     generator_opts = {

--- a/lua/null-ls/builtins/formatting/taplo.lua
+++ b/lua/null-ls/builtins/formatting/taplo.lua
@@ -4,6 +4,7 @@ local methods = require("null-ls.methods")
 local FORMATTING = methods.internal.FORMATTING
 
 return h.make_builtin({
+    name = "taplo",
     method = FORMATTING,
     filetypes = { "toml" },
     generator_opts = {

--- a/lua/null-ls/builtins/formatting/terraform_fmt.lua
+++ b/lua/null-ls/builtins/formatting/terraform_fmt.lua
@@ -4,6 +4,7 @@ local methods = require("null-ls.methods")
 local FORMATTING = methods.internal.FORMATTING
 
 return h.make_builtin({
+    name = "terraform_fmt",
     method = FORMATTING,
     filetypes = { "terraform", "tf" },
     generator_opts = {

--- a/lua/null-ls/builtins/formatting/uncrustify.lua
+++ b/lua/null-ls/builtins/formatting/uncrustify.lua
@@ -4,6 +4,7 @@ local methods = require("null-ls.methods")
 local FORMATTING = methods.internal.FORMATTING
 
 return h.make_builtin({
+    name = "uncrustify",
     method = FORMATTING,
     filetypes = { "c", "cpp", "cs", "java" },
     generator_opts = {

--- a/lua/null-ls/builtins/formatting/yapf.lua
+++ b/lua/null-ls/builtins/formatting/yapf.lua
@@ -24,6 +24,7 @@ local function range_formatting_args_factory(base_args, start_arg)
 end
 
 return h.make_builtin({
+    name = "yapf",
     method = { FORMATTING, RANGE_FORMATTING },
     filetypes = { "python" },
     generator_opts = {

--- a/lua/null-ls/builtins/formatting/zigfmt.lua
+++ b/lua/null-ls/builtins/formatting/zigfmt.lua
@@ -4,6 +4,7 @@ local methods = require("null-ls.methods")
 local FORMATTING = methods.internal.FORMATTING
 
 return h.make_builtin({
+    name = "zigfmt",
     method = FORMATTING,
     filetypes = { "zig" },
     generator_opts = {


### PR DESCRIPTION
As discussed in #520, default names were added to every builtin source.

I thought that the builtin source names took priority over the user provided name option, but apparently that's not the case and a user's name option works as expected.