### PR TITLE
fix: run CI checks on main branch

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -1,6 +1,10 @@
 name: default
 
-on: [pull_request]
+on:
+  pull_request:
+  # Also build the default branch so cache is available to PRs.
+  push:
+    branches: [main]
 
 jobs:
   stylua:


### PR DESCRIPTION
It looks like the stylua and selene checks are still not using cached downloads, and I suspect this is because PR builds can't populate the cache for security reasons. ([docs ref](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache))

CI is already plenty fast, it appears usually in the ~20s range. I expect this'll only save a second or two, so maybe a bit nitpicky. Also won't be able to tell if this works or not until it's on the main branch and someone opens a PR. 🤷 