### PR TITLE
feat(builtint): Add protoc-gen-lint diagnostic

### DIFF
--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -2189,6 +2189,24 @@ local sources = { null_ls.builtins.diagnostics.proselint }
 - `command = "proselint"`
 - `args = { "--json" }`
 
+#### [protoc-gen-lint](https://github.com/ckaznocha/protoc-gen-lint)
+
+##### About
+
+A plug-in for Google's Protocol Buffers (protobufs) compiler to lint .proto files for style violations.
+
+##### Usage
+
+```lua
+local sources = { null_ls.builtins.diagnostics.protoc_gen_lint }
+```
+
+##### Defaults
+
+- `filetypes = { "proto" }`
+- `command = "protoc"`
+- `args = { "--line_out", "$FILENAME", "-I", "/tmp", "$FILENAME"}`
+
 #### [protolint](https://https://github.com/yoheimuta/protolint)
 
 ##### About

--- a/lua/null-ls/builtins/diagnostics/protoc_gen_lint.lua
+++ b/lua/null-ls/builtins/diagnostics/protoc_gen_lint.lua
@@ -1,0 +1,31 @@
+local h = require("null-ls.helpers")
+local methods = require("null-ls.methods")
+
+local DIAGNOSTICS = methods.internal.DIAGNOSTICS
+
+return h.make_builtin({
+    name = "protoc-gen-lint",
+    method = DIAGNOSTICS,
+    filetypes = { "proto" },
+    generator_opts = {
+        command = "protoc",
+        args = { "--lint_out", "$FILENAME", "-I", "/tmp", "$FILENAME" },
+        from_stderr = true,
+        to_temp_file = true,
+        format = "line",
+        check_exit_code = function(code)
+            return code <= 1
+        end,
+        on_output = h.diagnostics.from_patterns({
+            {
+                pattern = [[:(%d+):(%d+): (.*)]],
+                groups = { "row", "col", "message" },
+            },
+            {
+                pattern = [[.*] (.*)]],
+                groups = { "message" },
+            },
+        }),
+    },
+    factory = h.generator_factory,
+})


### PR DESCRIPTION
Adds [protoc-gen-lint](https://github.com/ckaznocha/protoc-gen-lint) diagnostic for `.proto` files.

Since [protoc-gen-lint](https://github.com/ckaznocha/protoc-gen-lint) doesn't support input from `stdin` a temporary file is used instead.

This was initially implemented with `from_pattern` but had to be reworked with an additional matching pattern since [protoc-gen-lint](https://github.com/ckaznocha/protoc-gen-lint) spits out errors in a different format when its parsing invalid `.proto` files.

Let me know if anything needs to be adjusted.