### PR TITLE
feat: Expose symbol attribute for pylint

### DIFF
--- a/lua/null-ls/builtins/diagnostics/pylint.lua
+++ b/lua/null-ls/builtins/diagnostics/pylint.lua
@@ -22,6 +22,7 @@ return h.make_builtin({
                 code = "message-id",
                 severity = "type",
                 message = "message",
+                symbol = "symbol",
                 source = "pylint",
             },
             severities = {


### PR DESCRIPTION
The symbol attribute is used as a human-interpretable code in pylint,
for instance, "bad-indentation" for a error code W0311. (See:
https://pylint.pycqa.org/en/latest/technical_reference/features.html)

This additional metadata can be exported to as diagnostics entry,
so that users may include them in the diagnostics message.
