### PR TITLE
fix(loop): guard against multiple on_close calls

### DIFF
--- a/lua/null-ls/helpers/generator_factory.lua
+++ b/lua/null-ls/helpers/generator_factory.lua
@@ -188,6 +188,17 @@ return function(opts)
         fn = function(params, done)
             local loop = require("null-ls.loop")
 
+            local original_done = done
+            local done_called = false
+            done = function(...)
+                -- plenary will throw an error if its async callback is called more than once
+                if done_called then
+                    return
+                end
+                done_called = true
+                original_done(...)
+            end
+
             local root = u.get_root()
             params.root = root
 

--- a/lua/null-ls/helpers/generator_factory.lua
+++ b/lua/null-ls/helpers/generator_factory.lua
@@ -213,15 +213,15 @@ return function(opts)
             end
 
             local wrapper = function(error_output, output)
-                log:trace("error output: " .. (error_output or "nil"))
-                log:trace("output: " .. (output or "nil"))
-
                 if ignore_stderr then
                     error_output = nil
                 elseif from_stderr then
                     output = error_output
                     error_output = nil
                 end
+
+                log:trace("error output: " .. (error_output or "nil"))
+                log:trace("output: " .. (output or "nil"))
 
                 local handle_output = function()
                     if error_output and not (format == output_formats.raw or format == output_formats.json_raw) then

--- a/lua/null-ls/helpers/generator_factory.lua
+++ b/lua/null-ls/helpers/generator_factory.lua
@@ -205,7 +205,8 @@ return function(opts)
             if not _validated then
                 local validated = validate_opts(params)
                 if not validated then
-                    return done({ _should_deregister = true })
+                    done({ _should_deregister = true })
+                    return
                 end
 
                 _validated = true
@@ -254,6 +255,7 @@ return function(opts)
                 local ok, err = pcall(handle_output)
                 if not ok then
                     done({ _generator_err = err })
+                    return
                 end
             end
 

--- a/lua/null-ls/loop.lua
+++ b/lua/null-ls/loop.lua
@@ -98,6 +98,10 @@ M.spawn = function(cmd, args, opts)
 
     local handle
     local on_close = function(code)
+        if not handle then
+            return
+        end
+
         stdout:read_stop()
         stderr:read_stop()
 
@@ -120,6 +124,7 @@ M.spawn = function(cmd, args, opts)
         end
 
         done(exit_ok, code == TIMEOUT_EXIT_CODE)
+        handle = nil
     end
 
     local parsed_env = nil

--- a/test/spec/loop_spec.lua
+++ b/test/spec/loop_spec.lua
@@ -286,6 +286,27 @@ describe("loop", function()
                 done:clear()
             end)
 
+            it("should call done with exit and timeout results", function()
+                mock_opts.check_exit_code = nil
+                loop.spawn(mock_cmd, mock_args, mock_opts)
+
+                local on_close = uv.spawn.calls[1].refs[3]
+                on_close(0)
+
+                assert.stub(done).was_called_with(true, false)
+            end)
+
+            it("should only call done once", function()
+                mock_opts.check_exit_code = nil
+                loop.spawn(mock_cmd, mock_args, mock_opts)
+
+                local on_close = uv.spawn.calls[1].refs[3]
+                on_close(0)
+                on_close(0)
+
+                assert.stub(done).was_called(1)
+            end)
+
             it("should check that code is 0 when check_exit_code is nil", function()
                 mock_opts.check_exit_code = nil
                 loop.spawn(mock_cmd, mock_args, mock_opts)


### PR DESCRIPTION
May close #483. 

I can't reliably replicate the error, but based on the message and trace, I'm pretty confident the issue is that we are calling the same async callback multiple times. This PR prevents that situation, which (if I'm right) should fix the issue.

@horseinthesky @ahhshm Could you please try this fix and see if it makes a difference?
