### PR TITLE
fix(builtins): alex adds required factory entry

### DIFF
--- a/lua/null-ls/builtins/diagnostics/alex.lua
+++ b/lua/null-ls/builtins/diagnostics/alex.lua
@@ -27,4 +27,5 @@ return h.make_builtin({
             },
         }),
     },
+    factory = h.generator_factory,
 })


### PR DESCRIPTION
Ensures the builtins alex working. Otherwise neovim will print message
```
Error detected while processing /home/nkcfan/.config/nvim/init.vim:
line  106:
E5108: Error executing lua ...e/nkcfan/.vim/bundle/null-ls.nvim/lua/null-ls/sources.lua:208: fn: expected function, got nil
stack traceback:
        [C]: in function 'error'
        vim/shared.lua:608: in function 'validate'
        ...e/nkcfan/.vim/bundle/null-ls.nvim/lua/null-ls/sources.lua:208: in function 'validate_and_transform'
        ...e/nkcfan/.vim/bundle/null-ls.nvim/lua/null-ls/sources.lua:36: in function 'register_source'
        ...e/nkcfan/.vim/bundle/null-ls.nvim/lua/null-ls/sources.lua:279: in function 'register'
        /home/nkcfan/.vim/bundle/null-ls.nvim/lua/null-ls/config.lua:103: in function 'setup'
        /home/nkcfan/.vim/bundle/null-ls.nvim/lua/null-ls/init.lua:31: in function 'setup'
        /home/nkcfan/.config/nvim/lua/null_ls_config.lua:15: in main chunk
        [C]: in function 'require'
        [string ":lua"]:1: in main chunk
```