### PR TITLE
Mention --cache flag in ESLint documentation

### DIFF
--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -649,6 +649,8 @@ Fixes problems in your JavaScript code.
 
 - Slow and not suitable for formatting on save. If at all possible, use
   `eslint_d` (described below).
+- It's recommended to add the [`--cache`](https://eslint.org/docs/user-guide/command-line-interface#--cache)
+  flag as an extra argument, see [Expansion](https://github.com/jose-elias-alvarez/null-ls.nvim/blob/main/doc/BUILTINS.md#arguments).
 
 ##### Usage
 
@@ -667,6 +669,9 @@ local sources = { null_ls.builtins.formatting.eslint }
 ##### About
 
 An absurdly fast formatter (and linter).
+
+- Similar to esling, it's recommended to add the [`--cache`](https://eslint.org/docs/user-guide/command-line-interface#--cache)
+  flag as an extra argument, see [Expansion](https://github.com/jose-elias-alvarez/null-ls.nvim/blob/main/doc/BUILTINS.md#arguments).
 
 ##### Usage
 


### PR DESCRIPTION
This is a nice way to increase the performance of `eslint` as it will only run for the files that has changed (https://eslint.org/docs/user-guide/command-line-interface#--cache). It may however create surprises since this will create a `.eslintcache` file in the project root, so it may be better to add this as a flag instead of as a default? It is however in my mind a good default for the increased performance, but your mileage may vary.