### PR TITLE
Fix: Update qmllint parameters and args

### DIFF
--- a/lua/null-ls/builtins/diagnostics/qmllint.lua
+++ b/lua/null-ls/builtins/diagnostics/qmllint.lua
@@ -9,12 +9,18 @@ return h.make_builtin({
     filetypes = { "qml" },
     generator_opts = {
         command = "qmllint",
-        args = { "--no-unqualified-id", "$FILENAME" },
+        args = { "$FILENAME" },
         to_stdin = false,
         format = "raw",
         from_stderr = true,
         to_temp_file = true,
-        on_output = h.diagnostics.from_errorformat(table.concat({ "%trror: %m", "%f:%l : %m" }, ","), "qmllint"),
+        on_output = h.diagnostics.from_errorformat(
+            table.concat({
+                "%trror: %f:%l:%c: %m",
+                "%tarning: %f:%l:%c: %m",
+            }, ","),
+            "qmllint"
+        ),
     },
     factory = h.generator_factory,
 })


### PR DESCRIPTION
The latest qmllint now uses a configuration file so the users can just use that file to configure the settings. For earlier versions, I think using `with({})` to change how qmllint is run still an option.