### PR TITLE
Fix mypy builtin not displaying some diagnostics

### DIFF
--- a/lua/null-ls/builtins/diagnostics/mypy.lua
+++ b/lua/null-ls/builtins/diagnostics/mypy.lua
@@ -3,6 +3,14 @@ local methods = require("null-ls.methods")
 
 local DIAGNOSTICS = methods.internal.DIAGNOSTICS
 
+local overrides = {
+    severities = {
+        error = h.diagnostics.severities["error"],
+        warning = h.diagnostics.severities["warning"],
+        note = h.diagnostics.severities["information"],
+    },
+}
+
 return h.make_builtin({
     name = "mypy",
     meta = {
@@ -35,17 +43,18 @@ benefits of dynamic (or "duck") typing and static typing.]],
             return code <= 2
         end,
         multiple_files = true,
-        on_output = h.diagnostics.from_pattern(
-            "([^:]+):(%d+):(%d+): (%a+): (.*)  %[([%a-]+)%]", --
-            { "filename", "row", "col", "severity", "message", "code" },
+        on_output = h.diagnostics.from_patterns({
             {
-                severities = {
-                    error = h.diagnostics.severities["error"],
-                    warning = h.diagnostics.severities["warning"],
-                    note = h.diagnostics.severities["information"],
-                },
-            }
-        ),
+                pattern = "([^:]+):(%d+):(%d+): (%a+): (.*)  %[([%a-]+)%]",
+                groups = { "filename", "row", "col", "severity", "message", "code" },
+                overrides = overrides,
+            },
+            {
+                pattern = "([^:]+):(%d+): (%a+): (.*)",
+                groups = { "filename", "row", "severity", "message" },
+                overrides = overrides,
+            },
+        }),
     },
     factory = h.generator_factory,
 })


### PR DESCRIPTION
The mypy builtin was not displaying some diagnostics due to failing to
parse them properly. The previously used regex pattern assumed that
each line in mypy's output would have a column number and a error code.
This is the case for most lines but not for all of them. For example the
following line contains no column number or error code:

```tests/slack_app/conftest.py:10: error: Unused "type: ignore" comment```

In this case null-ls would fail to display this error in the editor
because it could not be parsed. This commit fixes that issue by adding a
additional regex pattern that can parse lines in the format of the
example.