### PR TITLE
fix(builtins): Add `-xml` parameter for XML files

### DIFF
--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -1267,7 +1267,7 @@ local sources = { null_ls.builtins.diagnostics.tidy }
 - Filetypes: `{ "html", "xml" }`
 - Method: `diagnostics`
 - Command: `tidy`
-- Args: `{ "--gnu-emacs", "yes", "-quiet", "-errors", "$FILENAME" }`
+- Args: dynamically resolved (see [source](https://github.com/jose-elias-alvarez/null-ls.nvim/blob/main/lua/null-ls/builtins/diagnostics/tidy.lua))
 
 ### trail_space
 

--- a/lua/null-ls/builtins/diagnostics/tidy.lua
+++ b/lua/null-ls/builtins/diagnostics/tidy.lua
@@ -19,13 +19,21 @@ return h.make_builtin({
     filetypes = { "html", "xml" },
     generator_opts = {
         command = "tidy",
-        args = {
-            "--gnu-emacs",
-            "yes",
-            "-quiet",
-            "-errors",
-            "$FILENAME",
-        },
+        args = function(params)
+            local common_args = {
+                "--gnu-emacs",
+                "yes",
+                "-quiet",
+                "-errors",
+                "$FILENAME",
+            }
+
+            if params.ft == "xml" then
+                table.insert(common_args, 1, "-xml")
+            end
+
+            return common_args
+        end,
         to_stdin = true,
         from_stderr = true,
         format = "line",


### PR DESCRIPTION
Ensures that tidy diagnostics appropriate to XML files are shown, rather than HTML files.

Should close issue https://github.com/jose-elias-alvarez/null-ls.nvim/issues/754.