### PR TITLE
feat(config): add optional user-defined should_attach callback

### DIFF
--- a/doc/CONFIG.md
+++ b/doc/CONFIG.md
@@ -189,13 +189,19 @@ directory.
 
 ### should_attach (function, optional)
 
-Defines a `should_attach` callback to run before null-ls attaches to a buffer.
-The callback receives the `bufnr` as its only argument.
+A user-defined function that controls whether to enable null-ls for a given
+buffer. Receives `bufnr` as its only argument.
+
+In order to cut down potentially expensive calls, null-ls will only call
+`should_attach` after its own internal "should attach" checks pass, so it's not
+guaranteed to run every time.
 
 ```lua
-local should_attach = function(bufnr)
-    return not vim.fn.bufname(bufnr):match("^git://")
-end
+require("null-ls.nvim").setup({
+    should_attach = function(bufnr)
+        return not vim.api.nvim_buf_get_name(bufnr):match("^git://")
+    end,
+})
 ```
 
 ### sources (table, optional)

--- a/doc/CONFIG.md
+++ b/doc/CONFIG.md
@@ -187,6 +187,17 @@ end
 If `root_dir` returns `nil`, the root will resolve to the current working
 directory.
 
+### should_attach (function, optional)
+
+Defines a `should_attach` callback to run before null-ls attaches to a buffer.
+The callback receives the `bufnr` as its only argument.
+
+```lua
+local should_attach = function(bufnr)
+    return not vim.fn.bufname(bufnr):match("^git://")
+end
+```
+
 ### sources (table, optional)
 
 Defines a list (array-like table) of sources for null-ls to register. Users can

--- a/lua/null-ls/client.lua
+++ b/lua/null-ls/client.lua
@@ -11,7 +11,9 @@ local lsp = vim.lsp
 local client, id
 
 local should_attach = function(bufnr)
-    if api.nvim_buf_get_option(bufnr, "buftype") ~= "" or api.nvim_buf_get_name(bufnr) == "" then
+    if c.get().should_attach and not c.get().should_attach(bufnr) then
+        return false
+    elseif api.nvim_buf_get_option(bufnr, "buftype") ~= "" or api.nvim_buf_get_name(bufnr) == "" then
         return false
     end
 

--- a/lua/null-ls/client.lua
+++ b/lua/null-ls/client.lua
@@ -11,16 +11,14 @@ local lsp = vim.lsp
 local client, id
 
 local should_attach = function(bufnr)
-    if c.get().should_attach and not c.get().should_attach(bufnr) then
-        return false
-    elseif api.nvim_buf_get_option(bufnr, "buftype") ~= "" or api.nvim_buf_get_name(bufnr) == "" then
+    if api.nvim_buf_get_option(bufnr, "buftype") ~= "" or api.nvim_buf_get_name(bufnr) == "" then
         return false
     end
 
     local ft = api.nvim_buf_get_option(bufnr, "filetype")
     for _, source in ipairs(sources.get_all()) do
         if sources.is_available(source, ft) then
-            return true
+            return not c.get().should_attach or c.get().should_attach(bufnr)
         end
     end
 

--- a/lua/null-ls/client.lua
+++ b/lua/null-ls/client.lua
@@ -15,10 +15,14 @@ local should_attach = function(bufnr)
         return false
     end
 
+    if c.get().should_attach and not c.get().should_attach(bufnr) then
+        return false
+    end
+
     local ft = api.nvim_buf_get_option(bufnr, "filetype")
     for _, source in ipairs(sources.get_all()) do
         if sources.is_available(source, ft) then
-            return not c.get().should_attach or c.get().should_attach(bufnr)
+            return true
         end
     end
 

--- a/lua/null-ls/config.lua
+++ b/lua/null-ls/config.lua
@@ -32,6 +32,7 @@ local type_overrides = {
     on_attach = { "function", "nil" },
     on_init = { "function", "nil" },
     on_exit = { "function", "nil" },
+    should_attach = { "function", "nil" },
     sources = { "table", "nil" },
 }
 

--- a/test/spec/client_spec.lua
+++ b/test/spec/client_spec.lua
@@ -186,8 +186,12 @@ describe("client", function()
         end)
 
         it("should run checks and attach if conditions match", function()
+            local should_attach = stub.new(nil, nil, true)
+            c._set({ should_attach = should_attach })
+
             local did_attach = client.try_add(mock_bufnr)
 
+            assert.stub(should_attach).was_called_with(mock_bufnr)
             assert.stub(api.nvim_buf_get_option).was_called_with(mock_bufnr, "buftype")
             assert.stub(api.nvim_buf_get_option).was_called_with(mock_bufnr, "filetype")
             assert.stub(api.nvim_buf_get_name).was_called_with(mock_bufnr)
@@ -196,6 +200,16 @@ describe("client", function()
             assert.stub(lsp.buf_is_attached).was_called_with(mock_bufnr, mock_client_id)
             assert.stub(lsp.buf_attach_client).was_called_with(mock_bufnr, mock_client_id)
             assert.truthy(did_attach)
+        end)
+
+        it("should not attach if user-defined should_attach returns false", function()
+            local should_attach = stub.new(nil, nil, false)
+            c._set({ should_attach = should_attach })
+
+            local did_attach = client.try_add(mock_bufnr)
+
+            assert.stub(should_attach).was_called_with(mock_bufnr)
+            assert.falsy(did_attach)
         end)
 
         it("should not attach if buftype is not empty", function()


### PR DESCRIPTION
Per the discussion in #502, there are some buffers we always want null-ls to ignore, regardless of filetype or buftype.

Allow the user to hook into the existing `should_attach` function in the client by specifying a callback on the config object.