### PR TITLE
Add ruleId to eslint adapter

### DIFF
--- a/lua/null-ls/builtins/diagnostics/eslint.lua
+++ b/lua/null-ls/builtins/diagnostics/eslint.lua
@@ -15,7 +15,6 @@ local add_rule_id_to_messages = function(messages)
 end
 
 local handle_eslint_output = function(params)
-    print(vim.inspect(params))
     params.messages = params.output and params.output[1] and params.output[1].messages or {}
     if params.err then
         table.insert(params.messages, { message = params.err })

--- a/lua/null-ls/builtins/diagnostics/eslint.lua
+++ b/lua/null-ls/builtins/diagnostics/eslint.lua
@@ -4,7 +4,18 @@ local methods = require("null-ls.methods")
 
 local DIAGNOSTICS = methods.internal.DIAGNOSTICS
 
+local add_rule_id_to_messages = function(messages)
+  if not messages then
+    return
+  end
+
+  for _, message in ipairs(messages) do
+    message.message = message.message .. " [" .. message.ruleId .. "]"
+  end
+end
+
 local handle_eslint_output = function(params)
+    print(vim.inspect(params))
     params.messages = params.output and params.output[1] and params.output[1].messages or {}
     if params.err then
         table.insert(params.messages, { message = params.err })
@@ -13,12 +24,15 @@ local handle_eslint_output = function(params)
     local parser = h.diagnostics.from_json({
         attributes = {
             severity = "severity",
+            message = "message"
         },
         severities = {
             h.diagnostics.severities["warning"],
             h.diagnostics.severities["error"],
         },
     })
+
+    add_rule_id_to_messages(params.messages)
 
     return parser({ output = params.messages })
 end

--- a/lua/null-ls/builtins/diagnostics/eslint.lua
+++ b/lua/null-ls/builtins/diagnostics/eslint.lua
@@ -24,7 +24,6 @@ local handle_eslint_output = function(params)
     local parser = h.diagnostics.from_json({
         attributes = {
             severity = "severity",
-            message = "message"
         },
         severities = {
             h.diagnostics.severities["warning"],

--- a/lua/null-ls/builtins/diagnostics/eslint.lua
+++ b/lua/null-ls/builtins/diagnostics/eslint.lua
@@ -10,7 +10,9 @@ local add_rule_id_to_messages = function(messages)
   end
 
   for _, message in ipairs(messages) do
-    message.message = message.message .. " [" .. message.ruleId .. "]"
+    if message.ruleId then
+      message.message = message.message .. " [" .. message.ruleId .. "]"
+    end
   end
 end
 


### PR DESCRIPTION
Without the ruleid in the diagnostic, this plugin is quite hard to use with eslint...