### PR TITLE
fix(diagnostics): statix

### DIFF
--- a/lua/null-ls/builtins/diagnostics/statix.lua
+++ b/lua/null-ls/builtins/diagnostics/statix.lua
@@ -12,6 +12,7 @@ return h.make_builtin({
         args = { "check", "--stdin", "--format=errfmt" },
         format = "line",
         to_stdin = true,
+        from_stderr = true,
         on_output = h.diagnostics.from_pattern(
             [[>(%d+):(%d+):(.):(%d+):(.*)]],
             { "row", "col", "severity", "code", "message" },


### PR DESCRIPTION
I just found out that statix ​​doesn't work.
I have the latest statix ```Version: 0.5.2```
With this fix it works again.