### PR TITLE
Add support for Yarn v2+ with PnP

### DIFF
--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -297,6 +297,27 @@ local sources = {
 Another solution is to use the `dynamic_command` option, as described in
 [HELPERS](./HELPERS.md). Note that this option can affect performance.
 
+null-ls includes several command resolvers to handle common cases and cache
+results to prevent repeated lookups.
+
+For example, the following looks for `prettier` in `node_modules/.bin`, then
+tries to find a local Yarn Plug'n'Play install, then tries to find a global
+`prettier` executable:
+
+```lua
+local command_resolver = require("null-ls.helpers.command_resolver")
+
+local sources = {
+    null_ls.builtins.formatting.prettier.with({
+        dynamic_command = function(params)
+            return command_resolver.from_node_modules(params)
+                or command_resolver.from_yarn_pnp(params)
+                or vim.fn.executable(params.command) == 1 and params.command
+        end,
+    }),
+}
+```
+
 ## Conditional sources
 
 ### `condition`

--- a/lua/null-ls/helpers/generator_factory.lua
+++ b/lua/null-ls/helpers/generator_factory.lua
@@ -278,7 +278,13 @@ return function(opts)
             local resolved_command
             if dynamic_command then
                 resolved_command = dynamic_command(params)
-                log:debug(string.format("Using dynamic command for [%s], got: %s", params.command, resolved_command))
+                log:debug(
+                    string.format(
+                        "Using dynamic command for [%s], got: %s",
+                        params.command,
+                        vim.inspect(resolved_command)
+                    )
+                )
             else
                 resolved_command = command
             end
@@ -334,8 +340,8 @@ return function(opts)
 
             log:debug(
                 string.format(
-                    "spawning command [%s] at %s with args %s",
-                    resolved_command,
+                    "spawning command %s at %s with args %s",
+                    vim.inspect(resolved_command),
                     resolved_cwd,
                     vim.inspect(resolved_args)
                 )

--- a/lua/null-ls/loop.lua
+++ b/lua/null-ls/loop.lua
@@ -132,6 +132,17 @@ M.spawn = function(cmd, args, opts)
         parsed_env = env_merge(env)
     end
 
+    if type(cmd) == "table" then
+        local concat_args = {}
+        for i = 2, #cmd do
+            concat_args[#concat_args + 1] = cmd[i]
+        end
+        for _, arg in ipairs(args) do
+            concat_args[#concat_args + 1] = arg
+        end
+        cmd, args = cmd[1], concat_args
+    end
+
     handle = uv.spawn(
         vim.fn.exepath(cmd),
         { args = args, env = parsed_env, stdio = stdio, cwd = opts.cwd or vim.fn.getcwd() },

--- a/test/spec/loop_spec.lua
+++ b/test/spec/loop_spec.lua
@@ -147,6 +147,13 @@ describe("loop", function()
             assert.stub(uv.read_start).was_called(2)
         end)
 
+        it("should allow a table for cmd", function()
+            loop.spawn({ "cat", "-b" }, { "-n" }, mock_opts)
+
+            assert.equals(uv.spawn.calls[1].refs[1], vim.fn.exepath("cat"))
+            assert.same(uv.spawn.calls[1].refs[2].args, { "-b", "-n" })
+        end)
+
         describe("stdin", function()
             local mock_input = "I have content"
             before_each(function()


### PR DESCRIPTION
This PR is probably quite ugly, but I don't do a lot of Lua or Vim scripting normally.

I also couldn't get tests to work locally, but it seems `doc/TESTING.md` is out of date? There's a mention of a relative runtimepath, which I can only find in old versions of `minimal.vim`. I'm not sure where it is trying to find plenary and null-ls right now. I get output like:

```
Error detected while processing /src/contrib/null-ls/test/minimal.vim:
line    5:
E919: Directory not found in 'packpath': "pack/*/opt/plenary.nvim"
line    6:
E919: Directory not found in 'packpath': "pack/*/opt/null-ls.nvim"
line    8:
E5108: Error executing lua [string ":lua"]:1: module 'null-ls.config' not found:
[...]
```

What this PR does is add an extra lookup step to `from_node_modules` for finding executables installed by Yarn (v2+) when it is using Plug'n'Play. Yarn is an alternative package manager for Node.js, and PnP means it doesn't create a `node_modules` directory structure, but instead hooks the Node.js loader to read from zip files. This means local installations of Prettier, for example, live in something like: `.yarn/cache/prettier-npm-2.3.2-4467ec48dc-17ce5784ac.zip`

As a user, you'd do `yarn run prettier ...` to run Prettier. For null-ls, we also need detection, and for that we can use `yarn bin prettier`, which outputs a virtual path like: `/path/to/project/.yarn/cache/prettier-npm-2.3.2-4467ec48dc-17ce5784ac.zip/node_modules/prettier/bin-prettier.js`

Detection is technically enough, and we could do `yarn run prettier ...` from there, but instead doing `node --require .pnp.cjs <prettier virtual path> ...` saves some indirection to speed things up a little. The `--require .pnp.cjs` configures the loader in Node.js so running the virtual path works. Ideally, we'd do `NODE_OPTIONS="--require .pnp.cjs" node <prettier virtual path> ...`, because that'd also apply the loader hook to any subprocess that may be spawned, but I'm not sure what the correct way is to accomplish that in null-ls code.

This is also why I think this PR is ugly. There's a hack in place to have a `dynamic_command` that actually returns multiple args, by allowing it to return a table. But curious to hear what you think. 🙂

edit: also just noticed that there's no way to make `only_local` work with this type of lookup.