### PR TITLE
Change prettier formatting call to fix OSX issue

### DIFF
--- a/lua/null-ls/builtins/formatting/prettier.lua
+++ b/lua/null-ls/builtins/formatting/prettier.lua
@@ -25,7 +25,7 @@ return h.make_builtin({
     },
     generator_opts = {
         command = "prettier",
-        args = h.range_formatting_args_factory({ "--stdin-filepath", "$FILENAME" }),
+        args = h.range_formatting_args_factory({ "$FILENAME" }),
         to_stdin = true,
         dynamic_command = cmd_resolver.from_node_modules,
     },


### PR DESCRIPTION
On OSX calling it with --stdin-filepath was causing a null return. Removing the argument seems to resolve the issue.