### PR TITLE
fix: corrected format on save behaviour for fnlfmt and raco fmt

### DIFF
--- a/lua/null-ls/builtins/formatting/fnlfmt.lua
+++ b/lua/null-ls/builtins/formatting/fnlfmt.lua
@@ -9,7 +9,7 @@ return h.make_builtin({
     filetypes = { "fennel", "fnl" },
     generator_opts = {
         command = "fnlfmt",
-        args = { "$FILENAME" },
+        args = { "-" },
         to_stdin = true,
     },
     factory = h.formatter_factory,

--- a/lua/null-ls/builtins/formatting/raco_fmt.lua
+++ b/lua/null-ls/builtins/formatting/raco_fmt.lua
@@ -9,7 +9,7 @@ return h.make_builtin({
     filetypes = { "racket" },
     generator_opts = {
         command = "raco",
-        args = { "fmt", "$FILENAME" },
+        args = { "fmt" },
         to_stdin = true,
     },
     factory = h.formatter_factory,


### PR DESCRIPTION
Because `fnlfmt` and `raco fmt` were formatting with `$FILENAME` in their args, it led to unsaved changes not being reflected in formatting on save. Using stdin seems to solve this.