### PR TITLE
Allow overriding to_temp_file

### DIFF
--- a/lua/null-ls/builtins/diagnostics/phpstan.lua
+++ b/lua/null-ls/builtins/diagnostics/phpstan.lua
@@ -23,13 +23,16 @@ return h.make_builtin({
             return code <= 1
         end,
         on_output = function(params)
-            local parser = h.diagnostics.from_json({})
-            params.messages = params.output
-                    and params.output.files
-                    and params.output.files[params.temp_path]
-                    and params.output.files[params.temp_path].messages
-                or {}
+            params.messages = {}
 
+            if params.output and params.output.files and type(params.output.files) == "table" then
+                for k in pairs(params.output.files) do
+                    params.messages = params.output.files[k].messages or {}
+                    break
+                end
+            end
+
+            local parser = h.diagnostics.from_json({})
             return parser({ output = params.messages })
         end,
     },

--- a/lua/null-ls/helpers/make_builtin.lua
+++ b/lua/null-ls/helpers/make_builtin.lua
@@ -26,6 +26,7 @@ local function make_builtin(opts)
     generator_opts = vim.tbl_deep_extend("force", generator_opts, {
         args = opts.args,
         command = opts.command,
+        to_temp_file = opts.to_temp_file,
         env = opts.env,
         cwd = opts.cwd,
         diagnostics_format = opts.diagnostics_format,

--- a/test/spec/helpers/make_builtin_spec.lua
+++ b/test/spec/helpers/make_builtin_spec.lua
@@ -177,7 +177,13 @@ describe("make_builtin", function()
         end)
 
         it("should use default factory function to assign opts to generator", function()
-            local default_opts = { generator = {}, generator_opts = { cwd = "mock-cwd" } }
+            local default_opts = {
+                generator = {},
+                generator_opts = {
+                    cwd = "mock-cwd",
+                    to_temp_file = false,
+                },
+            }
             builtin = helpers.make_builtin(default_opts)
 
             local generator = builtin.generator


### PR DESCRIPTION
Allows overriding the `to_temp_file` option.

The reason behind is that for example PHPStan doesn't support std in.  
If using temp files you may loose path-based project specific configuration.