### PR TITLE
docs: document staticcheck and revive quirks

### DIFF
--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -1142,6 +1142,10 @@ local sources = { null_ls.builtins.diagnostics.revive }
 - Command: `revive`
 - Args: `{ "-formatter", "json", "./..." }`
 
+#### Notes
+
+- `extra_args` does not work with this linter, since it does not support additional non-file arguments after the first file or `./...` is specified. Overwrite `args` instead.
+
 ### [rpmspec](https://rpm.org/)
 
 Command line tool to parse RPM spec files.
@@ -1336,6 +1340,10 @@ local sources = { null_ls.builtins.diagnostics.staticcheck }
 - Method: `diagnostics_on_save`
 - Command: `staticcheck`
 - Args: `{ "-f", "json", "./..." }`
+
+#### Notes
+
+- `extra_args` does not work with this linter, since it does not support additional non-file arguments after the first file or `./...` is specified. Overwrite `args` instead.
 
 ### [statix](https://github.com/nerdypepper/statix)
 


### PR DESCRIPTION
Those linters cannot correctly parse non-file arguments after the first
file is specified. This causes the extra_args feature of null-ls to not
work.

See discussion https://github.com/jose-elias-alvarez/null-ls.nvim/pull/399