### PR TITLE
fix(diagnostics): Fix ansible-lint parsing

### DIFF
--- a/lua/null-ls/builtins/diagnostics/ansiblelint.lua
+++ b/lua/null-ls/builtins/diagnostics/ansiblelint.lua
@@ -17,8 +17,8 @@ return h.make_builtin({
             return code <= 2
         end,
         on_output = h.diagnostics.from_pattern(
-            [[^[^:]+:(%d+): %[[%w-]+%] %[([%w]+)%] (.*)$]],
-            { "row", "severity", "message" },
+            [[^[^:]+:(%d+): %[([%w-]+)%] %[([%w_]+)%] (.*)$]],
+            { "row", "code", "severity", "message" },
             {
                 severities = {
                     ["VERY_HIGH"] = h.diagnostics.severities.error,

--- a/test/spec/builtins/diagnostics_spec.lua
+++ b/test/spec/builtins/diagnostics_spec.lua
@@ -910,13 +910,18 @@ describe("diagnostics", function()
                   }
                 ]
             ]]
-            local diagnostic = parser(output, { content = file })
-            assert.same({
-                row = "5",
-                severity = 1,
-                message = "[risky-file-permissions] File permissions unset or incorrect",
-                filename = "playbooks/test-ansible.yaml",
-            }, diagnostic)
+            local diagnostic = parser({ output = vim.json.decode(output), content = file })
+            assert.same(
+                {
+                    {
+                        row = 5,
+                        severity = 1,
+                        message = "[risky-file-permissions] File permissions unset or incorrect",
+                        filename = "playbooks/test-ansible.yaml",
+                    },
+                },
+                diagnostic
+            )
         end)
     end)
 end)

--- a/test/spec/builtins/diagnostics_spec.lua
+++ b/test/spec/builtins/diagnostics_spec.lua
@@ -869,4 +869,30 @@ describe("diagnostics", function()
             }, diagnostic)
         end)
     end)
+
+    describe("ansiblelint", function()
+        local linter = diagnostics.ansiblelint
+        local parser = linter._opts.on_output
+        local file = {
+            [[---]],
+            [[- name: generate file]],
+            [[  assemble:]],
+            [[    src: "files"]],
+            [[    dest: "dest"]],
+            [[  run_once: true]],
+            [[  become: false]],
+        }
+
+        it("should create a diagnostic", function()
+            local output =
+                [[path/to/file.yaml:2: [risky-file-permissions] [VERY_HIGH] File permissions unset or incorrect]]
+            local diagnostic = parser(output, { content = file })
+            assert.same({
+                row = "2",
+                severity = 1,
+                message = "File permissions unset or incorrect",
+                code = "risky-file-permissions",
+            }, diagnostic)
+        end)
+    end)
 end)

--- a/test/spec/builtins/diagnostics_spec.lua
+++ b/test/spec/builtins/diagnostics_spec.lua
@@ -875,23 +875,48 @@ describe("diagnostics", function()
         local parser = linter._opts.on_output
         local file = {
             [[---]],
-            [[- name: generate file]],
-            [[  assemble:]],
-            [[    src: "files"]],
-            [[    dest: "dest"]],
-            [[  run_once: true]],
-            [[  become: false]],
+            [[- name: null-ls]],
+            [[  hosts: all]],
+            [[  tasks:]],
+            [[    - name: This tasks is no good]],
+            [[      assemble:]],
+            [[        src: "files"]],
+            [[        dest: "dest"]],
+            [[      become: false]],
         }
 
         it("should create a diagnostic", function()
-            local output =
-                [[path/to/file.yaml:2: [risky-file-permissions] [VERY_HIGH] File permissions unset or incorrect]]
+            local output = [[
+                [
+                  {
+                    "type": "issue",
+                    "check_name": "[risky-file-permissions] File permissions unset or incorrect",
+                    "categories": [
+                      "unpredictability",
+                      "experimental"
+                    ],
+                    "severity": "blocker",
+                    "description": "Missing or unsupported mode parameter can cause unexpected file permissions based on version of Ansible being used. Be explicit, like ``mode: 0644`` to avoid hitting this rule. Special ``preserve`` value is accepted only by copy, template modules. See https://github.com/ansible/ansible/issues/71200",
+                    "fingerprint": "b66d9f9db860c0fedb7d1d583c5a808df9a1ed72b8abdbedeff0aad836490951",
+                    "location": {
+                      "path": "playbooks/test-ansible.yaml",
+                      "lines": {
+                        "begin": 5
+                      }
+                    },
+                    "content": {
+                      "body": "Task/Handler: This tasks is no good"
+                    }
+                  }
+                ]
+            ]]
             local diagnostic = parser(output, { content = file })
             assert.same({
-                row = "2",
+                row = "5",
                 severity = 1,
                 message = "File permissions unset or incorrect",
                 code = "risky-file-permissions",
+                filename = "playbooks/test-ansible.yaml",
             }, diagnostic)
         end)
     end)

--- a/test/spec/builtins/diagnostics_spec.lua
+++ b/test/spec/builtins/diagnostics_spec.lua
@@ -911,17 +911,14 @@ describe("diagnostics", function()
                 ]
             ]]
             local diagnostic = parser({ output = vim.json.decode(output), content = file })
-            assert.same(
+            assert.same({
                 {
-                    {
-                        row = 5,
-                        severity = 1,
-                        message = "[risky-file-permissions] File permissions unset or incorrect",
-                        filename = "playbooks/test-ansible.yaml",
-                    },
+                    row = 5,
+                    severity = 1,
+                    message = "[risky-file-permissions] File permissions unset or incorrect",
+                    filename = "playbooks/test-ansible.yaml",
                 },
-                diagnostic
-            )
+            }, diagnostic)
         end)
     end)
 end)

--- a/test/spec/builtins/diagnostics_spec.lua
+++ b/test/spec/builtins/diagnostics_spec.lua
@@ -914,8 +914,7 @@ describe("diagnostics", function()
             assert.same({
                 row = "5",
                 severity = 1,
-                message = "File permissions unset or incorrect",
-                code = "risky-file-permissions",
+                message = "[risky-file-permissions] File permissions unset or incorrect",
                 filename = "playbooks/test-ansible.yaml",
             }, diagnostic)
         end)


### PR DESCRIPTION
There was an issue with parsing severities containing `_`.

This also adds parsing of the error code as well as a test.

Unfortunately, I can't seem to figure out why the test fails.

It works correctly when I run it on an actual file and the match pattern seems to work when executed on the test output.

```sh
echo 'print(string.match([[path/to/file.yaml:2: [risky-file-permissions] [VERY_HIGH] File permissions unset or incorrect]], [[^[^:]+:(%d+): %[([%w-]+)%] %[([%w_]+)%] (.*)$]]))' | lua
2	risky-file-permissions	VERY_HIGH	File permissions unset or incorrect
```

But when I run the test I get
```
Fail	||	diagnostics ansiblelint should create a diagnostic
            ./test/spec/builtins/diagnostics_spec.lua:804: Expected objects to be the same.
            Passed in:
            (nil)
            Expected:
            (table: 0x0102e82a10) {
              [code] = 'risky-file-permissions'
              [message] = 'File permissions unset or incorrect'
              [row] = '2'
              [severity] = 1 }

            stack traceback:
            	./test/spec/builtins/diagnostics_spec.lua:804: in function <./test/spec/builtins/diagnostics_spec.lua:801>

```