### PR TITLE
fix: adapt to 0.8 breaking changes

### DIFF
--- a/lua/null-ls/client.lua
+++ b/lua/null-ls/client.lua
@@ -30,10 +30,24 @@ local should_attach = function(bufnr)
 end
 
 local on_init = function(new_client, initialize_result)
+    local capability_is_disabled
+    if u.has_version("0.8") then
+        capability_is_disabled = function(method)
+            -- TODO: extract map to prevent future issues
+            local required_capability = lsp._request_name_to_capability[method]
+            return not required_capability
+                or vim.tbl_get(new_client.server_capabilities, unpack(required_capability)) == false
+        end
+    else
+        capability_is_disabled = function(method)
+            return new_client.resolved_capabilities[methods.request_name_to_capability[method]] == false
+        end
+    end
+
     -- null-ls broadcasts all capabilities on launch, so this lets us have finer control
     new_client.supports_method = function(method)
-        -- capability was not declared or is specifically disabled
-        if new_client.resolved_capabilities[methods.request_name_to_capability[method]] == false then
+        -- allow users to specifically disable capabilities
+        if capability_is_disabled(method) then
             return false
         end
 

--- a/lua/null-ls/rpc.lua
+++ b/lua/null-ls/rpc.lua
@@ -42,7 +42,7 @@ local capabilities = {
     textDocumentSync = {
         change = 1, -- prompt LSP client to send full document text on didOpen and didChange
         openClose = true,
-        save = true,
+        save = { includeText = true },
     },
     hoverProvider = true,
 }


### PR DESCRIPTION
Should fix #835. The specific issue is that the type of `textDocumentSync.save` doesn't match what Neovim expects. I think this is an upstream regression, since the specification indicates that a boolean value is acceptable:

<img width="674" alt="Screen Shot 2022-04-30 at 10 55 13 AM" src="https://user-images.githubusercontent.com/54108223/166110625-779e4021-00e4-47df-a872-31d3b1553d90.png">

But it's an easy fix on our end. I've also included a fix for the deprecation warning from accessing `client.resolved_capabilities` on 0.8.

Edit: tests will fail until there's a new nightly build, since the CI action doesn't build from source, but they're passing for me locally. I'd appreciate confirmation from anyone who commented on the original issue!