### PR TITLE
feat: adding solhint diagnostic support for solidity files

### DIFF
--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -1133,6 +1133,23 @@ local sources = { null_ls.builtins.diagnostics.shellcheck }
 - Command: `shellcheck`
 - Args: `{ "--format", "json1", "--source-path=$DIRNAME", "--external-sources", "-" }`
 
+### [solhint](https://protofire.github.io/solhint/)
+
+Solidity linter providing security and style guide validations.
+
+#### Usage
+
+```lua
+local sources = { null_ls.builtins.diagnostics.solhint }
+```
+
+#### Defaults
+
+- Filetypes: `{ "solidity" }`
+- Method: `diagnostics`
+- Command: `solhint`
+- Args: `{ "$FILENAME", "--formatter", "unix" }`
+
 ### [standardjs](https://standardjs.com/)
 
 JavaScript style guide, linter, and formatter.

--- a/lua/null-ls/builtins/diagnostics/solhint.lua
+++ b/lua/null-ls/builtins/diagnostics/solhint.lua
@@ -18,8 +18,8 @@ return h.make_builtin({
         },
         command = "solhint",
         format = "line",
-        from_stderr = false,
-        on_output = h.diagnostics.from_pattern("([^:]+):([%d]+):([%d]+): (.*) %[([%a]+)/([^]]+)%]", {
+        from_stderr = true,
+        on_output = h.diagnostics.from_pattern("([^:]*):([%d]+):([%d]+): (.*) %[([%a]+)/([%a%p]+)%]", {
             "filename",
             "row",
             "col",
@@ -28,8 +28,10 @@ return h.make_builtin({
             "code",
         }, {
             severities = {
+                ["Error"] = h.diagnostics.severities.error,
                 ["Warning"] = h.diagnostics.severities.warning,
             },
         }),
+        to_stdin = true,
     },
 })

--- a/lua/null-ls/builtins/diagnostics/solhint.lua
+++ b/lua/null-ls/builtins/diagnostics/solhint.lua
@@ -1,0 +1,35 @@
+local h = require("null-ls.helpers")
+local DIAGNOSTICS = require("null-ls.methods").internal.DIAGNOSTICS
+
+return h.make_builtin({
+    name = "solhint",
+    meta = {
+        url = "https://protofire.github.io/solhint/",
+        description = "An open source project for linting Solidity code. It provides both security and style guide validations.",
+    },
+    method = DIAGNOSTICS,
+    filetypes = { "solidity" },
+    factory = h.generator_factory,
+    generator_opts = {
+        args = {
+            "$FILENAME",
+            "--formatter",
+            "unix",
+        },
+        command = "solhint",
+        format = "line",
+        from_stderr = false,
+        on_output = h.diagnostics.from_pattern("([^:]+):([%d]+):([%d]+): (.*) %[([%a]+)/([^]]+)%]", {
+            "filename",
+            "row",
+            "col",
+            "message",
+            "severity",
+            "code",
+        }, {
+            severities = {
+                ["Warning"] = h.diagnostics.severities.warning,
+            },
+        }),
+    },
+})

--- a/test/spec/builtins/diagnostics_spec.lua
+++ b/test/spec/builtins/diagnostics_spec.lua
@@ -458,6 +458,43 @@ describe("diagnostics", function()
         end)
     end)
 
+    describe("solhint", function()
+        local linter = diagnostics.solhint
+        local parser = linter._opts.on_output
+
+        it("should create a diagnostic with an Error severity", function()
+            local file = {
+                [[ import 'interfaces/IToken.sol'; ]],
+            }
+            local output = "contracts/Token.sol:22:8: Use double quotes for string literals [Error/quotes]"
+            local diagnostic = parser(output, { content = file })
+            assert.same({
+                code = "quotes",
+                col = "8",
+                filename = "contracts/Token.sol",
+                message = "Use double quotes for string literals",
+                row = "22",
+                severity = 1,
+            }, diagnostic)
+        end)
+
+        it("should create a diagnostic with a Warning severity", function()
+            local file = {
+                [[ function somethingPrivate(uint8 id) returns (bool) {}; ]],
+            }
+            local output = "contracts/Token.sol:359:5: Explicitly mark visibility in function [Warning/func-visibility]"
+            local diagnostic = parser(output, { content = file })
+            assert.same({
+                code = "func-visibility",
+                col = "5",
+                filename = "contracts/Token.sol",
+                message = "Explicitly mark visibility in function",
+                row = "359",
+                severity = 2,
+            }, diagnostic)
+        end)
+    end)
+
     describe("eslint", function()
         local linter = diagnostics.eslint
         local parser = linter._opts.on_output


### PR DESCRIPTION
Closes #171.

Adding support for linting [Solidity](https://soliditylang.org/) files using [solhint](https://protofire.github.io/solhint/).

Changes include:

- solhint diagnostic builtin
- solhint documentation in BUILTINS.md
- solhint diagnostic tests

Tested with `solhint v3.3.7` on `Pop!_OS 21.10 x86_64` and `nvim v0.6.1`. Screenshot below showing an example of null-ls output with solhint via [trouble](https://github.com/folke/trouble.nvim).

![Screenshot from 2022-03-19 12-12-54](https://user-images.githubusercontent.com/57511/159135247-767c3119-da93-4f4a-b9a7-d65ae5b025b3.png)
