### PR TITLE
feat: Added raco fmt builtin for formatting Racket files

### DIFF
--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -1362,6 +1362,28 @@ local sources = { null_ls.builtins.formatting.qmlformat }
 - `command = "qmlformat"`
 - `args = { "-i", "$FILENAME" }`
 
+#### [raco fmt](https://docs.racket-lang.org/fmt/)
+
+##### About
+
+The `fmt` package provides an extensible tool to format Racket code, using an
+expressive pretty printer library to compute the optimal layout.
+
+- Requires Racket 8.0 or later
+- Install with `raco pkg install fmt`
+
+##### Usage
+
+```lua
+local sources = { null_ls.builtins.formatting.raco_fmt }
+```
+
+##### Defaults
+
+- `filetypes = { "racket" }`
+- `command = "raco"`
+- `args = { "fmt", "$FILENAME" }`
+
 #### [rubocop](https://github.com/rubocop/rubocop)
 
 ##### About

--- a/lua/null-ls/builtins/formatting/raco_fmt.lua
+++ b/lua/null-ls/builtins/formatting/raco_fmt.lua
@@ -1,0 +1,16 @@
+local h = require("null-ls.helpers")
+local methods = require("null-ls.methods")
+
+local FORMATTING = methods.internal.FORMATTING
+
+return h.make_builtin({
+    name = "raco_fmt",
+    method = FORMATTING,
+    filetypes = { "racket" },
+    generator_opts = {
+        command = "raco",
+        args = { "fmt", "$FILENAME" },
+        to_stdin = true,
+    },
+    factory = h.formatter_factory,
+})


### PR DESCRIPTION
Added [raco fmt](https://docs.racket-lang.org/fmt/) tool for formatting Racket files and updated `BUILTINS.md` doc file.