### PR TITLE
feat: add root_markers to help detect config files

### DIFF
--- a/lua/null-ls/builtins/diagnostics/flake8.lua
+++ b/lua/null-ls/builtins/diagnostics/flake8.lua
@@ -1,5 +1,6 @@
 local h = require("null-ls.helpers")
 local methods = require("null-ls.methods")
+local root_resolver = require("null-ls.helpers.root_resolver")
 
 local DIAGNOSTICS = methods.internal.DIAGNOSTICS
 
@@ -62,6 +63,7 @@ return h.make_builtin({
         to_stdin = true,
         from_stderr = true,
         args = { "--format", "default", "--stdin-display-name", "$FILENAME", "-" },
+        cwd = root_resolver.from_python_markers,
         format = "line",
         check_exit_code = function(code)
             return code == 0 or code == 255

--- a/lua/null-ls/builtins/diagnostics/mypy.lua
+++ b/lua/null-ls/builtins/diagnostics/mypy.lua
@@ -1,5 +1,6 @@
 local h = require("null-ls.helpers")
 local methods = require("null-ls.methods")
+local root_resolver = require("null-ls.helpers.root_resolver")
 
 local DIAGNOSTICS = methods.internal.DIAGNOSTICS
 
@@ -29,6 +30,7 @@ benefits of dynamic (or "duck") typing and static typing.]],
                 params.bufname,
             }
         end,
+        cwd = root_resolver.from_python_markers,
         to_temp_file = true,
         format = "line",
         check_exit_code = function(code)

--- a/lua/null-ls/builtins/diagnostics/pydocstyle.lua
+++ b/lua/null-ls/builtins/diagnostics/pydocstyle.lua
@@ -1,5 +1,6 @@
 local h = require("null-ls.helpers")
 local methods = require("null-ls.methods")
+local root_resolver = require("null-ls.helpers.root_resolver")
 
 local DIAGNOSTICS = methods.internal.DIAGNOSTICS
 
