### PR TITLE
feat: add fish --no-execute diagnostics

### DIFF
--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -564,6 +564,23 @@ local sources = { null_ls.builtins.diagnostics.eslint_d }
 - Command: `eslint_d`
 - Args: `{ "-f", "json", "--stdin", "--stdin-filename", "$FILENAME" }`
 
+### [fish](https://github.com/fish-shell/fish-shell)
+
+Basic linting is available for fish scripts using `fish --no-execute`.
+
+#### Usage
+
+```lua
+local sources = { null_ls.builtins.diagnostics.fish }
+```
+
+#### Defaults
+
+- Filetypes: `{ "fish" }`
+- Method: `diagnostics`
+- Command: `fish`
+- Args: `{ " --no-execute", "$FILENAME" }`
+
 ### [flake8](https://github.com/PyCQA/flake8)
 
 flake8 is a python tool that glues together pycodestyle, pyflakes, mccabe, and third-party plugins to check the style and quality of Python code.

--- a/lua/null-ls/builtins/_meta/diagnostics.lua
+++ b/lua/null-ls/builtins/_meta/diagnostics.lua
@@ -58,6 +58,9 @@ return {
   eslint_d = {
     filetypes = { "javascript", "javascriptreact", "typescript", "typescriptreact", "vue" }
   },
+  fish = {
+    filetypes = { "fish" }
+  },
   flake8 = {
     filetypes = { "python" }
   },

--- a/lua/null-ls/builtins/_meta/filetype_map.lua
+++ b/lua/null-ls/builtins/_meta/filetype_map.lua
@@ -89,6 +89,7 @@ return {
     formatting = { "fnlfmt" }
   },
   fish = {
+    diagnostics = { "fish" },
     formatting = { "fish_indent" }
   },
   fnl = {

--- a/lua/null-ls/builtins/diagnostics/fish.lua
+++ b/lua/null-ls/builtins/diagnostics/fish.lua
@@ -1,0 +1,25 @@
+local h = require("null-ls.helpers")
+local methods = require("null-ls.methods")
+
+return h.make_builtin({
+    name = "fish",
+    meta = {
+        url = "https://github.com/fish-shell/fish-shell",
+        description = "Code audit tool for Python.",
+    },
+    method = methods.internal.DIAGNOSTICS,
+    filetypes = { "fish" },
+    factory = h.generator_factory,
+    generator_opts = {
+        command = "fish",
+        args = { "--no-execute", "$FILENAME" },
+        to_stdin = false,
+        from_stderr = true,
+        to_temp_file = true,
+        format = "raw",
+        check_exit_code = function(code)
+            return code <= 1
+        end,
+        on_output = h.diagnostics.from_errorformat(table.concat({ "%f (line %l): %m" }, ","), "fish"),
+    },
+})

--- a/lua/null-ls/builtins/diagnostics/fish.lua
+++ b/lua/null-ls/builtins/diagnostics/fish.lua
@@ -5,7 +5,7 @@ return h.make_builtin({
     name = "fish",
     meta = {
         url = "https://github.com/fish-shell/fish-shell",
-        description = "Code audit tool for Python.",
+        description = "Basic linting is available for fish scripts using `fish --no-execute`.",
     },
     method = methods.internal.DIAGNOSTICS,
     filetypes = { "fish" },


### PR DESCRIPTION
`fish --no-execute $FILENAME` will give basic diagnostics for `.fish` files.