### PR TITLE
Allow exit 1 for statix action

### DIFF
--- a/lua/null-ls/builtins/code_actions/statix.lua
+++ b/lua/null-ls/builtins/code_actions/statix.lua
@@ -12,6 +12,9 @@ return h.make_builtin({
         args = { "check", "--stdin", "--format=json" },
         format = "json",
         to_stdin = true,
+        check_exit_code = function(code)
+            return code <= 1
+        end,
         on_output = function(params)
             local actions = {}
             for _, r in ipairs(params.output.report) do


### PR DESCRIPTION
Never version uses 1 to indicate possible fixes, fix should be backward compatible.