### PR TITLE
feat(builtin): Add `gitlint` diagnostic

### DIFF
--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -1915,6 +1915,24 @@ local sources = { null_ls.builtins.diagnostics.flake8 }
 - `command = "flake8"`
 - `args = { "--stdin-display-name", "$FILENAME", "-" }`
 
+#### [gitlint](https://jorisroovers.com/gitlint/)
+
+##### About
+
+Linter for git commit messages
+
+##### Usage
+
+```lua
+local sources = { null_ls.builtins.diagnostics.gitlint }
+```
+
+##### Defaults
+
+- `filetypes = { "gitcommit" }`
+- `command = "gitlint"`
+- `args = { "--msg-filename", "$FILENAME" }`
+
 #### [pylama](https://github.com/klen/pylama)
 
 ##### About

--- a/lua/null-ls/builtins/diagnostics/gitlint.lua
+++ b/lua/null-ls/builtins/diagnostics/gitlint.lua
@@ -1,0 +1,27 @@
+local h = require("null-ls.helpers")
+local methods = require("null-ls.methods")
+
+local DIAGNOSTICS = methods.internal.DIAGNOSTICS
+
+return h.make_builtin({
+    name = "gitlint",
+    method = DIAGNOSTICS,
+    filetypes = { "gitcommit" },
+    generator_opts = {
+        command = "gitlint",
+        args = { "--msg-filename", "$FILENAME" },
+        to_temp_file = true,
+        from_stderr = true,
+        format = "line",
+        check_exit_code = function(code)
+            return code <= 1
+        end,
+        on_output = h.diagnostics.from_patterns({
+            {
+                pattern = [[(%d+): (%w+) (.+)]],
+                groups = { "row", "code", "message" },
+            },
+        }),
+    },
+    factory = h.generator_factory,
+})


### PR DESCRIPTION
Adds `gitlint` diagnostic source, for checking git commit messages: https://jorisroovers.com/gitlint/

Unfortunately [`gitlint` doesn't support receiving data over stdin from sockets](https://github.com/jorisroovers/gitlint/blob/3c017995633f602125f7caaa91e96bb767ca5953/gitlint-core/gitlint/cli.py#L121-L122), so I had to use the temporary-file strategy to make it work.