### PR TITLE
fix(logger): respect config.log.enable

### DIFF
--- a/lua/null-ls/logger.lua
+++ b/lua/null-ls/logger.lua
@@ -7,6 +7,10 @@ local log = {}
 ---@param msg any
 ---@param level string [same as vim.log.log_levels]
 function log:add_entry(msg, level)
+    if not c.get().log.enable then
+        return
+    end
+
     if self.__handle then
         -- plenary uses lower-case log levels
         self.__handle[level:lower()](msg)


### PR DESCRIPTION
hi! it seems the `config.log.enable` option isn't working for me, and I can't find any other references to it

![image](https://user-images.githubusercontent.com/6832539/148651784-dd68a880-d5c6-41f4-8e6d-bb22152cc50e.png)
