### PR TITLE
fix: prevent errors from killing PHPMD Language Server

### DIFF
--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -2425,7 +2425,7 @@ Note that `extra_args` is required, and allows you so specify the
 
 - `filetypes = { "php" }`
 - `command = "phpmd"`
-- `args = { '--ignore-violations-on-exit', '-', 'json' }`
+- `args = { '--ignore-violations-on-exit', '--ignore-errors-on-exit', '-', 'json' }`
 
 ##### Additional Notes
 

--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -2433,7 +2433,7 @@ Note that PHPMD version 2.11.1 requires updating with the latest version of
 [PHP_Depend](https://github.com/pdepend/pdepend):
 
 ```bash
-composer update pdepend/pdepend:dev-master
+composer require --dev pdepend/pdepend:dev-master
 ```
 
 - Bug: https://github.com/phpmd/phpmd/issues/941

--- a/lua/null-ls/builtins/diagnostics/phpmd.lua
+++ b/lua/null-ls/builtins/diagnostics/phpmd.lua
@@ -9,6 +9,7 @@ return h.make_builtin({
         command = "phpmd",
         args = {
             "--ignore-violations-on-exit",
+            "--ignore-errors-on-exit",
             "-", -- process stdin
             "json",
             -- 'phpmd.xml',


### PR DESCRIPTION
When writing code, you will naturally have syntax errors (before you have finished writing a line of code, for example).

Without this change, such errors will cause an error in null-ls:

```
lua/null-ls/helpers/generator_factory.lua:229: error in generator output
```

The PHPMD language server will stop working:

- any existing diagnostic messages will remain on the screen, even if you fix the relevant problem
- no new diagnostic messages will be shown

I believe this is because `phpmd` is exiting with a non-zero status code when it encounters syntax errors.  This change stops it from doing that.