### PR TITLE
feat(diagnostics): fallback_severity option for per built-in

### DIFF
--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -185,6 +185,22 @@ See [CONFIG](CONFIG.md) to learn about the structure of `diagnostics_format`.
 Note that specifying `diagnostics_format` for a built-in will override your
 global `diagnostics_format` for that source.
 
+### Fallback severity
+
+You can define the severity by setting `fallback_severity` when the diagnostic
+source does not explicitly define a severity.
+
+```lua
+local sources = {
+    null_ls.builtins.diagnostics.cspell.with({
+        fallback_severity = vim.diagnostic.severity.HINT,
+    }),
+}
+```
+
+Note that specifying `fallback_severity` for a built-in will override your
+global `fallback_severity` specified in [CONFIG](CONFIG.md) for that source.
+
 ### Diagnostics performance
 
 If you have performance issues with a diagnostic source, you can configure any

--- a/doc/CONFIG.md
+++ b/doc/CONFIG.md
@@ -138,6 +138,9 @@ described in [BUILTINS](BUILTINS.md).
 Defines the severity used when a diagnostic source does not explicitly define a
 severity. See `:help diagnostic-severity` for available values.
 
+You can also set `fallback_severity` for built-ins by using the `with` method,
+described in [BUILTINS](BUILTINS.md).
+
 ### log (table)
 
 Sets options for null-ls logging.

--- a/doc/MAIN.md
+++ b/doc/MAIN.md
@@ -321,7 +321,7 @@ Note that `filename` (if specified) should be an absolute path to the file.
 
 `severity` should be one of the values described in `:help diagnostic-severity`.
 If unspecified, `severity` falls back to the config option `fallback_severity`,
-described in [CONFIG](./CONFIG.md).
+described in [CONFIG](./CONFIG.md) and [BUILTINS](./BUILTINS.md).
 
 #### Formatting
 

--- a/lua/null-ls/diagnostics.lua
+++ b/lua/null-ls/diagnostics.lua
@@ -50,7 +50,7 @@ local postprocess = function(diagnostic, _, generator)
     diagnostic.end_lnum = range["end"].line
     diagnostic.col = range["start"].character
     diagnostic.end_col = range["end"].character
-    diagnostic.severity = diagnostic.severity or c.get().fallback_severity
+    diagnostic.severity = diagnostic.severity or generator.opts.fallback_severity or c.get().fallback_severity
 
     diagnostic.source = diagnostic.source or generator.opts.name or generator.opts.command or "null-ls"
     if diagnostic.filename and not diagnostic.bufnr then

--- a/lua/null-ls/helpers/make_builtin.lua
+++ b/lua/null-ls/helpers/make_builtin.lua
@@ -28,6 +28,7 @@ local function make_builtin(opts)
         command = opts.command,
         env = opts.env,
         cwd = opts.cwd,
+        fallback_severity = opts.fallback_severity,
         diagnostics_format = opts.diagnostics_format,
         dynamic_command = opts.dynamic_command,
         runtime_condition = opts.runtime_condition,

--- a/test/spec/diagnostics_spec.lua
+++ b/test/spec/diagnostics_spec.lua
@@ -430,13 +430,23 @@ describe("diagnostics", function()
                 assert.equals(starting_severity, mock_diagnostic.severity)
             end)
 
-            it("should set severity to fallback when not set", function()
+            it("should set severity to global fallback when not set", function()
                 mock_diagnostic.severity = nil
 
                 postprocess(mock_diagnostic, mock_params, mock_generator)
 
                 assert.truthy(mock_diagnostic.severity)
                 assert.equals(mock_diagnostic.severity, c.get().fallback_severity)
+            end)
+
+            it("should set severity to generator specified fallback when not set", function()
+                mock_diagnostic.severity = nil
+                mock_generator.opts.fallback_severity = vim.diagnostic.severity.HINT
+
+                postprocess(mock_diagnostic, mock_params, mock_generator)
+
+                assert.truthy(mock_diagnostic.severity)
+                assert.equals(mock_diagnostic.severity, mock_generator.opts.fallback_severity)
             end)
         end)
     end)


### PR DESCRIPTION
This patch makes `fallback_severity` seem to `diagnostics_format`.