### PR TITLE
feat: Add xmllint for XML formatting

### DIFF
--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -1780,6 +1780,25 @@ local sources = { null_ls.builtins.formatting.uncrustify }
 - `command = "uncrustify"`
 - `args = { "-q", "-l <LANG>" }`
 
+#### [xmllint](http://xmlsoft.org/xmllint.html)
+
+##### About
+
+Despite the name, `xmllint` can be used to format XML files as well as lint
+them, and that's the mode this builtin is using.
+
+##### Usage
+
+```lua
+local sources = { null_ls.builtins.formatting.xmllint }
+```
+
+##### Defaults
+
+- `filetypes = { "xml" }`
+- `command = "xmllint"`
+- `args = { "--format", "-" }`
+
 #### [yapf](https://github.com/google/yapf)
 
 ##### About

--- a/lua/null-ls/builtins/_meta/filetype_map.lua
+++ b/lua/null-ls/builtins/_meta/filetype_map.lua
@@ -259,6 +259,9 @@ return {
     diagnostics = { "eslint", "eslint_d" },
     formatting = { "eslint", "eslint_d", "prettier", "prettier_d_slim", "prettierd", "rustywind" }
   },
+  xml = {
+    formatting = { "xmllint" }
+  },
   yaml = {
     diagnostics = { "yamllint" },
     formatting = { "prettier", "prettier_d_slim", "prettierd" }

--- a/lua/null-ls/builtins/_meta/formatting.lua
+++ b/lua/null-ls/builtins/_meta/formatting.lua
@@ -235,6 +235,9 @@ return {
   uncrustify = {
     filetypes = { "c", "cpp", "cs", "java" }
   },
+  xmllint = {
+    filetypes = { "xml" }
+  },
   yapf = {
     filetypes = { "python" }
   },

--- a/lua/null-ls/builtins/formatting/xmllint.lua
+++ b/lua/null-ls/builtins/formatting/xmllint.lua
@@ -1,0 +1,16 @@
+local h = require("null-ls.helpers")
+local methods = require("null-ls.methods")
+
+local FORMATTING = methods.internal.FORMATTING
+
+return h.make_builtin({
+    name = "xmllint",
+    method = FORMATTING,
+    filetypes = { "xml" },
+    generator_opts = {
+        command = "xmllint",
+        args = { "--format", "-" },
+        to_stdin = true,
+    },
+    factory = h.formatter_factory,
+})


### PR DESCRIPTION
This is another custom source I've been using successfully for some time that I've reworked as a builtin. Although `xmllint` may not be a very well known tool, it's installed by default on many *nix systems as it's part of libxml2, and it works very smoothly for formatting.