### PR TITLE
feat: cabal-fmt formatting source for cabal files

### DIFF
--- a/lua/null-ls/builtins/_meta/filetype_map.lua
+++ b/lua/null-ls/builtins/_meta/filetype_map.lua
@@ -14,6 +14,9 @@ return {
     diagnostics = { "cppcheck", "gccdiag" },
     formatting = { "clang_format", "uncrustify" }
   },
+  cabal = {
+    formatting = { "cabal_fmt" }
+  },
   clj = {
     formatting = { "joker" }
   },

--- a/lua/null-ls/builtins/_meta/formatting.lua
+++ b/lua/null-ls/builtins/_meta/formatting.lua
@@ -19,6 +19,9 @@ return {
   buildifier = {
     filetypes = { "bzl" }
   },
+  cabal_fmt = {
+    filetypes = { "cabal" }
+  },
   clang_format = {
     filetypes = { "c", "cpp", "cs", "java" }
   },

--- a/lua/null-ls/builtins/formatting/cabal_fmt/cabal_fmt.lua
+++ b/lua/null-ls/builtins/formatting/cabal_fmt/cabal_fmt.lua
@@ -1,0 +1,15 @@
+local h = require("null-ls.helpers")
+local methods = require("null-ls.methods")
+
+local FORMATTING = methods.internal.FORMATTING
+
+return h.make_builtin({
+    name = "cabal_fmt",
+    method = FORMATTING,
+    filetypes = { "cabal" },
+    generator_opts = {
+        command = "cabal-fmt",
+        to_stdin = true,
+    },
+    factory = h.formatter_factory,
+})


### PR DESCRIPTION
Resolved: #563 

* "cabal-fmt" is original command name, I changed it to underscore for lib.