### PR TITLE
fix(rubocop): extract column info from location

### DIFF
--- a/lua/null-ls/builtins/diagnostics/rubocop.lua
+++ b/lua/null-ls/builtins/diagnostics/rubocop.lua
@@ -25,9 +25,9 @@ local handle_rubocop_output = function(params)
                     ruleId = offense.cop_name,
                     level = offense.severity,
                     line = offense.location.start_line,
-                    column = offense.start_column,
+                    column = offense.location.start_column,
                     endLine = offense.location.last_line,
-                    endColumn = offense.last_column,
+                    endColumn = offense.location.last_column + 1,
                 })
             end
 


### PR DESCRIPTION
The `start_column` and `last_column` properties are under the `location` property in RuboCop's JSON output, not at the top-level. Previously the builtin for RuboCop was extracting these from the wrong location, so diagnostics were not annotated with the correct begin and end points.

This fixes the builtin so that it sources `start_column` and `last_column` from the correct place.

I have tested this locally by creating a custom source for RuboCop with this change, and the diagnostics have the correct start and end columns.

**Before**

![Screen Shot 2022-01-06 at 09 13 45](https://user-images.githubusercontent.com/284007/148423537-8dbd72bf-b920-454b-b26e-088cb52cb6c9.png)

**After**

![Screen Shot 2022-01-06 at 09 12 27](https://user-images.githubusercontent.com/284007/148423571-df475b99-68fd-4d35-af4c-b0e4d99cc81d.png)