### PR TITLE
fix: Use bufnr from the function parameter

### DIFF
--- a/lua/null-ls/utils.lua
+++ b/lua/null-ls/utils.lua
@@ -18,7 +18,7 @@ local resolve_content = function(params, bufnr)
     -- diagnostic notifications will send full buffer content on open and change
     -- so we can avoid unnecessary api calls
     if params.method == methods.lsp.DID_OPEN and params.textDocument and params.textDocument.text then
-        return M.split_at_newline(params.bufnr, params.textDocument.text)
+        return M.split_at_newline(bufnr, params.textDocument.text)
     end
     if
         params.method == methods.lsp.DID_CHANGE
@@ -26,7 +26,7 @@ local resolve_content = function(params, bufnr)
         and params.contentChanges[1]
         and params.contentChanges[1].text
     then
-        return M.split_at_newline(params.bufnr, params.contentChanges[1].text)
+        return M.split_at_newline(bufnr, params.contentChanges[1].text)
     end
 
     return M.buf.content(bufnr)


### PR DESCRIPTION
`params` doesn't contain a `bufnr` field.

Fixes this error:

```
Error executing vim.schedule lua callback: ...//pack/packages/start/null-ls.nvim/lua/null-ls/utils.lua:14: Expected Lua number

stack traceback:
        [C]: in function 'nvim_buf_get_option'
        ...//pack/packages/start/null-ls.nvim/lua/null-ls/utils.lua:14: in function 'get_line_ending'
        ...//pack/packages/start/null-ls.nvim/lua/null-ls/utils.lua:56: in function 'resolve_content'
        ...//pack/packages/start/null-ls.nvim/lua/null-ls/utils.lua:110: in function 'make_params'
        .../packages/start/null-ls.nvim/lua/null-ls/diagnostics.lua:145: in function 'handler'
        ...im//pack/packages/start/null-ls.nvim/lua/null-ls/rpc.lua:103: in function 'notify'
        ...f/Projects/tools/nvim/share/nvim/runtime/lua/vim/lsp.lua:484: in function 'text_document_did_open_handler'
        ...f/Projects/tools/nvim/share/nvim/runtime/lua/vim/lsp.lua:1095: in function '_on_attach'
        ...f/Projects/tools/nvim/share/nvim/runtime/lua/vim/lsp.lua:931: in function ''
        vim.lua: in function <vim.lua:0>
```