### PR TITLE
Add support for builtin astyle.

### DIFF
--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -3190,3 +3190,20 @@ Registering this source will show available snippets in the completion list, but
 luasnip is in charge of expanding them. Consult luasnip's documentation
 [here](https://github.com/L3MON4D3/LuaSnip#keymaps) to set up keymaps for
 expansion and jumping.
+
+#### [astyle](http://astyle.sourceforge.net/)
+
+##### About
+
+Artistic Style is a source code indenter, formatter, and beautifier for the C, C++, C++/CLI, Objective‑C, C# and Java programming languages.
+
+This formatter works well for [Arduino](https://www.arduino.cc/) project files and it is the same formatting files in the Arduino IDE
+
+##### Usage
+
+```lua
+local sources = { null_ls.builtins.formatting.astyle }
+```
+
+#### Defaults
+- `filetypes = { "arduino", "c", "cpp", "cs", "java" }`

--- a/lua/null-ls/builtins/formatting/astyle.lua
+++ b/lua/null-ls/builtins/formatting/astyle.lua
@@ -1,0 +1,18 @@
+local h = require("null-ls.helpers")
+local methods = require("null-ls.methods")
+
+local FORMATTING = methods.internal.FORMATTING
+
+return h.make_builtin({
+    name = "astyle",
+    method = FORMATTING,
+    filetypes = { "arduino", "c", "cpp", "cs", "java" },
+    generator_opts = {
+        command = "astyle",
+        args = {
+            "--quiet",
+        },
+        to_stdin = true,
+    },
+    factory = h.formatter_factory,
+})


### PR DESCRIPTION
This is a simple file formatter that works well for Arduino files.

I also added filetypes `"c", "cpp", "cs", "java" ` as this formatter also supports them.

I tested this locally and it works well.

