### PR TITLE
feat: Add sqlfluff as sql format and diag source

### DIFF
--- a/lua/null-ls/builtins/diagnostics/sqlfluff.lua
+++ b/lua/null-ls/builtins/diagnostics/sqlfluff.lua
@@ -1,0 +1,45 @@
+local null_ls = require("null-ls")
+local helpers = require("null-ls.helpers")
+
+return helpers.make_builtin({
+    name = "sqlfluff",
+    meta = {
+        url = "https://github.com/sqlfluff/sqlfluff",
+        description = "A SQL linter and auto-formatter for Humans",
+    },
+    method = null_ls.methods.DIAGNOSTICS,
+    filetypes = { "sql" },
+    generator_opts = {
+        command = "sqlfluff",
+        args = {
+            "lint",
+            "-f",
+            "github-annotation",
+            "-n",
+            "--disable_progress_bar",
+            "-",
+        },
+        from_stderr = true,
+        to_stdin = true,
+        format = "json",
+        check_exit_code = function(c)
+            return c <= 1
+        end,
+        on_output = helpers.diagnostics.from_json({
+            attributes = {
+                row = "line",
+                col = "start_column",
+                end_col = "end_column",
+                severity = "annotation_level",
+                message = "message",
+            },
+            severities = {
+                helpers.diagnostics.severities["information"],
+                helpers.diagnostics.severities["warning"],
+                helpers.diagnostics.severities["error"],
+                helpers.diagnostics.severities["hint"],
+            },
+        }),
+    },
+    factory = helpers.generator_factory,
+})

--- a/lua/null-ls/builtins/formatting/sqlfluff.lua
+++ b/lua/null-ls/builtins/formatting/sqlfluff.lua
@@ -1,0 +1,27 @@
+local h = require("null-ls.helpers")
+local methods = require("null-ls.methods")
+
+local FORMATTING = methods.internal.FORMATTING
+
+return h.make_builtin({
+    name = "sqlfluff",
+    meta = {
+        url = "https://github.com/sqlfluff/sqlfluff",
+        description = "A SQL linter and auto-formatter for Humans",
+    },
+    method = FORMATTING,
+    filetypes = { "sql" },
+    generator_opts = {
+        command = "sqlfluff",
+        args = {
+            "fix",
+            "--disable_progress_bar",
+            "-f",
+            "-n",
+            "-",
+        },
+        from_stdin = true,
+        to_stdin = true,
+    },
+    factory = h.formatter_factory,
+})


### PR DESCRIPTION
Add sqlfluff as a diagnosis and formatting option for sql files. (Thanks again for the help on the question answered the other day).