### PR TITLE
feat(helpers): generalize range_formatting_args_factory

### DIFF
--- a/doc/HELPERS.md
+++ b/doc/HELPERS.md
@@ -294,23 +294,32 @@ Defines the source's null-ls method, as described in [MAIN](MAIN.md).
 
 ## range_formatting_args_factory
 
-Converts the visually-selected range into character offsets and adds the
+Converts the visually-selected range into character offsets / rows and adds the
 converted range to the spawn arguments. Used for sources that provide both
 formatting and range formatting.
 
 ```lua
-null_ls.helpers.range_formatting_args_factory(base_args, start_arg, end_rag)
+null_ls.helpers.range_formatting_args_factory(base_args, start_arg, end_rag, opts)
 ```
 
-- `base_args`: the base arguments required to get formatted output. Formatting
-  requests will use `base_args` as-is, and range formatting requests will append
-  the range arguments.
+- `base_args` (string[]): the base arguments required to get formatted output.
+  Formatting requests will use `base_args` as-is and range formatting requests
+  will append range arguments.
 
-- `start_arg` (optional): the name of the argument that indicates the start of
-  the range. Defaults to `"--range-start"`.
+- `start_arg` (string): the name of the argument that indicates the start of the
+  range.
 
-- `end_arg` (optional): the name of the argument that indicates the end of the
-  range. Defaults to `"--range-end"`.
+- `end_arg` (string?): the name of the argument that indicates the end of the
+  range. If not specified, the helper will insert the start and end of the range
+  after `start_arg`.
+
+- `opts` (table?): a table containing the following options:
+  - `opts.use_rows` (boolean?): specifies whether to use rows over character
+    offsets.
+  - `opts.row_offset` (number?): offset applied to row numbers.
+  - `opts.col_offset` (number?): offset applied to column numbers.
+  - `opts.delimiter` (string?): used to join range start and end into a single
+    argument.
 
 ## diagnostics
 

--- a/lua/null-ls/builtins/formatting/autopep8.lua
+++ b/lua/null-ls/builtins/formatting/autopep8.lua
@@ -4,29 +4,15 @@ local methods = require("null-ls.methods")
 local FORMATTING = methods.internal.FORMATTING
 local RANGE_FORMATTING = methods.internal.RANGE_FORMATTING
 
-local function range_formatting_args_factory(base_args, start_arg)
-    return function(params)
-        local args = vim.deepcopy(base_args)
-        if params.method == FORMATTING then
-            return args
-        end
-
-        local range = params.range
-        table.insert(args, start_arg)
-        table.insert(args, range.row)
-        table.insert(args, range.end_row)
-        return args
-    end
-end
 return h.make_builtin({
     name = "autopep8",
     method = { FORMATTING, RANGE_FORMATTING },
     filetypes = { "python" },
     generator_opts = {
         command = "autopep8",
-        args = range_formatting_args_factory({
+        args = h.range_formatting_args_factory({
             "-",
-        }, "--line-range"),
+        }, "--line-range", nil, { use_rows = true }),
         to_stdin = true,
     },
     factory = h.formatter_factory,

--- a/lua/null-ls/builtins/formatting/format_r.lua
+++ b/lua/null-ls/builtins/formatting/format_r.lua
@@ -15,7 +15,7 @@ return h.make_builtin({
             "--no-save",
             "-e",
             'formatR::tidy_source(source="stdin")',
-        }),
+        }, "--range-start", "--range-end", { row_offset = -1, col_offset = -1 }),
         to_stdin = true,
     },
     factory = h.formatter_factory,

--- a/lua/null-ls/builtins/formatting/prettier.lua
+++ b/lua/null-ls/builtins/formatting/prettier.lua
@@ -27,7 +27,10 @@ return h.make_builtin({
     },
     generator_opts = {
         command = "prettier",
-        args = h.range_formatting_args_factory({ "--stdin-filepath", "$FILENAME" }),
+        args = h.range_formatting_args_factory({
+            "--stdin-filepath",
+            "$FILENAME",
+        }, "--range-start", "--range-end", { row_offset = -1, col_offset = -1 }),
         to_stdin = true,
         dynamic_command = cmd_resolver.from_node_modules,
     },

--- a/lua/null-ls/builtins/formatting/prettier_d_slim.lua
+++ b/lua/null-ls/builtins/formatting/prettier_d_slim.lua
@@ -27,7 +27,12 @@ return h.make_builtin({
     },
     generator_opts = {
         command = "prettier_d_slim",
-        args = h.range_formatting_args_factory({ "--stdin", "--stdin-filepath", "$FILENAME" }),
+        args = h.range_formatting_args_factory(
+            { "--stdin", "--stdin-filepath", "$FILENAME" },
+            "--range-start",
+            "--range-end",
+            { row_offset = -1, col_offset = -1 }
+        ),
         to_stdin = true,
         dynamic_command = cmd_resolver.from_node_modules,
     },

--- a/lua/null-ls/builtins/formatting/stylua.lua
+++ b/lua/null-ls/builtins/formatting/stylua.lua
@@ -15,7 +15,7 @@ return h.make_builtin({
             "--stdin-filepath",
             "$FILENAME",
             "-",
-        }),
+        }, "--range-start", "--range-end", { row_offset = -1, col_offset = -1 }),
         to_stdin = true,
     },
     factory = h.formatter_factory,

