### PR TITLE
fix: luasnip not getting all available snippets

### DIFF
--- a/lua/null-ls/builtins/completion/luasnip.lua
+++ b/lua/null-ls/builtins/completion/luasnip.lua
@@ -30,7 +30,7 @@ return h.make_builtin({
 
             for i = 1, #filetypes do
                 local ft = filetypes[i]
-                local ft_table = require("luasnip").snippets[ft]
+                local ft_table = require("luasnip").get_snippets(ft)
                 if ft_table then
                     for j, snip in pairs(ft_table) do
                         local data = {


### PR DESCRIPTION
As currently configured, this completion source misses all snippets not directly added to the `snippets` table, including those loaded with [`require("luasnip.loaders.from_lua")`](https://github.com/L3MON4D3/LuaSnip/blob/master/DOC.md#lua) and those loaded with [`require("luasnip.loaders.from_vscode")`](https://github.com/L3MON4D3/LuaSnip/blob/master/DOC.md#vscode). Using `get_snippets` method gets all available snippets, including those loaded by other methods.