### PR TITLE
Allow functions to specify diagnostics_format

### DIFF
--- a/doc/CONFIG.md
+++ b/doc/CONFIG.md
@@ -109,7 +109,7 @@ out. Note that built-in sources can define their own timeout period and that
 users can override the timeout period on a per-source basis, too (see
 [BUILTINS.md](BUILTINS.md)).
 
-### diagnostics_format (string)
+### diagnostics_format (string or function)
 
 Sets the default format used for diagnostics. The plugin will replace the
 following special components with the relevant diagnostic information:
@@ -124,10 +124,26 @@ For example, setting `diagnostics_format` to the following:
 diagnostics_format = "[#{c}] #{m} (#{s})"
 ```
 
-Formats diagnostics as follows:
+This formats diagnostics as follows:
 
 ```txt
 [2148] Tips depend on target shell and yours is unknown. Add a shebang or a 'shell' directive. (shellcheck)
+```
+
+Alternatively, an user-defined function can be used to set the diagnostics
+message. This function receives a diagnostic (lua table) as the only argument
+and should return a format string.
+
+For example, the following will produce the same result as the previous example:
+```lua
+diagnostics_format = function(diagnostic)
+  return string.format("[%s] %s (%s)", diagnostic.code, diagnostic.message, diagnostic.source)
+end
+
+-- or alternatively,
+diagnostics_format = function(diagnostic)
+  return string.format("#{c} #{m} (%s)", diagnostic.source)
+end
 ```
 
 You can also set `diagnostics_format` for built-ins by using the `with` method,

--- a/lua/null-ls/diagnostics.lua
+++ b/lua/null-ls/diagnostics.lua
@@ -59,6 +59,10 @@ local postprocess = function(diagnostic, _, generator)
     end
 
     local formatted = generator and generator.opts.diagnostics_format or c.get().diagnostics_format
+    -- allow custom diagnostics format from a function
+    if type(formatted) == "function" then
+        formatted = formatted(diagnostic)
+    end
     -- avoid unnecessary gsub if using default
     if formatted == "#{m}" then
         return

--- a/test/spec/diagnostics_spec.lua
+++ b/test/spec/diagnostics_spec.lua
@@ -403,6 +403,16 @@ describe("diagnostics", function()
                 assert.equals(mock_diagnostic.message, "code! message [source]")
             end)
 
+            it("should format message from a function", function()
+                mock_generator.opts.diagnostics_format = function(diagnostic)
+                    return "from a function -- #{m}: " .. diagnostic.source
+                end
+
+                postprocess(mock_diagnostic, mock_params, mock_generator)
+
+                assert.equals(mock_diagnostic.message, "from a function -- message: source")
+            end)
+
             it("should set bufnr from filename", function()
                 mock_diagnostic.filename = "mock-file"
 


### PR DESCRIPTION
An user-defined function can be used to set the diagnostics message,
which should be more general than the format string.

See the documentation and test specs for example.