### PR TITLE
fix: add "jsonc" in prettier filetypes

### DIFF
--- a/lua/null-ls/builtins/formatting/prettier.lua
+++ b/lua/null-ls/builtins/formatting/prettier.lua
@@ -19,6 +19,7 @@ return h.make_builtin({
         "less",
         "html",
         "json",
+        "jsonc",
         "yaml",
         "markdown",
         "graphql",

--- a/lua/null-ls/builtins/formatting/prettier_d_slim.lua
+++ b/lua/null-ls/builtins/formatting/prettier_d_slim.lua
@@ -19,6 +19,7 @@ return h.make_builtin({
         "less",
         "html",
         "json",
+        "jsonc",
         "yaml",
         "markdown",
         "graphql",

--- a/lua/null-ls/builtins/formatting/prettierd.lua
+++ b/lua/null-ls/builtins/formatting/prettierd.lua
@@ -18,6 +18,7 @@ return h.make_builtin({
         "less",
         "html",
         "json",
+        "jsonc",
         "yaml",
         "markdown",
         "graphql",


### PR DESCRIPTION
I was recently looking for a way to avoid showing diagnostic errors for comments in json files and found [this](https://www.reddit.com/r/neovim/comments/pfy8et/how_to_not_have_diagnostic_error_in_a_json_file/hb8t57j/?utm_source=share&utm_medium=web2x&context=3) way to fix it. 

TL;DR the fix consists in setting the filetype to jsonc (same conduct as vscode, json lsp continues working as usual), so I added jsonc in prettier filetypes.