### PR TITLE
Add has_file utility

### DIFF
--- a/lua/null-ls/utils.lua
+++ b/lua/null-ls/utils.lua
@@ -146,7 +146,8 @@ M.make_conditional_utils = function()
         has_file = function(...)
             local patterns = vim.tbl_flatten({ ... })
             for _, name in ipairs(patterns) do
-                if M.path.exists(name) then
+                local full_path = vim.loop.fs_realpath(name)
+                if full_path and M.path.exists(full_path) then
                     return true
                 end
             end

--- a/lua/null-ls/utils.lua
+++ b/lua/null-ls/utils.lua
@@ -143,6 +143,15 @@ M.make_conditional_utils = function()
     local root = M.get_root()
 
     return {
+        has_file = function(...)
+            local patterns = vim.tbl_flatten({ ... })
+            for _, name in ipairs(patterns) do
+                if M.path.exists(name) then
+                    return true
+                end
+            end
+            return false
+        end,
         root_has_file = function(...)
             local patterns = vim.tbl_flatten({ ... })
             for _, name in ipairs(patterns) do

--- a/test/spec/utils_spec.lua
+++ b/test/spec/utils_spec.lua
@@ -324,8 +324,27 @@ describe("utils", function()
         local utils = u.make_conditional_utils()
 
         it("should return object containing utils", function()
+            assert.truthy(type(utils.has_file) == "function")
             assert.truthy(type(utils.root_has_file) == "function")
             assert.truthy(type(utils.root_matches) == "function")
+        end)
+
+        describe("has_file", function()
+            it("should return true if file exists in cwd", function()
+                assert.truthy(utils.has_file("stylua.toml"))
+            end)
+
+            it("should return true if some file exists in cwd", function()
+                assert.truthy(utils.has_file({ ".stylua.toml", "stylua.toml" }))
+            end)
+
+            it("should return false if some file not exists in cwd", function()
+                assert.falsy(utils.has_file({ "bad-file", "bad-file2" }))
+            end)
+
+            it("should return false if file does not exist in cwd", function()
+                assert.falsy(utils.has_file("bad-file"))
+            end)
         end)
 
         describe("root_has_file", function()


### PR DESCRIPTION
This utility makes it easier to work in polyglot monorepos. For instance, I may have a `.prettierrc` file I want to check for in a sub-directory rather than the root directory.

An alternative name for this function could be `cwd_has_file`. This is more convenient than `vim.loop.fs_stat(filename)` because it allows for tables like the `root_has_file` function, enabling the following:

```lua
local function prettier_condition(utils)
  -- See https://prettier.io/docs/en/configuration.html
  local files = {
    '.prettierrc',
    '.prettierrc.json',
    '.prettierrc.yml',
    '.prettierrc.yaml',
    '.prettierrc.json5',
    '.prettierrc.js',
    '.prettierrc.cjs',
    '.prettier.config.js',
    '.prettier.config.cjs',
    '.prettierrc.toml',
  }

  return utils.has_file(files) or utils.root_has_file(files)
end

local sources = {
  nls.builtins.formatting.prettierd.with({
    condition = prettier_condition,
  })
}

nls.setup({
  sources = sources,
})
```