### PR TITLE
refactor(helpers): offset end_col.from_quote by 1

### DIFF
--- a/lua/null-ls/builtins/diagnostics/cspell.lua
+++ b/lua/null-ls/builtins/diagnostics/cspell.lua
@@ -31,7 +31,6 @@ return h.make_builtin({
             { "row", "col", "message", "_quote" },
             {
                 adapters = { h.diagnostics.adapters.end_col.from_quote },
-                offsets = { end_col = 1 },
             }
         ),
     },

--- a/lua/null-ls/builtins/diagnostics/luacheck.lua
+++ b/lua/null-ls/builtins/diagnostics/luacheck.lua
@@ -29,9 +29,6 @@ return h.make_builtin({
             [[:(%d+):(%d+)-(%d+): %((%a)(%d+)%) (.*)]],
             { "row", "col", "end_col", "severity", "code", "message" },
             {
-                adapters = {
-                    h.diagnostics.adapters.end_col.from_quote,
-                },
                 severities = {
                     E = h.diagnostics.severities["error"],
                     W = h.diagnostics.severities["warning"],

--- a/lua/null-ls/builtins/diagnostics/selene.lua
+++ b/lua/null-ls/builtins/diagnostics/selene.lua
@@ -22,7 +22,7 @@ return h.make_builtin({
         on_output = h.diagnostics.from_pattern(
             [[(%d+):(%d+): (%w+)%[([%w_]+)%]: ([`]*([%w_]+)[`]*.*)]],
             { "row", "col", "severity", "code", "message", "_quote" },
-            { adapters = { h.diagnostics.adapters.end_col.from_quote }, offsets = { end_col = 1 } }
+            { adapters = { h.diagnostics.adapters.end_col.from_quote } }
         ),
     },
     factory = h.generator_factory,

--- a/lua/null-ls/builtins/diagnostics/teal.lua
+++ b/lua/null-ls/builtins/diagnostics/teal.lua
@@ -58,10 +58,7 @@ local function parse_diagnostics(params, done)
                 _quote = quote,
             }
             local content_line = params.content[tonumber(row)]
-            local end_col = end_col_from_quote(entries, content_line)
-            if end_col then
-                diagnostic.end_col = end_col + 1
-            end
+            diagnostic.end_col = end_col_from_quote(entries, content_line)
         end
 
         return diagnostic

--- a/lua/null-ls/builtins/diagnostics/write_good.lua
+++ b/lua/null-ls/builtins/diagnostics/write_good.lua
@@ -21,7 +21,7 @@ return h.make_builtin({
             { "row", "col", "message", "_quote" },
             {
                 adapters = { h.diagnostics.adapters.end_col.from_quote },
-                offsets = { col = 1, end_col = 1 },
+                offsets = { col = 1 },
             }
         ),
     },

--- a/lua/null-ls/helpers/diagnostics.lua
+++ b/lua/null-ls/helpers/diagnostics.lua
@@ -29,7 +29,9 @@ local diagnostic_adapters = {
                 end
 
                 _, end_col = line:find(quote, 1, true)
-                return end_col and end_col > tonumber(entries["col"]) and end_col or nil
+                if end_col and end_col > tonumber(entries["col"]) then
+                    return end_col + 1
+                end
             end,
         },
         from_length = {


### PR DESCRIPTION
As mentioned in #821, all builtins that used end_col.from_quote added a manual offset of 1. This removes the need for that by offsetting the end_col in the helper itself.
This also removes the adapter from luacheck since no `_quote` field was parsed anyway.