### PR TITLE
feat(builtin): Add `textlint` diagnostic

### DIFF
--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -2326,6 +2326,24 @@ local sources = { null_ls.builtins.diagnostics.teal }
 - `command = "tl"`
 - `args = { "check", "$FILENAME" }`
 
+#### [textlint](https://github.com/textlint/textlint)
+
+##### About
+
+The pluggable linting tool for text and markdown.
+
+##### Usage
+
+```lua
+local sources = { null_ls.builtins.diagnostics.textlint }
+```
+
+##### Defaults
+
+- `filetypes = {}`
+- `command = "textlint"`
+- `args = { "-f", "json", "--stdin", "--stdin-filename", "$FILENAME" }`
+
 #### [vale](https://docs.errata.ai/vale/about)
 
 ##### About

--- a/lua/null-ls/builtins/diagnostics/textlint.lua
+++ b/lua/null-ls/builtins/diagnostics/textlint.lua
@@ -1,0 +1,38 @@
+local h = require("null-ls.helpers")
+local methods = require("null-ls.methods")
+
+local DIAGNOSTICS = methods.internal.DIAGNOSTICS
+
+local handle_output = function(params)
+    params.messages = params.output and params.output[1] and params.output[1].messages or {}
+    if params.err then
+        table.insert(params.messages, { message = params.err })
+    end
+
+    local parser = h.diagnostics.from_json({
+        attributes = {
+            severity = "severity",
+        },
+        severities = {
+            h.diagnostics.severities["warning"],
+            h.diagnostics.severities["error"],
+        },
+    })
+
+    return parser({ output = params.messages })
+end
+
+return h.make_builtin({
+    name = "textlint",
+    method = DIAGNOSTICS,
+    filetypes = {},
+    generator_opts = {
+        command = "textlint",
+        to_stdin = true,
+        args = { "-f", "json", "--stdin", "--stdin-filename", "$FILENAME" },
+        format = "json_raw",
+        check_exit_code = { 0, 1 },
+        on_output = handle_output,
+    },
+    factory = h.generator_factory,
+})


### PR DESCRIPTION
Hi, thanks for the great software!
I tried to add textlint to null-ls, as I often use textlint when writing.
I'm afraid I wrote the same function in several places, but I couldn't think of a better way. Since the diagnostics are compatible with eslint, I wrote the same function as eslint.
Please review.