@@ -18,6 +19,7 @@ return h.make_builtin({
         command = "pydocstyle",
         name = "pydocstyle",
         args = { "$FILENAME" },
+        cwd = root_resolver.from_python_markers,
         to_stdin = false,
         to_temp_file = true,
         format = "raw",

--- a/lua/null-ls/builtins/diagnostics/pylama.lua
+++ b/lua/null-ls/builtins/diagnostics/pylama.lua
@@ -1,5 +1,6 @@
 local h = require("null-ls.helpers")
 local methods = require("null-ls.methods")
+local root_resolver = require("null-ls.helpers.root_resolver")
 
 return h.make_builtin({
     name = "pylama",
@@ -16,6 +17,7 @@ return h.make_builtin({
         from_stderr = false,
         ignore_stderr = true,
         args = { "--from-stdin", "$FILENAME", "-f", "json" },
+        cwd = root_resolver.from_python_markers,
         format = "json_raw",
         check_exit_code = function(code)
             return code <= 1

--- a/lua/null-ls/builtins/diagnostics/pylint.lua
+++ b/lua/null-ls/builtins/diagnostics/pylint.lua
@@ -1,5 +1,6 @@
 local h = require("null-ls.helpers")
 local methods = require("null-ls.methods")
+local root_resolver = require("null-ls.helpers.root_resolver")
 
 local DIAGNOSTICS = methods.internal.DIAGNOSTICS
 
@@ -15,6 +16,7 @@ return h.make_builtin({
         command = "pylint",
         to_stdin = true,
         args = { "--from-stdin", "$FILENAME", "-f", "json" },
+        cwd = root_resolver.from_python_markers,
         format = "json",
         check_exit_code = function(code)
             return code ~= 32

--- a/lua/null-ls/builtins/diagnostics/vulture.lua
+++ b/lua/null-ls/builtins/diagnostics/vulture.lua
@@ -1,5 +1,6 @@
 local h = require("null-ls.helpers")
 local methods = require("null-ls.methods")
+local root_resolver = require("null-ls.helpers.root_resolver")
 
 local DIAGNOSTICS = methods.internal.DIAGNOSTICS
 
@@ -14,6 +15,7 @@ return h.make_builtin({
     generator_opts = {
         command = "vulture",
         args = { "$FILENAME" },
+        cwd = root_resolver.from_python_markers,
         to_temp_file = true,
         from_stderr = true,
         format = "line",

--- a/lua/null-ls/builtins/formatting/autopep8.lua
+++ b/lua/null-ls/builtins/formatting/autopep8.lua
@@ -1,5 +1,6 @@
 local h = require("null-ls.helpers")
 local methods = require("null-ls.methods")
+local root_resolver = require("null-ls.helpers.root_resolver")
 
 local FORMATTING = methods.internal.FORMATTING
 local RANGE_FORMATTING = methods.internal.RANGE_FORMATTING
@@ -17,6 +18,7 @@ return h.make_builtin({
         args = h.range_formatting_args_factory({
             "-",
         }, "--line-range", nil, { use_rows = true }),
+        cwd = root_resolver.from_python_markers,
         to_stdin = true,
     },
     factory = h.formatter_factory,

--- a/lua/null-ls/builtins/formatting/black.lua
+++ b/lua/null-ls/builtins/formatting/black.lua
@@ -1,5 +1,6 @@
 local h = require("null-ls.helpers")
 local methods = require("null-ls.methods")
+local root_resolver = require("null-ls.helpers.root_resolver")
 
 local FORMATTING = methods.internal.FORMATTING
 
@@ -19,6 +20,7 @@ return h.make_builtin({
             "--quiet",
             "-",
         },
+        cwd = root_resolver.from_python_markers,
         to_stdin = true,
     },
     factory = h.formatter_factory,

--- a/lua/null-ls/builtins/formatting/isort.lua
+++ b/lua/null-ls/builtins/formatting/isort.lua
@@ -1,5 +1,6 @@
 local h = require("null-ls.helpers")
 local methods = require("null-ls.methods")
+local root_resolver = require("null-ls.helpers.root_resolver")
 
 local FORMATTING = methods.internal.FORMATTING
 
@@ -19,6 +20,7 @@ return h.make_builtin({
             "$FILENAME",
             "-",
         },
+        cwd = root_resolver.from_python_markers,
         to_stdin = true,
     },
     factory = h.formatter_factory,

--- a/lua/null-ls/builtins/formatting/reorder_python_imports.lua
+++ b/lua/null-ls/builtins/formatting/reorder_python_imports.lua
@@ -1,5 +1,6 @@
 local h = require("null-ls.helpers")
 local methods = require("null-ls.methods")
+local root_resolver = require("null-ls.helpers.root_resolver")
 
 local FORMATTING = methods.internal.FORMATTING
 
@@ -14,6 +15,7 @@ return h.make_builtin({
     generator_opts = {
         command = "reorder-python-imports",
         args = { "-", "--exit-zero-even-if-changed" },
+        cwd = root_resolver.from_python_markers,
         to_stdin = true,
     },
     factory = h.formatter_factory,

--- a/lua/null-ls/builtins/formatting/yapf.lua
+++ b/lua/null-ls/builtins/formatting/yapf.lua
@@ -1,5 +1,6 @@
 local h = require("null-ls.helpers")
 local methods = require("null-ls.methods")
+local root_resolver = require("null-ls.helpers.root_resolver")
 
 local FORMATTING = methods.internal.FORMATTING
 local RANGE_FORMATTING = methods.internal.RANGE_FORMATTING
@@ -17,6 +18,7 @@ return h.make_builtin({
         args = h.range_formatting_args_factory({
             "--quiet",
         }, "--lines", nil, { use_rows = true, delimiter = "-" }),
+        cwd = root_resolver.from_python_markers,
         to_stdin = true,
     },
     factory = h.formatter_factory,

--- a/lua/null-ls/helpers/root_resolver.lua
+++ b/lua/null-ls/helpers/root_resolver.lua
@@ -26,7 +26,7 @@ M.from_python_markers = function(params)
     if cwd and cwd ~= "" then
         log:debug(fmt("Resolved python project path: [%s]", cwd))
     else
-        log:debug("Unable to resolved python project path")
+        log:debug("Unable to resolve python project path")
     end
     return cwd
 end
@@ -34,7 +34,11 @@ end
 M.from_node_markers = function(params)
     local cwd = u.root_pattern(M.root_markers.node)(params.bufname)
     log:trace(fmt("Using node markers: [%s]", M.root_markers.node))
-    log:debug(fmt("Resolved node project path: [%s]", cwd or ""))
+    if cwd and cwd ~= "" then
+        log:debug(fmt("Resolved node project path: [%s]", cwd))
+    else
+        log:debug("Unable to resolve node project path")
+    end
     return cwd
 end
 

--- a/lua/null-ls/helpers/root_resolver.lua
+++ b/lua/null-ls/helpers/root_resolver.lua
@@ -1,0 +1,41 @@
+local log = require("null-ls.logger")
+local u = require("null-ls.utils")
+local fmt = string.format
+
+local M = {}
+
+M.root_markers = {
+    python = {
+        "pyproject.toml",
+        "setup.cfg",
+        "tox.ini",
+        ".flake8",
+    },
+    node = {
+        ".eslintrc*",
+        "package.json",
+        "tsconfig.json",
+        "jsconfig.json",
+        ".prettierrc*",
+    },
+}
+
+M.from_python_markers = function(params)
+    local cwd = u.root_pattern(M.root_markers.python)(params.bufname)
+    log:trace(fmt("Using python markers: [%s]", M.root_markers.python))
+    if cwd and cwd ~= "" then
+        log:debug(fmt("Resolved python project path: [%s]", cwd))
+    else
+        log:debug("Unable to resolved python project path")
+    end
+    return cwd
+end
+
+M.from_node_markers = function(params)
+    local cwd = u.root_pattern(M.root_markers.node)(params.bufname)
+    log:trace(fmt("Using node markers: [%s]", M.root_markers.node))
+    log:debug(fmt("Resolved node project path: [%s]", cwd or ""))
+    return cwd
+end
+
+return M


### PR DESCRIPTION
# Description

Add `root_resolver.lua` to help with set `cwd` from _root-markers_. This helps with detecting common configuration files, e.g. `pyproject.toml`.
Additionally, this should be easily configurable since `root_markers.FOO` is global, and `cwd` is still overridable as well.

Fixes #538, #722
