### PR TITLE
Uncrustify argument split breaks extra_args

### DIFF
--- a/lua/null-ls/builtins/formatting/uncrustify.lua
+++ b/lua/null-ls/builtins/formatting/uncrustify.lua
@@ -10,8 +10,7 @@ return h.make_builtin({
     generator_opts = {
         command = "uncrustify",
         args = function(params)
-            local format_type = "-l " .. params.ft:upper()
-            return { "-q", format_type }
+            return { "-q", "-l", params.ft:upper() }
         end,
         to_stdin = true,
     },


### PR DESCRIPTION
The space between "-l" and the language causes any extra_args to not be accepted, simply splitting it up solves the issue.