### PR TITLE
refactor(formatting)!: make formatting API LSP-independent

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,14 +202,10 @@ plugin before sending anything upstream.
 
 ### How do I format files?
 
-null-ls formatters run when you call `vim.lsp.buf.formatting()` or
-`vim.lsp.buf.formatting_sync()`. If a source supports it, you can run range
-formatting by visually selecting part of the buffer and calling
-`vim.lsp.buf.range_formatting()`.
-
-### How do I stop Neovim from asking me which server I want to use for formatting?
-
-See [this wiki page](https://github.com/jose-elias-alvarez/null-ls.nvim/wiki/Avoiding-LSP-formatting-conflicts).
+null-ls formatters run when you call `:lua require("null-ls").formatting()` or
+`:lua require("null-ls").formatting_sync()`. If a source supports it, you can run
+range formatting by visually selecting part of the buffer and calling
+`:lua require("null-ls").range_formatting()`.
 
 ### How do I format files on save?
 
@@ -217,13 +213,12 @@ See the following snippet:
 
 ```lua
 require("null-ls").setup({
-    -- you can reuse a shared lspconfig on_attach callback here
     on_attach = function(client)
         if client.resolved_capabilities.document_formatting then
             vim.cmd([[
             augroup LspFormatting
                 autocmd! * <buffer>
-                autocmd BufWritePre <buffer> lua vim.lsp.buf.formatting_sync()
+                autocmd BufWritePre <buffer> lua require("null-ls").formatting_sync()
             augroup END
             ]])
         end
@@ -231,10 +226,12 @@ require("null-ls").setup({
 })
 ```
 
-You can also set up async formatting, as described on [this wiki
-page](https://github.com/jose-elias-alvarez/null-ls.nvim/wiki/Async-formatting).
-Please read the Caveats section there to understand the meaning of (and
-drawbacks of) async formatting.
+If you want to try formatting with null-ls and fall back to LSP formatting, add
+the following option:
+
+```lua
+require("null-ls").formatting_sync({ fallback_to_lsp = true })
+```
 
 ### How do I view project-level diagnostics?
 
@@ -259,15 +256,8 @@ option after you've collected the information you're looking for.
 
 ### Does it work with (other plugin)?
 
-In most cases, yes. null-ls tries to act like an actual LSP server as much as
-possible, so it should work seamlessly with most LSP-related plugins. If you run
-into problems, please try to determine which plugin is causing them and open an
-issue.
-
-[This wiki
-page](https://github.com/jose-elias-alvarez/null-ls.nvim/wiki/Compatibility-with-other-plugins)
-mentions plugins that require specific configuration options / tweaks to work
-with null-ls.
+In most cases, yes. If you run into problems, please try to determine which
+plugin is causing them and open an issue.
 
 ### How does it work?
 
@@ -282,18 +272,6 @@ More testing is necessary, but since null-ls uses pure Lua and runs entirely in
 memory without any external processes, in most cases it should run faster than
 similar solutions. If you notice that performance is worse with null-ls than
 with an alternative, please open an issue!
-
-### I am seeing a `vim.lsp.buf.formatting_sync: timeout` error message
-
-This issue occurs when a formatter takes longer than the default timeout value
-of the `formatting_sync` function. This is an automatic mechanism and controlled
-by Neovim. You might want to increase the timeout in your `formatting_sync`
-call:
-
-```lua
--- increase timeout to 2 seconds
-vim.lsp.buf.formatting_sync(nil, 2000)
-```
 
 ## Tests
 

--- a/doc/FORMATTING.md
+++ b/doc/FORMATTING.md
@@ -1,0 +1,94 @@
+# Formatting
+
+The null-ls formatting API is analogous to Neovim's LSP formatting API and
+provides the following methods, exposed under the main `require("null-ls")`
+module.
+
+```lua
+local null_ls = require("null-ls")
+
+null-ls.formatting(options)
+null-ls.formatting_sync(options, timeout_ms)
+null-ls.range_formatting(options, start_pos, end_pos)
+```
+
+## `null-ls.formatting(options)`
+
+Analogous to `vim.lsp.buf.formatting`. Accepts the following arguments:
+
+- `options` (table, optional): See `:help vim.lsp.buf.formatting`. Note that as
+  of now, null-ls does not recognize these options.
+
+  null-ls accepts an extra option, `options.fallback_to_lsp` (boolean), which will
+  automatically call `vim.lsp.buf.formatting(options)` if null-ls formatting is
+  unavailable.
+
+## `null-ls.formatting_sync(options, timeout_ms)`
+
+Analogous to `vim.lsp.buf.formatting`. Accepts the following arguments:
+
+- `options` (table, optional): See `:help vim.lsp.buf.formatting_sync`. Note
+  that as of now, null-ls does not recognize these options.
+
+  null-ls accepts an extra option, `options.fallback_to_lsp` (boolean), which
+  will automatically call `vim.lsp.buf.formatting_sync(options, timeout_ms)` if
+  null-ls formatting is unavailable.
+
+- `timeout_ms` (number, optional): See `:help vim.lsp.buf.formatting_sync`. Note
+  that as of now, null-ls does not recognize this option (timeouts are
+  source-specific, as described in [SOURCES](./SOURCES.md).
+
+## `null-ls.range_formatting(options, start_pos, end_pos)`
+
+Analogous to `vim.lsp.buf.range_formatting`. Accepts the following arguments:
+
+- `options` (table, optional): See `:help vim.lsp.buf.range_formatting`. Note
+  that as of now, null-ls does not recognize these options.
+
+  null-ls accepts an extra option, `options.fallback_to_lsp` (boolean), which
+  will automatically call `vim.lsp.buf.range_formatting(options, start_pos, end_pos)` if null-ls formatting is unavailable.
+
+- `start_pos` (number, optional): See `:help vim.lsp.buf.range_formatting`.
+  Defaults to the start of the last visual selection.
+- `end_pos` (number, optional): See `:help vim.lsp.buf.range_formatting`.
+  Defaults to the end of the last visual selection.
+
+## Custom formatting
+
+### Chaining
+
+The API methods described above return `false` if null-ls is unable to format
+the current buffer. This makes it possible to fall back to another formatting
+source if null-ls is unavailable, as in this example:
+
+```lua
+local custom_formatting = function()
+    if not require("null-ls").formatting_sync() then
+      -- fallback
+    end
+end
+```
+
+### Manual requests
+
+For advanced use cases, you can manually send requests to the null-ls client:
+
+```lua
+local manual_formatting = function()
+    local bufnr = vim.api.nvim_get_current_buf()
+    local client = require("null-ls.client").get_client()
+    if not client then
+        return
+    end
+
+    local params = vim.lsp.util.make_formatting_params()
+    -- note that the method must correspond to an internal formatting method
+    client.request(require("null-ls").methods.FORMATTING, params, function(err, res)
+        if err then
+            -- handle error
+        elseif res then
+            -- handle response
+        end
+    end, bufnr)
+end
+```

--- a/doc/MAIN.md
+++ b/doc/MAIN.md
@@ -22,6 +22,8 @@ Splits into the following documents:
 - [HELPERS](HELPERS.md), which describes available helpers and how to use
   them to make new sources
 
+- [FORMATTING](FORMATTING.md), which describes the formatting API
+
 - [TESTING](TESTING.md), which describes best practices for testing null-ls
   integrations
 
@@ -56,22 +58,30 @@ definition is by referencing the `methods` object.
 
 ```lua
 local null_ls = require("null-ls")
-
 local my_source = {}
+
 -- source will run on LSP code action request
 my_source.method = null_ls.methods.CODE_ACTION
-
--- source will run on LSP diagnostics request
-my_source.method = null_ls.methods.DIAGNOSTICS
-
--- source will run on LSP formatting request
-my_source.method = null_ls.methods.FORMATTING
 
 -- source will run on LSP hover request
 my_source.method = null_ls.methods.HOVER
 
 -- source will run on LSP completion request
 my_source.method = null_ls.methods.COMPLETION
+
+-- source will run on LSP change notification
+my_source.method = null_ls.methods.DIAGNOSTICS
+```
+
+Some methods are independent from LSP methods and will run when invoked using
+the relevant API or a direct request to the client:
+
+```lua
+local null_ls = require("null-ls")
+local my_source = {}
+
+-- source will run on direct formatting request (see FORMATTING.md)
+my_source.method = null_ls.methods.FORMATTING
 ```
 
 ### Filetypes
@@ -215,7 +225,7 @@ editor state.
 ```lua
 local params = {
     content, -- current buffer content (table, split at newline)
-    lsp_method, -- lsp method that triggered request (string)
+    lsp_method, -- lsp method that triggered request (string or nil)
     method, -- null-ls method that triggered generator (string)
     row, -- cursor's current row (number, zero-indexed)
     col, -- cursor's current column (number)

--- a/lua/null-ls/client.lua
+++ b/lua/null-ls/client.lua
@@ -30,17 +30,18 @@ local should_attach = function(bufnr)
 end
 
 local on_init = function(new_client, initialize_result)
-    -- null-ls broadcasts all capabilities on launch, so this lets us have finer control
-    new_client.supports_method = function(method)
+    new_client.supports_method = function(method, bufnr)
+        bufnr = bufnr or 0
+
         -- capability was not declared or is specifically disabled
         if new_client.resolved_capabilities[methods.request_name_to_capability[method]] == false then
             return false
         end
 
         -- determine capability by ability to run for the current buffer
-        local internal_method = methods.map[method]
+        local internal_method = (methods.internal[method] and method) or methods.map[method]
         if internal_method then
-            return require("null-ls.generators").can_run(vim.bo.filetype, internal_method)
+            return require("null-ls.generators").can_run(api.nvim_buf_get_option(bufnr, "filetype"), internal_method)
         end
 
         -- return true for supported methods w/o a corresponding internal method (init, shutdown)

--- a/lua/null-ls/init.lua
+++ b/lua/null-ls/init.lua
@@ -15,6 +15,10 @@ M.register_name = sources.register_name
 M.reset_sources = sources.reset
 M.toggle = sources.toggle
 
+M.formatting = require("null-ls.formatting").formatting
+M.formatting_sync = require("null-ls.formatting").formatting_sync
+M.range_formatting = require("null-ls.formatting").range_formatting
+
 M.builtins = require("null-ls.builtins")
 M.methods = require("null-ls.methods").internal
 M.null_ls_info = require("null-ls.info").show_window

--- a/lua/null-ls/methods.lua
+++ b/lua/null-ls/methods.lua
@@ -38,6 +38,7 @@ local lsp_to_internal_map = {
     [lsp_methods.HOVER] = internal_methods.HOVER,
     [lsp_methods.COMPLETION] = internal_methods.COMPLETION,
 }
+vim.tbl_add_reverse_lookup(lsp_to_internal_map)
 
 local overrides = {
     [internal_methods.DIAGNOSTICS_ON_OPEN] = {

--- a/lua/null-ls/utils.lua
+++ b/lua/null-ls/utils.lua
@@ -113,7 +113,7 @@ M.make_params = function(original_params, method)
 
     local params = {
         client_id = original_params.client_id,
-        lsp_method = original_params.method,
+        lsp_method = methods.lsp[original_params.method] and original_params.method,
         options = original_params.options,
         content = content,
         method = method,

--- a/test/spec/e2e_spec.lua
+++ b/test/spec/e2e_spec.lua
@@ -3,6 +3,9 @@ local methods = require("null-ls.methods")
 local sources = require("null-ls.sources")
 local main = require("null-ls")
 
+local formatting = require("null-ls.formatting").formatting
+local range_formatting = require("null-ls.formatting").range_formatting
+
 local c = require("null-ls.config")
 local u = require("null-ls.utils")
 local s = require("null-ls.state")
@@ -241,7 +244,7 @@ describe("e2e", function()
         end)
 
         it("should format file", function()
-            lsp.buf.formatting()
+            formatting()
             wait_for_prettier()
 
             assert.equals(u.buf.content(nil, true), formatted)
@@ -264,7 +267,7 @@ describe("e2e", function()
             end)
 
             it("should format file", function()
-                lsp.buf.formatting()
+                formatting()
                 wait_for_prettier()
 
                 assert.equals(u.buf.content(nil, true), formatted)
@@ -294,7 +297,7 @@ describe("e2e", function()
         it("should format specified range", function()
             vim.cmd("normal ggV")
 
-            lsp.buf.range_formatting()
+            range_formatting()
             wait_for_prettier()
 
             assert.equals(u.buf.content(nil, true), formatted)
@@ -474,7 +477,7 @@ describe("e2e", function()
             tu.edit_test_file("test-file.txt")
             tu.wait()
 
-            lsp.buf.formatting()
+            formatting()
             tu.wait_for_mock_source(2)
 
             assert.equals(u.buf.content(nil, true), "sequential\n")
@@ -485,7 +488,7 @@ describe("e2e", function()
             sources.register(builtins._test.second_formatter)
             tu.edit_test_file("test-file.txt")
             tu.wait()
-            lsp.buf.formatting()
+            formatting()
             tu.wait_for_mock_source(2)
 
             vim.cmd("silent normal u")
@@ -499,7 +502,7 @@ describe("e2e", function()
             tu.edit_test_file("test-file.txt")
             tu.wait()
 
-            lsp.buf.formatting()
+            formatting()
             tu.wait_for_mock_source(2)
 
             assert.equals(u.buf.content(nil, true), "first\n")
@@ -516,7 +519,7 @@ describe("e2e", function()
             tu.edit_test_file("test-file.txt")
             tu.wait()
 
-            lsp.buf.formatting()
+            formatting()
             tu.wait_for_mock_source()
 
             assert.equals(#sources.get({}), 1)
@@ -532,7 +535,7 @@ describe("e2e", function()
             tu.edit_test_file("test-file.txt")
             tu.wait()
 
-            lsp.buf.formatting()
+            formatting()
             tu.wait_for_mock_source()
 
             assert.equals(#sources.get({}), 0)
@@ -549,7 +552,7 @@ describe("e2e", function()
             tu.edit_test_file("test-file.txt")
             tu.wait()
 
-            lsp.buf.formatting()
+            formatting()
             tu.wait_for_mock_source(2)
 
             assert.equals(#sources.get({}), 2)
@@ -571,7 +574,7 @@ describe("e2e", function()
         end)
 
         it("should use client handler", function()
-            lsp.buf.formatting()
+            formatting()
             tu.wait_for_mock_source()
 
             assert.stub(mock_handler).was_called()

--- a/test/spec/formatting_spec.lua
+++ b/test/spec/formatting_spec.lua
@@ -6,7 +6,7 @@ local methods = require("null-ls.methods")
 local generators = require("null-ls.generators")
 local diff = require("null-ls.diff")
 
-local method = methods.lsp.FORMATTING
+local method = methods.internal.FORMATTING
 
 local lsp = mock(vim.lsp, true)
 mock(require("null-ls.logger"), true)
@@ -65,25 +65,25 @@ describe("formatting", function()
             assert.equals(mock_params._null_ls_handled, nil)
         end)
 
-        it("should set handled flag if method is lsp.FORMATTING", function()
+        it("should set handled flag if method is internal.FORMATTING", function()
             formatting.handler(method, mock_params, handler)
 
             assert.equals(mock_params._null_ls_handled, true)
         end)
 
-        it("should set handled flag if method is lsp.RANGE_FORMATTING", function()
-            formatting.handler(methods.lsp.RANGE_FORMATTING, mock_params, handler)
+        it("should set handled flag if method is internal.RANGE_FORMATTING", function()
+            formatting.handler(methods.internal.RANGE_FORMATTING, mock_params, handler)
 
             assert.equals(mock_params._null_ls_handled, true)
         end)
 
         it("should call run_registered_sequentially with opts", function()
-            formatting.handler(methods.lsp.FORMATTING, mock_params, handler)
+            formatting.handler(method, mock_params, handler)
 
             local opts = generators.run_registered_sequentially.calls[1].refs[1]
 
             assert.equals(opts.filetype, vim.api.nvim_buf_get_option(mock_params.bufnr, "filetype"))
-            assert.equals(opts.method, methods.map[method])
+            assert.equals(opts.method, method)
             assert.equals(type(opts.make_params), "function")
             assert.equals(type(opts.postprocess), "function")
             assert.equals(type(opts.after_each), "function")
@@ -93,7 +93,7 @@ describe("formatting", function()
 
     describe("make_params", function()
         it("should call make_params with params and internal method", function()
-            formatting.handler(methods.lsp.FORMATTING, mock_params, handler)
+            formatting.handler(method, mock_params, handler)
 
             local make_params = generators.run_registered_sequentially.calls[1].refs[1].make_params
             make_params()
@@ -104,7 +104,7 @@ describe("formatting", function()
 
         it("should override params.content with temp buffer content", function()
             u.buf.content.returns("temp file content")
-            formatting.handler(methods.lsp.FORMATTING, mock_params, handler)
+            formatting.handler(method, mock_params, handler)
 
             local make_params = generators.run_registered_sequentially.calls[1].refs[1].make_params
             local updated_params = make_params()
@@ -119,7 +119,7 @@ describe("formatting", function()
             local mock_edits = { newText = "newText", rangeLength = 7 }
             diff.compute_diff.returns(mock_edits)
 
-            formatting.handler(methods.lsp.FORMATTING, mock_params, handler)
+            formatting.handler(method, mock_params, handler)
 
             local callback = generators.run_registered_sequentially.calls[1].refs[1].callback
             callback()
@@ -131,7 +131,7 @@ describe("formatting", function()
             local mock_edits = { newText = "", rangeLength = 0 }
             diff.compute_diff.returns(mock_edits)
 
-            formatting.handler(methods.lsp.FORMATTING, mock_params, handler)
+            formatting.handler(method, mock_params, handler)
 
             local callback = generators.run_registered_sequentially.calls[1].refs[1].callback
             callback()

--- a/test/spec/utils_spec.lua
+++ b/test/spec/utils_spec.lua
@@ -213,6 +213,14 @@ describe("utils", function()
             assert.same(params.content, { 'print("I am a test file!")', "" })
         end)
 
+        it("should not set lsp method if method is internal", function()
+            local params = u.make_params({
+                method = mock_method,
+            }, mock_method)
+
+            assert.equals(params.lsp_method, nil)
+        end)
+
         it("should convert original range and assign to params.range", function()
             local original_params = {
                 range = {


### PR DESCRIPTION
Closes #697. This is a potential solution to the issue of formatting conflicts and represents a potential divergent path for the plugin as a whole, but as it's a significant breaking change and nothing is immediately broken, the plan for now is to wait and see. See below for further discussion.

As mentioned in the linked issue:

> The initial logic behind hooking into LSP formatting was to allow users to have a "unified" setup that lets them, say, use the same keybindings and commands for LSP formatting and null-ls formatting without having to worry about which one is currently active.

However, unlike other LSP features, it's quite rare to want to combine null-ls formatting and formatting from actual language servers. The headaches caused by conflicts outweigh the benefits of unification, and so the goal of this PR is to refactor the formatting API to make it independent from the LSP formatting family.

In practice, this has the following implications:

1. The following functions no longer interact with null-ls:

```lua
vim.lsp.buf.formatting_sync()
vim.lsp.buf.formatting()
vim.lsp.buf.range_formatting()
```

2. Instead, users can use the following functions, which should work as drop-in replacements:

```lua
require("null-ls").formatting_sync()
-- for convenience, these will resolve and use the relevant LSP formatting handler
require("null-ls").formatting()
require("null-ls").range_formatting()
```

3. To make it easier to prioritize null-ls formatting but fall back to LSP formatting, which seems to be the most common use case, I've added an option which should make the transition easier (most users will only have to replace a single line in their configs):

```lua
local my_common_on_attach = function(client)
    if client.resolved_capabilities.document_formatting then
        vim.cmd([[
            augroup LspFormatting
                autocmd! * <buffer>
                autocmd BufWritePre <buffer> lua require("null-ls").formatting_sync({ fallback_to_lsp = true })
            augroup END
            ]])
    end
end
```

4. The new functions return `false` if null-ls is unable to format the current buffer, meaning users who want more control can chain null-ls formatting and LSP formatting (something many users are already accustomed to from plugins like nvim-cmp):

```lua

_G.formatting_sync = function() 
    -- pretend this is doing something more interesting
    return require("null-ls").formatting_sync() or vim.lsp.buf.formatting_sync()
end

local my_common_on_attach = function(client)
    if client.resolved_capabilities.document_formatting then
        vim.cmd([[
            augroup LspFormatting
                autocmd! * <buffer>
                autocmd BufWritePre <buffer> lua formatting_sync()
            augroup END
            ]])
    end
end
```

5. More advanced use cases (e.g. async formatting) can still be handled by directly sending requests to the client using null-ls specific methods:

```lua
_G.formatting = function()
    local bufnr = vim.api.nvim_get_current_buf()
    local client = require("null-ls.client").get_client()
    if not client then
        return
    end

    local params = vim.lsp.util.make_formatting_params()
    client.request(require("null-ls").methods.FORMATTING, params, function(err, res)
        if err then
            -- handle error
        elseif res then
            -- handle response
        end
    end, bufnr)
end
```

This is a breaking change for many null-ls users, but as mentioned, most users should only have to change a single line in their configs, with the advantage of removing code that disables server capabilities. I also see this as a potential step towards making null-ls more LSP-independent, which in the absence of other changes is one way to ensure the plugin's continued longevity. 

- [ ] Add tests
- [x] Update documentation