### PR TITLE
WIP Filtering Diagnostic Messages

### DIFF
--- a/doc/BUILTIN_CONFIG.md
+++ b/doc/BUILTIN_CONFIG.md
@@ -178,15 +178,11 @@ be a function that returns `true` to keep the result, and `false` to remove it.
 
 ```lua
 local sources = {
-        null_ls.builtins.diagnostics.eslint_d.with({
-            -- ignore prettier warnings from eslint-plugin-prettier
-            filter = function(diagnostic)
-                if diagnostic.code == "prettier/prettier" then
-                    return false
-                else
-                    return true
-                end
-            end
+    null_ls.builtins.diagnostics.eslint_d.with({
+        -- ignore prettier warnings from eslint-plugin-prettier
+        filter = function(diagnostic)
+            return diagnostic.code != "prettier/prettier"
+        end
     }),
 }
 ```

--- a/doc/BUILTIN_CONFIG.md
+++ b/doc/BUILTIN_CONFIG.md
@@ -171,6 +171,26 @@ local sources = {
 }
 ```
 
+### Filtering
+
+You can filter generator results using the `filter` option. The option should
+be a function that returns `true` to keep the result, and `false` to remove it.
+
+```lua
+local sources = {
+        null_ls.builtins.diagnostics.eslint_d.with({
+            -- ignore prettier warnings from eslint-plugin-prettier
+            filter = function(diagnostic)
+                if diagnostic.code == "prettier/prettier" then
+                    return false
+                else
+                    return true
+                end
+            end
+    }),
+}
+```
+
 ### Diagnostics format
 
 For diagnostics sources, you can change the format of diagnostic messages by

--- a/doc/BUILTIN_CONFIG.md
+++ b/doc/BUILTIN_CONFIG.md
@@ -174,7 +174,7 @@ local sources = {
 ### Filtering
 
 You can filter generator results using the `filter` option. The option should
-be a function that returns `true` to keep the result, and `false` to remove it.
+be a function that returns `true` to keep the result, and `false` or `nil` to ignore it.
 
 ```lua
 local sources = {

--- a/lua/null-ls/diagnostics.lua
+++ b/lua/null-ls/diagnostics.lua
@@ -76,15 +76,6 @@ local postprocess = function(diagnostic, _, generator)
     diagnostic.message = formatted
 end
 
-local filter = function(diagnostic, generator)
-    local user_filter = generator.opts.diagnostics_filter
-    if user_filter then
-        return user_filter(diagnostic)
-    else
-        return true
-    end
-end
-
 local handle_single_file_diagnostics = function(namespace, diagnostics, bufnr)
     vim.diagnostic.set(namespace, bufnr, diagnostics)
 end
@@ -170,7 +161,6 @@ M.handler = function(original_params)
         method = methods.map[method],
         params = params,
         postprocess = postprocess,
-        filter = filter,
         after_each = function(diagnostics, _, generator)
             if not vim.api.nvim_buf_is_valid(bufnr) then
                 return

--- a/lua/null-ls/diagnostics.lua
+++ b/lua/null-ls/diagnostics.lua
@@ -76,6 +76,15 @@ local postprocess = function(diagnostic, _, generator)
     diagnostic.message = formatted
 end
 
+local filter = function(diagnostic, generator)
+    local user_filter = generator.opts.diagnostics_filter
+    if user_filter then
+        return user_filter(diagnostic)
+    else
+        return true
+    end
+end
+
 local handle_single_file_diagnostics = function(namespace, diagnostics, bufnr)
     vim.diagnostic.set(namespace, bufnr, diagnostics)
 end
@@ -161,6 +170,7 @@ M.handler = function(original_params)
         method = methods.map[method],
         params = params,
         postprocess = postprocess,
+        filter = filter,
         after_each = function(diagnostics, _, generator)
             if not vim.api.nvim_buf_is_valid(bufnr) then
                 return

--- a/lua/null-ls/generators.lua
+++ b/lua/null-ls/generators.lua
@@ -58,11 +58,9 @@ M.run = function(generators, params, opts, callback)
             a.util.scheduler()
 
             -- filter diagnostics results with the diagnostic_filter option
-            local filter = opts.filter
+            local filter = generator.opts.filter
             if filter and results then
-                results = vim.tbl_filter(function(result)
-                    return filter(result, generator)
-                end, results)
+                results = vim.tbl_filter(filter, results)
             end
 
             if results then

--- a/lua/null-ls/generators.lua
+++ b/lua/null-ls/generators.lua
@@ -57,8 +57,8 @@ M.run = function(generators, params, opts, callback)
             local ok, results = protected_call(to_run, copied_params)
             a.util.scheduler()
 
-            -- filter diagnostics results with the diagnostic_filter option
-            local filter = generator.opts.filter
+            -- filter results with the filter option
+            local filter = generator.opts and generator.opts.filter
             if filter and results then
                 results = vim.tbl_filter(filter, results)
             end

--- a/lua/null-ls/generators.lua
+++ b/lua/null-ls/generators.lua
@@ -139,11 +139,11 @@ M.run_sequentially = function(generators, make_params, opts, callback)
 end
 
 M.run_registered = function(opts)
-    local filetype, method, params, postprocess, filter, callback, after_each =
-        opts.filetype, opts.method, opts.params, opts.postprocess, opts.filter, opts.callback, opts.after_each
+    local filetype, method, params, postprocess, callback, after_each =
+        opts.filetype, opts.method, opts.params, opts.postprocess, opts.callback, opts.after_each
     local generators = M.get_available(filetype, method)
 
-    M.run(generators, params, { postprocess = postprocess, filter = filter, after_each = after_each }, callback)
+    M.run(generators, params, { postprocess = postprocess, after_each = after_each }, callback)
 end
 
 M.run_registered_sequentially = function(opts)

--- a/lua/null-ls/generators.lua
+++ b/lua/null-ls/generators.lua
@@ -57,6 +57,14 @@ M.run = function(generators, params, opts, callback)
             local ok, results = protected_call(to_run, copied_params)
             a.util.scheduler()
 
+            -- filter diagnostics results with the diagnostic_filter option
+            local filter = opts.filter
+            if filter and results then
+                results = vim.tbl_filter(function(result)
+                    return filter(result, generator)
+                end, results)
+            end
+
             if results then
                 -- allow generators to pass errors without throwing them (e.g. in luv callbacks)
                 if results._generator_err then
@@ -133,11 +141,11 @@ M.run_sequentially = function(generators, make_params, opts, callback)
 end
 
 M.run_registered = function(opts)
-    local filetype, method, params, postprocess, callback, after_each =
-        opts.filetype, opts.method, opts.params, opts.postprocess, opts.callback, opts.after_each
+    local filetype, method, params, postprocess, filter, callback, after_each =
+        opts.filetype, opts.method, opts.params, opts.postprocess, opts.filter, opts.callback, opts.after_each
     local generators = M.get_available(filetype, method)
 
-    M.run(generators, params, { postprocess = postprocess, after_each = after_each }, callback)
+    M.run(generators, params, { postprocess = postprocess, filter = filter, after_each = after_each }, callback)
 end
 
 M.run_registered_sequentially = function(opts)

--- a/lua/null-ls/helpers/make_builtin.lua
+++ b/lua/null-ls/helpers/make_builtin.lua
@@ -29,6 +29,7 @@ local function make_builtin(opts)
         env = opts.env,
         cwd = opts.cwd,
         diagnostics_format = opts.diagnostics_format,
+        diagnostics_filter = opts.diagnostics_filter,
         diagnostics_postprocess = opts.diagnostics_postprocess,
         dynamic_command = opts.dynamic_command,
         ignore_stderr = opts.ignore_stderr,

--- a/lua/null-ls/helpers/make_builtin.lua
+++ b/lua/null-ls/helpers/make_builtin.lua
@@ -29,7 +29,7 @@ local function make_builtin(opts)
         env = opts.env,
         cwd = opts.cwd,
         diagnostics_format = opts.diagnostics_format,
-        diagnostics_filter = opts.diagnostics_filter,
+        filter = opts.filter,
         diagnostics_postprocess = opts.diagnostics_postprocess,
         dynamic_command = opts.dynamic_command,
         ignore_stderr = opts.ignore_stderr,


### PR DESCRIPTION
This is a rough first pass at being able to filter diagnostic messages. Am I somewhere in the ballpark? 😅

I've been using it locally for the last couple weeks, seems to be working well. I was looking at adding unit tests but I was unable to get the e2e tests to pass locally. I figured I would get some feedback before I went too deep.

My vim config looks like this, with a new `diagnostics_filter` function parameter:

```
null_ls.setup({
	on_attach = function(client)
		if client.resolved_capabilities.document_formatting then
			-- format on save
			vim.cmd("autocmd BufWritePost <buffer> lua vim.lsp.buf.formatting_sync(nil, 2000)")
		end
	end,
	diagnostics_format = "[#{c}] #{m} (#{s})",
	sources = {
		null_ls.builtins.diagnostics.eslint_d.with({
			diagnostics_filter = function(diagnostic)
				if diagnostic.code == "prettier/prettier" then
					return false
				else
					return true
				end
			end,
		}),
		null_ls.builtins.code_actions.eslint_d,
		null_ls.builtins.formatting.eslint_d,
		null_ls.builtins.formatting.stylua,
		null_ls.builtins.formatting.prettierd,
	},
})
```

