### PR TITLE
[Cspell] Add "_fallback" severity: error -> warning

### DIFF
--- a/lua/null-ls/builtins/diagnostics/cspell.lua
+++ b/lua/null-ls/builtins/diagnostics/cspell.lua
@@ -28,6 +28,9 @@ return h.make_builtin({
             {
                 adapters = { h.diagnostics.adapters.end_col.from_quote },
                 offsets = { end_col = 1 },
+                severities = {
+                    ["_fallback"] = h.diagnostics.severities["warning"],
+                },
             }
         ),
     },


### PR DESCRIPTION
I change severity because cspell diagnostic raise error by default, it confuses me when combined with other LSP.