### PR TITLE
fix(client): schedule progress handler call

### DIFF
--- a/lua/null-ls/client.lua
+++ b/lua/null-ls/client.lua
@@ -211,17 +211,19 @@ M.send_progress_notification = function(token, opts)
         return
     end
 
-    handler(nil, {
-        token = token,
-        value = {
-            kind = opts.kind,
-            title = opts.title,
-            percentage = opts.percentage,
-            message = opts.message,
-        },
-    }, {
-        client_id = id,
-    })
+    vim.schedule(function()
+        handler(nil, {
+            token = token,
+            value = {
+                kind = opts.kind,
+                title = opts.title,
+                percentage = opts.percentage,
+                message = opts.message,
+            },
+        }, {
+            client_id = id,
+        })
+    end)
 end
 
 M._reset = function()


### PR DESCRIPTION
May fix j-hui/fidget.nvim#9. 

Calling a progress handler inside of an async callback can cause issues if that handler does something that's blocked by textlock. This change schedules the call to prevent the issue.

If a user of fidget.nvim can confirm that this fixes the issue, I'll merge it.