### PR TITLE
fix auto insert of 'log' to current source file

### DIFF
--- a/lua/null-ls/builtins/formatting/djlint.lua
+++ b/lua/null-ls/builtins/formatting/djlint.lua
@@ -11,9 +11,6 @@ return h.make_builtin({
         command = "djlint",
         args = {
             "--reformat",
-            "--stdin-filename",
-            "$FILENAME",
-            "--quiet",
             "-",
         },
         to_stdin = true,


### PR DESCRIPTION
Formatting with djList also inserts "0 files were updated."  on current source file.

> The quiet option just skips printing the diff, it doesn't suppress all output.
> Using stdin will surpress all output.

more: [Riverside-Healthcare/djLint/issues/184](https://github.com/Riverside-Healthcare/djLint/issues/184)