### PR TITLE
Do not set diagnostics for nonexisting buffer

### DIFF
--- a/lua/null-ls/diagnostics.lua
+++ b/lua/null-ls/diagnostics.lua
@@ -131,6 +131,10 @@ M.handler = function(original_params)
     local method, uri = original_params.method, original_params.textDocument.uri
     local bufnr = vim.uri_to_bufnr(uri)
 
+    if not vim.api.nvim_buf_is_valid(bufnr) then
+        return
+    end
+
     if method == methods.lsp.DID_CLOSE then
         changedticks_by_uri[uri] = nil
         s.clear_cache(uri)

--- a/test/spec/diagnostics_spec.lua
+++ b/test/spec/diagnostics_spec.lua
@@ -18,6 +18,7 @@ describe("diagnostics", function()
         stub(u, "make_params")
         stub(generators, "run_registered")
         stub(vim, "uri_to_bufnr")
+        stub(vim.api, "nvim_buf_is_valid")
 
         local mock_uri = "file:///mock-file"
         local mock_handler = stub.new()
@@ -39,6 +40,7 @@ describe("diagnostics", function()
 
             u.make_params.returns(mock_params)
             vim.uri_to_bufnr.returns(mock_bufnr)
+            vim.api.nvim_buf_is_valid.returns(true)
         end)
 
         after_each(function()
@@ -49,6 +51,7 @@ describe("diagnostics", function()
             generators.run_registered:clear()
             u.make_params:clear()
             vim.uri_to_bufnr:clear()
+            vim.api.nvim_buf_is_valid:clear()
 
             s.reset()
             c.reset()


### PR DESCRIPTION
It can occur after (LSP) renaming the class without opening it (e.g. on its some reference).

