### PR TITLE
feature: `terrafmt` formatting builtin

### DIFF
--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -1706,6 +1706,25 @@ local sources = { null_ls.builtins.formatting.taplo }
 - `command = "taplo"`
 - `args = { "format", "-" }`
 
+#### [terrafmt](https://github.com/katbyte/terrafmt)
+
+##### About
+
+The `terrafmt` command formats `terraform` blocks embedded on `markdown` files.
+
+##### Usage
+
+```lua
+local sources = { null_ls.builtins.formatting.terrafmt }
+```
+
+##### Defaults
+
+- `filetypes = { "markdown" }`
+- `command = "terrafmt"`
+- `args = { "fmt", "$FILENAME" }`
+
+
 #### [terraform_fmt](https://www.terraform.io/docs/cli/commands/fmt.html)
 
 ##### About

--- a/lua/null-ls/builtins/formatting/terrafmt.lua
+++ b/lua/null-ls/builtins/formatting/terrafmt.lua
@@ -1,0 +1,19 @@
+local h = require("null-ls.helpers")
+local methods = require("null-ls.methods")
+
+local FORMATTING = methods.internal.FORMATTING
+
+return h.make_builtin({
+    name = "terrafmt",
+    method = FORMATTING,
+    filetypes = { "markdown" },
+    generator_opts = {
+        command = "terrafmt",
+        args = {
+            "fmt",
+            "$FILENAME",
+        },
+        to_stdin = true,
+    },
+    factory = h.formatter_factory,
+})


### PR DESCRIPTION
This PR introduces `terrafmt` as a new Terraform formatting builtin, a tool that allows formatting Terraform code blocks embedded on Markdown files.