### PR TITLE
Godot-gdscript-toolkit formatter support

### DIFF
--- a/lua/null-ls/builtins/formatting/gdformat.lua
+++ b/lua/null-ls/builtins/formatting/gdformat.lua
@@ -1,0 +1,20 @@
+local h = require("null-ls.helpers")
+local methods = require("null-ls.methods")
+
+local FORMATTING = methods.internal.FORMATTING
+-- local RANGE_FORMATTING = methods.internal.RANGE_FORMATTING
+
+return h.make_builtin({
+    name = "gdformat",
+    meta = {
+        url = "https://github.com/Scony/godot-gdscript-toolkit",
+        description = "A formatter for Godot's gdscript",
+    },
+    method = { FORMATTING },
+    filetypes = {"gd", "gdscript", "gdscript3"},
+    generator_opts = {
+        command = "gdformat",
+        to_stdin = true,
+    },
+    factory = h.formatter_factory,
+})


### PR DESCRIPTION
just added the formatter gdformat from https://github.com/Scony/godot-gdscript-toolkit
it doesn't work with ```lua vim.lsp.buf.formatting_sync()``` I don't know why...help