### PR TITLE
feat(builtins): Add cljstyle formatter for clojure code

### DIFF
--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -478,6 +478,24 @@ local sources = { null_ls.builtins.formatting.clang_format }
 - `command = "clang-format"`
 - `args = { "-assume-filename=<FILENAME>" }`
 
+#### [cljstyle](https://github.com/greglook/cljstyle)
+
+##### About
+
+Formatter for `Clojure` code.
+
+##### Usage
+
+```lua
+local sources = { null_ls.builtins.formatting.cljstyle }
+```
+
+##### Defaults
+
+- `filetypes = { "clojure" }`
+- `command = "cljstyle"`
+- `args = { "pipe" }`
+
 #### [cmake-format](https://github.com/cheshirekow/cmake_format)
 
 ##### About

--- a/lua/null-ls/builtins/formatting/cljstyle.lua
+++ b/lua/null-ls/builtins/formatting/cljstyle.lua
@@ -9,7 +9,7 @@ return h.make_builtin({
     filetypes = { "clojure" },
     generator_opts = {
         command = "cljstyle",
-        args = { "pipe", },
+        args = { "pipe" },
         to_stdin = true,
     },
     factory = h.formatter_factory,

--- a/lua/null-ls/builtins/formatting/cljstyle.lua
+++ b/lua/null-ls/builtins/formatting/cljstyle.lua
@@ -1,0 +1,16 @@
+local h = require("null-ls.helpers")
+local methods = require("null-ls.methods")
+
+local FORMATTING = methods.internal.FORMATTING
+
+return h.make_builtin({
+    name = "cljstyle",
+    method = FORMATTING,
+    filetypes = { "clojure" },
+    generator_opts = {
+        command = "cljstyle",
+        args = { "pipe", },
+        to_stdin = true,
+    },
+    factory = h.formatter_factory,
+})


### PR DESCRIPTION
Adds `cljstyle` formatter for `clojure` code.

Let me know if something does not look right.