### PR TITLE
Add diagnostics and formatter for Puppet

### DIFF
--- a/lua/null-ls/builtins/_meta/diagnostics.lua
+++ b/lua/null-ls/builtins/_meta/diagnostics.lua
@@ -91,6 +91,9 @@ return {
   psalm = {
     filetypes = { "php" }
   },
+  puppet_lint = {
+    filetypes = { "puppet", "epuppet" }
+  },
   pydocstyle = {
     filetypes = { "python" }
   },

--- a/lua/null-ls/builtins/_meta/filetype_map.lua
+++ b/lua/null-ls/builtins/_meta/filetype_map.lua
@@ -66,6 +66,10 @@ return {
   elm = {
     formatting = { "elm_format" }
   },
+  epuppet = {
+    diagnostics = { "puppet_lint" },
+    formatting = { "puppet_lint" }
+  },
   erlang = {
     formatting = { "erlfmt" }
   },
@@ -162,6 +166,10 @@ return {
   proto = {
     diagnostics = { "protoc_gen_lint", "protolint" },
     formatting = { "protolint" }
+  },
+  puppet = {
+    diagnostics = { "puppet_lint" },
+    formatting = { "puppet_lint" }
   },
   python = {
     diagnostics = { "flake8", "mypy", "pydocstyle", "pylama", "pylint", "vulture" },

--- a/lua/null-ls/builtins/_meta/formatting.lua
+++ b/lua/null-ls/builtins/_meta/formatting.lua
@@ -160,6 +160,9 @@ return {
   ptop = {
     filetypes = { "pascal", "delphi" }
   },
+  puppet_lint = {
+    filetypes = { "puppet", "epuppet" }
+  },
   qmlformat = {
     filetypes = { "qml" }
   },

--- a/lua/null-ls/builtins/diagnostics/puppet_lint.lua
+++ b/lua/null-ls/builtins/diagnostics/puppet_lint.lua
@@ -1,0 +1,39 @@
+local h = require("null-ls.helpers")
+local methods = require("null-ls.methods")
+local u = require("null-ls.utils")
+
+local severities = {
+    error = vim.lsp.protocol.DiagnosticSeverity.Error,
+    warning = vim.lsp.protocol.DiagnosticSeverity.Warning,
+}
+
+return h.make_builtin({
+    name = "puppet-lint",
+    method = methods.internal.DIAGNOSTICS,
+    filetypes = { "puppet", "epuppet" },
+    generator_opts = {
+        command = "puppet-lint",
+        args = { "--json", "$FILENAME" },
+        format = "json",
+        check_exit_code = function(code)
+            return code <= 1
+        end,
+        on_output = function(params)
+            local diags = {}
+            for _, d in ipairs(params.output) do
+                for _, f in ipairs(d) do
+                    table.insert(diags, {
+                        row = f.line,
+                        col = f.column,
+                        source = f.check,
+                        message = f.message,
+                        severity = severities[f.kind],
+                        filename = f.fullpath,
+                    })
+                end
+            end
+            return diags
+        end,
+    },
+    factory = h.generator_factory,
+})

--- a/lua/null-ls/builtins/formatting/puppet_lint.lua
+++ b/lua/null-ls/builtins/formatting/puppet_lint.lua
@@ -1,0 +1,19 @@
+local h = require("null-ls.helpers")
+local methods = require("null-ls.methods")
+
+local FORMATTING = methods.internal.FORMATTING
+
+return h.make_builtin({
+    name = "puppet-lint",
+    method = FORMATTING,
+    filetypes = { "puppet", "epuppet" },
+    generator_opts = {
+        command = "puppet-lint",
+        args = {
+            "--fix",
+            "$FILENAME",
+        },
+        to_temp_file = true,
+    },
+    factory = h.formatter_factory,
+})


### PR DESCRIPTION
Based on the Rubocop formatter. This uses puppet-lint.

Signed-off-by: Jo Vandeginste <Jo.Vandeginste@kuleuven.be>