### PR TITLE
fix(formatting): properly handle nofixeol

### DIFF
--- a/lua/null-ls/formatting.lua
+++ b/lua/null-ls/formatting.lua
@@ -12,7 +12,8 @@ local postprocess = function(edit, params)
     edit.end_col = edit.end_col or 1
 
     edit.range = u.range.to_lsp(edit)
-    edit.newText = edit.text
+    -- strip trailing newline
+    edit.newText = edit.text:gsub("[\r\n]$", "")
 end
 
 local M = {}
@@ -28,6 +29,7 @@ M.handler = function(method, original_params, handler)
         -- copy content and options to temp buffer
         local temp_bufnr = api.nvim_create_buf(false, true)
         api.nvim_buf_set_option(temp_bufnr, "eol", api.nvim_buf_get_option(bufnr, "eol"))
+        api.nvim_buf_set_option(temp_bufnr, "fixeol", api.nvim_buf_get_option(bufnr, "fixeol"))
         api.nvim_buf_set_option(temp_bufnr, "fileformat", api.nvim_buf_get_option(bufnr, "fileformat"))
         api.nvim_buf_set_lines(temp_bufnr, 0, -1, false, api.nvim_buf_get_lines(bufnr, 0, -1, false))
 

--- a/lua/null-ls/utils.lua
+++ b/lua/null-ls/utils.lua
@@ -162,19 +162,15 @@ M.buf = {
     content = function(bufnr, to_string)
         bufnr = bufnr or api.nvim_get_current_buf()
 
-        local eol = api.nvim_buf_get_option(bufnr, "eol")
+        local should_add_eol = api.nvim_buf_get_option(bufnr, "eol") and api.nvim_buf_get_option(bufnr, "fixeol")
         local line_ending = get_line_ending(bufnr)
 
         local lines = api.nvim_buf_get_lines(bufnr, 0, -1, false)
-        if to_string then
-            local text = table.concat(lines, line_ending)
-            return eol and text .. line_ending or text
-        end
-
-        if eol then
+        if should_add_eol then
             table.insert(lines, "")
         end
-        return lines
+
+        return to_string and table.concat(lines, line_ending) or lines
     end,
     for_each_bufnr = function(cb)
         for _, bufnr in ipairs(api.nvim_list_bufs()) do


### PR DESCRIPTION
May fix #569.

The changes to `u.buf.content()` should be safe, since unless explicitly specified both `eol` and `fixeol` will be `true`, but the change to `edit.newText` is a bit more complicated. The issue is that most (all?) formatters that support `stdout` also output a final newline that isn't part of the "actual" content. This hasn't been a problem so far because [`vim.lsp.util.apply_text_edits()` will remove it](https://github.com/neovim/neovim/blob/b65a23a13a29176aa669afc5d1c906d1d51e0a39/runtime/lua/vim/lsp/util.lua#L476) unless `fixeol` is `false`.  

These changes seem to handle the case in the linked issue without affecting the default case. I'm not thrilled with this, as it relies on the internal behavior of `apply_text_edits()`, and I think that creating our own version of the utility is a good idea, but this should hopefully be okay for now. 