### PR TITLE
feat: environment variable injection

### DIFF
--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -129,6 +129,21 @@ local sources = {
 }
 ```
 
+### Environment Variables
+
+You can inject additional environment variables to the process via utilizing the `env` option. This option should be in the form of a dictionary. This will extend the operating system variables.
+
+```lua
+local sources = {
+    null_ls.builtins.formatting.prettierd.with({
+          env = {
+            PRETTIERD_DEFAULT_CONFIG = vim.fn.expand "~/.config/nvim/utils/linter-config/.prettierrc.json",
+          }
+    }),
+}
+```
+
+
 ### Expansion
 
 Note that environment variables and `~` aren't expanded in arguments. As a

--- a/doc/HELPERS.md
+++ b/doc/HELPERS.md
@@ -28,6 +28,7 @@ helpers.generator_factory({
     args, -- table (optional)
     check_exit_code, -- function or table of numbers (optional)
     command, -- string or function
+    env, -- table (optional)
     cwd, -- function (optional)
     dynamic_command, -- function (optional)
     format, -- "raw", "line", "json", or "json_raw" (optional)

--- a/lua/null-ls/helpers/generator_factory.lua
+++ b/lua/null-ls/helpers/generator_factory.lua
@@ -138,7 +138,7 @@ return function(opts)
             env = {
                 env,
                 "table",
-                true
+                true,
             },
             on_output = { on_output, "function" },
             format = {

--- a/lua/null-ls/helpers/generator_factory.lua
+++ b/lua/null-ls/helpers/generator_factory.lua
@@ -138,6 +138,7 @@ return function(opts)
             env = {
                 env,
                 "table",
+                true
             },
             on_output = { on_output, "function" },
             format = {

--- a/lua/null-ls/helpers/generator_factory.lua
+++ b/lua/null-ls/helpers/generator_factory.lua
@@ -99,9 +99,10 @@ local line_output_wrapper = function(params, done, on_output)
 end
 
 return function(opts)
-    local command, args, on_output, format, ignore_stderr, from_stderr, to_stdin, check_exit_code, timeout, to_temp_file, from_temp_file, use_cache, runtime_condition, cwd, dynamic_command, multiple_files =
+    local command, args, env, on_output, format, ignore_stderr, from_stderr, to_stdin, check_exit_code, timeout, to_temp_file, from_temp_file, use_cache, runtime_condition, cwd, dynamic_command, multiple_files =
         opts.command,
         opts.args,
+        opts.env,
         opts.on_output,
         opts.format,
         opts.ignore_stderr,
@@ -133,6 +134,10 @@ return function(opts)
                     return v == nil or vim.tbl_contains({ "function", "table" }, type(v))
                 end,
                 "function or table",
+            },
+            env = {
+                env,
+                "table",
             },
             on_output = { on_output, "function" },
             format = {
@@ -276,6 +281,7 @@ return function(opts)
                 handler = wrapper,
                 check_exit_code = check_exit_code,
                 timeout = timeout or c.get().default_timeout,
+                env = env,
             }
 
             if to_temp_file then

--- a/lua/null-ls/helpers/make_builtin.lua
+++ b/lua/null-ls/helpers/make_builtin.lua
@@ -21,6 +21,7 @@ local function make_builtin(opts)
     generator_opts = vim.tbl_deep_extend("force", generator_opts, {
         args = opts.args,
         command = opts.command,
+        env = opts.env,
         cwd = opts.cwd,
         diagnostics_format = opts.diagnostics_format,
         dynamic_command = opts.dynamic_command,

--- a/lua/null-ls/loop.lua
+++ b/lua/null-ls/loop.lua
@@ -21,8 +21,8 @@ local TIMEOUT_EXIT_CODE = 7451
 local M = {}
 
 M.spawn = function(cmd, args, opts)
-    local handler, input, check_exit_code, timeout, on_stdout_end =
-        opts.handler, opts.input, opts.check_exit_code, opts.timeout, opts.on_stdout_end
+    local handler, input, check_exit_code, timeout, on_stdout_end, env =
+        opts.handler, opts.input, opts.check_exit_code, opts.timeout, opts.on_stdout_end, opts.env
 
     local output, error_output = "", ""
     local handle_stdout = function(err, chunk)
@@ -98,7 +98,11 @@ M.spawn = function(cmd, args, opts)
         done(exit_ok, code == TIMEOUT_EXIT_CODE)
     end
 
-    handle = uv.spawn(vim.fn.exepath(cmd), { args = args, stdio = stdio, cwd = opts.cwd or vim.fn.getcwd() }, on_close)
+    handle = uv.spawn(
+        vim.fn.exepath(cmd),
+        { args = args, env = env, stdio = stdio, cwd = opts.cwd or vim.fn.getcwd() },
+        on_close
+    )
 
     if timeout then
         timer = M.timer(timeout, nil, true, function()

--- a/lua/null-ls/loop.lua
+++ b/lua/null-ls/loop.lua
@@ -51,7 +51,7 @@ local M = {}
 
 M.spawn = function(cmd, args, opts)
     local handler, input, check_exit_code, timeout, on_stdout_end, env =
-        opts.handler, opts.input, opts.check_exit_code, opts.timeout, opts.on_stdout_end, opts.env
+        opts.handler, opts.input, opts.check_exit_code, opts.timeout, opts.on_stdout_end, env_merge(opts.env)
 
     local output, error_output = "", ""
     local handle_stdout = function(err, chunk)
@@ -129,7 +129,7 @@ M.spawn = function(cmd, args, opts)
 
     handle = uv.spawn(
         vim.fn.exepath(cmd),
-        { args = args, env = env_merge(env), stdio = stdio, cwd = opts.cwd or vim.fn.getcwd() },
+        { args = args, env = env, stdio = stdio, cwd = opts.cwd or vim.fn.getcwd() },
         on_close
     )
 

--- a/lua/null-ls/loop.lua
+++ b/lua/null-ls/loop.lua
@@ -29,20 +29,20 @@ end
 ---@param env (table) table of environment variable assignments
 ---@returns (table) list of `"k=v"` strings
 local function env_merge(env)
-  if env == nil then
-    return env
-  end
+    if env == nil then
+        return env
+    end
 
-  -- Merge.
-  env = vim.tbl_extend('force', vim.fn.environ(), env)
+    -- Merge.
+    env = vim.tbl_extend("force", vim.fn.environ(), env)
 
-  local final_env = {}
-  for k,v in pairs(env) do
-    assert(type(k) == 'string', 'env must be a dict')
-    table.insert(final_env, k..'='..tostring(v))
-  end
+    local final_env = {}
+    for k, v in pairs(env) do
+        assert(type(k) == "string", "env must be a dict")
+        table.insert(final_env, k .. "=" .. tostring(v))
+    end
 
-  return final_env
+    return final_env
 end
 
 local TIMEOUT_EXIT_CODE = 7451

--- a/test/spec/helpers/generator_factory_spec.lua
+++ b/test/spec/helpers/generator_factory_spec.lua
@@ -126,6 +126,16 @@ describe("generator_factory", function()
             local parsed = loop.spawn.calls[1].refs[2]
             assert.same(parsed, generator_opts.args)
         end)
+
+        it("should pass in the environment variables to the command", function()
+            generator_opts.env = { TEST = "TESTING" }
+
+            local generator = helpers.generator_factory(generator_opts)
+            generator.fn({}, done)
+
+            local parsed = loop.spawn.calls[1].refs[3]
+            assert.same(parsed.env, generator_opts.env)
+        end)
     end)
 
     describe("json_output_wrapper", function()

--- a/test/spec/loop_spec.lua
+++ b/test/spec/loop_spec.lua
@@ -114,7 +114,7 @@ describe("loop", function()
         it("should call uv.spawn with cmd and parse environment variables accordingly", function()
             local key = "TEST"
             local value = "TESTING"
-            local options = { env = { [key] = value} }
+            local options = { env = { [key] = value } }
             local expected = key .. "=" .. value
 
             loop.spawn(mock_cmd, mock_args, options)

--- a/test/spec/loop_spec.lua
+++ b/test/spec/loop_spec.lua
@@ -111,6 +111,26 @@ describe("loop", function()
             assert.same(uv.spawn.calls[1].refs[2].args, mock_args)
         end)
 
+        it("should call uv.spawn with cmd and parse environment variables accordingly", function()
+            local key = "TEST"
+            local value = "TESTING"
+            local options = { env = { [key] = value} }
+            local expected = key .. "=" .. value
+
+            loop.spawn(mock_cmd, mock_args, options)
+
+            assert.stub(uv.spawn).was_called()
+
+            -- environment variables are converted from a dict to key-value pair table
+            local found = false
+            for _, e in ipairs(uv.spawn.calls[1].refs[2].env) do
+                if e == expected then
+                    found = true
+                end
+            end
+            assert.equal(found, true)
+        end)
+
         it("should call uv.read_start twice", function()
             loop.spawn(mock_cmd, mock_args, mock_opts)
 


### PR DESCRIPTION
closes #385

- Adds another option field to pass in environment variables as in dictionary form.

Currently merges operating system variables first to match the default behavior used in the `neovim` repository.

What I could not manage to do because of `null-ls` first checking the command to be executable is extending the environment variables while doing that to match the behavior in the `lsp-installer` breaking change commit [here](https://github.com/williamboman/nvim-lsp-installer/commit/095ab4eb6a02d5fd3ea4b782a0e868e2c65e4427) where it now uses extending the `PATH` variable without using the absolute path of the executable. If you have any advice on that, I guess I can further improve this by injecting environment variables to the initial check of the file being executable, so that this external plugin would also work well.