--- a/lua/null-ls/builtins/formatting/yapf.lua
+++ b/lua/null-ls/builtins/formatting/yapf.lua
@@ -4,34 +4,15 @@ local methods = require("null-ls.methods")
 local FORMATTING = methods.internal.FORMATTING
 local RANGE_FORMATTING = methods.internal.RANGE_FORMATTING
 
-local function range_formatting_args_factory(base_args, start_arg)
-    vim.validate({
-        base_args = { base_args, "table" },
-        start_arg = { start_arg, "string" },
-    })
-
-    return function(params)
-        local args = vim.deepcopy(base_args)
-        if params.method == FORMATTING then
-            return args
-        end
-
-        local range = params.range
-        table.insert(args, start_arg)
-        table.insert(args, range.row .. "-" .. range.end_row) -- range of lines to reformat, one-based
-        return args
-    end
-end
-
 return h.make_builtin({
     name = "yapf",
     method = { FORMATTING, RANGE_FORMATTING },
     filetypes = { "python" },
     generator_opts = {
         command = "yapf",
-        args = range_formatting_args_factory({
+        args = h.range_formatting_args_factory({
             "--quiet",
-        }, "--lines"),
+        }, "--lines", nil, { use_rows = true, delimiter = "-" }),
         to_stdin = true,
     },
     factory = h.formatter_factory,

--- a/lua/null-ls/utils.lua
+++ b/lua/null-ls/utils.lua
@@ -92,12 +92,14 @@ M.is_executable = function(cmd)
     return false, string.format("command %s is not executable (make sure it's installed and on your $PATH)", cmd)
 end
 
+---@alias NullLsRange table<"'row'"|"'col'"|"'end_row'"|"'end_col'", number>
+---@alias LspRange table<"'start'"|"'end'", table<"'line'"|"'character'", number>>
 -- lsp-compatible range is 0-indexed
 -- lua-friendly range is 1-indexed
 M.range = {
     -- transforms lua-friendly range to a lsp-compatible shape
-    ---@param range table<"'row'"|"'col'"|"'end_row'"|"'end_col'", number>
-    ---@return table<"'start'"|"'end'", table<"'line'"|"'character'", number>>
+    ---@param range NullLsRange
+    ---@return LspRange
     to_lsp = function(range)
         local lsp_range = {
             ["start"] = {
@@ -112,8 +114,8 @@ M.range = {
         return lsp_range
     end,
     -- transforms lsp range to a lua-friendly shape
-    ---@param lsp_range table<"'start'"|"'end'", table<"'line'"|"'character'", number>>
-    ---@return table<"'row'"|"'col'"|"'end_row'"|"'end_col'", number>
+    ---@param lsp_range LspRange
+    ---@return NullLsRange
     from_lsp = function(lsp_range)
         local start_range = lsp_range["start"]
         local end_range = lsp_range["end"]
@@ -127,7 +129,7 @@ M.range = {
     end,
 }
 
----@class Params
+---@class NullLsParams
 ---@field client_id number null-ls client id
 ---@field lsp_method string|nil
 ---@field options table|nil table of options from lsp params
@@ -138,12 +140,12 @@ M.range = {
 ---@field col number current column number
 ---@field bufname string
 ---@field ft string
----@field range table|nil converted LSP range
+---@field range NullLsRange|nil converted LSP range
 ---@field word_to_complete string|nil
 
 ---@param original_params table original LSP params
 ---@param method string internal null-ls method
----@return Params
+---@return NullLsParams
 M.make_params = function(original_params, method)
     local bufnr = resolve_bufnr(original_params)
     local content = resolve_content(original_params, bufnr)

--- a/test/spec/helpers/range_formatting_args_factory_spec.lua
+++ b/test/spec/helpers/range_formatting_args_factory_spec.lua
@@ -1,0 +1,152 @@
+local stub = require("luassert.stub")
+local methods = require("null-ls.methods")
+
+describe("range_formatting_args_factory", function()
+    local factory = require("null-ls.helpers").range_formatting_args_factory
+    local base_args = { "--quiet" }
+    local start_arg = "--range-start"
+    local end_arg = "--range-end"
+
+    local mock_bufnr = 15
+    local mock_range = { row = 1, col = 1, end_row = 5, end_col = 5 }
+    local get_offset = stub(vim.api, "nvim_buf_get_offset")
+    local mock_offset = 100
+    before_each(function()
+        get_offset.returns(mock_offset)
+    end)
+    after_each(function()
+        get_offset:clear()
+    end)
+
+    it("should return base args when method is FORMATTING", function()
+        local args_fn = factory(base_args, start_arg, end_arg)
+
+        local resolved_args = args_fn({ method = methods.internal.FORMATTING })
+
+        assert.same(resolved_args, base_args)
+    end)
+
+    it("should extend args when method is RANGE_FORMATTING", function()
+        local args_fn = factory(base_args, start_arg, end_arg)
+
+        local resolved_args = args_fn({
+            method = methods.internal.RANGE_FORMATTING,
+            range = mock_range,
+            bufnr = mock_bufnr,
+        })
+
+        assert.stub(get_offset).was_called_with(mock_bufnr, mock_range.row)
+        assert.same(
+            resolved_args,
+            vim.list_extend(base_args, {
+                start_arg,
+                mock_offset + mock_range.col,
+                end_arg,
+                mock_offset + mock_range.end_col,
+            })
+        )
+    end)
+
+    it("should skip end arg when not specified", function()
+        local args_fn = factory(base_args, start_arg, nil)
+
+        local resolved_args = args_fn({
+            method = methods.internal.RANGE_FORMATTING,
+            range = mock_range,
+            bufnr = mock_bufnr,
+        })
+
+        assert.stub(get_offset).was_called_with(mock_bufnr, mock_range.row)
+        assert.same(
+            resolved_args,
+            vim.list_extend(base_args, {
+                start_arg,
+                mock_offset + mock_range.col,
+                mock_offset + mock_range.end_col,
+            })
+        )
+    end)
+
+    it("should apply row offset", function()
+        local opts = { row_offset = 10 }
+        local args_fn = factory(base_args, start_arg, end_arg, opts)
+
+        local resolved_args = args_fn({
+            method = methods.internal.RANGE_FORMATTING,
+            range = mock_range,
+            bufnr = mock_bufnr,
+        })
+
+        assert.stub(get_offset).was_called_with(mock_bufnr, mock_range.row + opts.row_offset)
+        assert.same(
+            resolved_args,
+            vim.list_extend(base_args, {
+                start_arg,
+                mock_offset + mock_range.col,
+                end_arg,
+                mock_offset + mock_range.end_col,
+            })
+        )
+    end)
+
+    it("should apply col offset", function()
+        local opts = { col_offset = 10 }
+        local args_fn = factory(base_args, start_arg, end_arg, opts)
+
+        local resolved_args = args_fn({
+            method = methods.internal.RANGE_FORMATTING,
+            range = mock_range,
+            bufnr = mock_bufnr,
+        })
+
+        assert.same(
+            resolved_args,
+            vim.list_extend(base_args, {
+                start_arg,
+                mock_offset + mock_range.col + opts.col_offset,
+                end_arg,
+                mock_offset + mock_range.end_col + opts.col_offset,
+            })
+        )
+    end)
+
+    it("should use rows", function()
+        local opts = { use_rows = true }
+        local args_fn = factory(base_args, start_arg, end_arg, opts)
+
+        local resolved_args = args_fn({
+            method = methods.internal.RANGE_FORMATTING,
+            range = mock_range,
+            bufnr = mock_bufnr,
+        })
+
+        assert.same(
+            resolved_args,
+            vim.list_extend(base_args, {
+                start_arg,
+                mock_range.row,
+                end_arg,
+                mock_range.end_row,
+            })
+        )
+    end)
+
+    it("should join range with delimiter", function()
+        local opts = { delimiter = "-" }
+        local args_fn = factory(base_args, start_arg, nil, opts)
+
+        local resolved_args = args_fn({
+            method = methods.internal.RANGE_FORMATTING,
+            range = mock_range,
+            bufnr = mock_bufnr,
+        })
+
+        assert.same(
+            resolved_args,
+            vim.list_extend(base_args, {
+                start_arg,
+                mock_offset + mock_range.col .. opts.delimiter .. mock_offset + mock_range.end_col,
+            })
+        )
+    end)
+end)


### PR DESCRIPTION
The current implementation of `range_formatting_args_factory` is too narrow, since it assumes that formatters always want separate arguments to define the start and end of the range and that they always use character offsets. This has led contributors to write their own versions to handle common cases like passing line numbers instead of offsets. This is fine but defeats the purpose of having the helper in the first place.

The PR should be fairly self-documenting, but the overall goal here was for the helper to handle the cases currently in the codebase and (hopefully) be flexible enough to handle future cases we haven't yet encountered. I also added test coverage and improved type annotations in a few places.

I tested the current built-ins and confirmed that they're all working (`yapf` behaves strangely, but that's consistent with the previous behavior / running the formatter directly from the CLI). 