### PR TITLE
Add faq for timeout error message to FAQ section in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,8 +289,8 @@ This seems to be an issue, when the formatter you are trying to use, takes a
 longer time than the default timeout value of the `formatting_sync` function.
 This is an automatic mechanism, so that if you are using the formatting after
 writing a buffer, you are not stuck in the editor until the formatting is ready.
-You might want to increase the timeout in your formatting_sync call (second 
-parameter).
+You might want to increase the timeout in your formatting_sync call (i.e. 
+`vim.lsp.buf.formatting_sync(nil, 2000)` – this is adding a timeout of 2 seconds).
 
 ## Tests
 

--- a/README.md
+++ b/README.md
@@ -283,6 +283,15 @@ memory without any external processes, in most cases it should run faster than
 similar solutions. If you notice that performance is worse with null-ls than
 with an alternative, please open an issue!
 
+### I am seeing a `vim.lsp.buf.formatting_sync: timeout` error message
+
+This seems to be an issue, when the formatter you are trying to use, takes a 
+longer time than the default timeout value of the `formatting_sync` function.
+This is an automatic mechanism, so that if you are using the formatting after
+writing a buffer, you are not stuck in the editor until the formatting is ready.
+You might want to increase the timeout in your formatting_sync call (second 
+parameter).
+
 ## Tests
 
 The test suite includes unit and integration tests and depends on plenary.nvim.


### PR DESCRIPTION
Having this problem my self, and seeing this message pop up in the issues (#572) of this project, I decided to create this little FAQ in the FAQs section.

Problem here: In my case, `rubocop` took longer than the default timeout, so I decided to drop the formatting for rubocop, since it takes to long. Other solution would be to just increase the timeout for any `formatting_sync` call, however this slowed down my editor performance massively, so I just dropped formatting support.