### PR TITLE
fix(diagnostics): Compatibility with older versions of PHPMD work

### DIFF
--- a/lua/null-ls/builtins/diagnostics/phpmd.lua
+++ b/lua/null-ls/builtins/diagnostics/phpmd.lua
@@ -11,18 +11,11 @@ return h.make_builtin({
     filetypes = { "php" },
     generator_opts = {
         command = "phpmd",
-        args = {
-            "--ignore-violations-on-exit",
-            "--ignore-errors-on-exit",
-            "-", -- process stdin
-            "json",
-            -- 'phpmd.xml',
-        },
+        args = { "$FILENAME", "json" },
         format = "json",
-        to_stdin = true,
-        from_stderr = false,
+        to_temp_file = true,
         check_exit_code = function(code)
-            return code <= 1
+            return code <= 2
         end,
         on_output = function(params)
             local parser = h.diagnostics.from_json({
@@ -37,6 +30,7 @@ return h.make_builtin({
                     h.diagnostics.severities["error"],
                     h.diagnostics.severities["warning"],
                     h.diagnostics.severities["information"],
+                    h.diagnostics.severities["hint"],
                     h.diagnostics.severities["hint"],
                 },
             })

--- a/lua/null-ls/builtins/diagnostics/phpmd.lua
+++ b/lua/null-ls/builtins/diagnostics/phpmd.lua
@@ -27,11 +27,11 @@ return h.make_builtin({
                     code = "rule",
                 },
                 severities = {
-                    h.diagnostics.severities["error"],
-                    h.diagnostics.severities["warning"],
-                    h.diagnostics.severities["information"],
-                    h.diagnostics.severities["hint"],
-                    h.diagnostics.severities["hint"],
+                    [1] = h.diagnostics.severities["error"],
+                    [2] = h.diagnostics.severities["warning"],
+                    [3] = h.diagnostics.severities["information"],
+                    [4] = h.diagnostics.severities["hint"],
+                    [5] = h.diagnostics.severities["hint"],
                 },
             })
             params.violations = params.output

--- a/lua/null-ls/builtins/diagnostics/phpmd.lua
+++ b/lua/null-ls/builtins/diagnostics/phpmd.lua
@@ -15,7 +15,7 @@ return h.make_builtin({
         format = "json",
         to_temp_file = true,
         check_exit_code = function(code)
-            return code <= 2
+            return code <= 3
         end,
         on_output = function(params)
             local parser = h.diagnostics.from_json({

--- a/lua/null-ls/builtins/diagnostics/twigcs.lua
+++ b/lua/null-ls/builtins/diagnostics/twigcs.lua
@@ -11,7 +11,7 @@ return h.make_builtin({
     filetypes = { "twig" },
     generator_opts = {
         command = "twigcs",
-        args = { "--reporter", "json", "$FILENAME", },
+        args = { "--reporter", "json", "$FILENAME" },
         format = "json",
         to_temp_file = true,
         check_exit_code = function(code)

--- a/lua/null-ls/builtins/diagnostics/twigcs.lua
+++ b/lua/null-ls/builtins/diagnostics/twigcs.lua
@@ -1,0 +1,45 @@
+local null_ls = require("null-ls")
+local h = require("null-ls.helpers")
+
+return h.make_builtin({
+    name = "twigcs",
+    meta = {
+        url = "https://github.com/friendsoftwig/twigcs",
+        description = "Runs Twigcs against Twig files.",
+    },
+    method = null_ls.methods.DIAGNOSTICS,
+    filetypes = { "twig" },
+    generator_opts = {
+        command = "twigcs",
+        args = { "--reporter", "json", "$FILENAME", },
+        format = "json",
+        to_temp_file = true,
+        check_exit_code = function(code)
+            return code <= 1
+        end,
+        on_output = function(params)
+            local parser = h.diagnostics.from_json({
+                attributes = {
+                    row = "line",
+                    col = "column",
+                    severity = "severity",
+                },
+                severities = {
+                    h.diagnostics.severities["information"],
+                    h.diagnostics.severities["warning"],
+                    h.diagnostics.severities["error"],
+                    h.diagnostics.severities["hint"],
+                },
+            })
+            params.violations = params.output
+                    and params.output.files
+                    and params.output.files[1]
+                    and params.output.files[1].violations
+                or {}
+
+            return parser({ output = params.violations })
+        end,
+    },
+
+    factory = h.generator_factory,
+})


### PR DESCRIPTION
Due to [a bug](https://github.com/phpmd/phpmd/issues/941) in PHPMD, STDIN doesn't work on the current version unless you explicitly update its dependency, PDepend. (see https://github.com/pdepend/pdepend/pull/593).

This update to the builtin makes it use a temp file instead, meaning it will work with PHPMD without requiring the PDepend fix.

I have also removed the `--ignore-errors-on-exit` argument, because it isn't supported on older versions of PHPMD and we can instead handle non-zero exit codes in `check_exit_code` .