### PR TITLE
docs: document staticcheck and revive quirks v2

### DIFF
--- a/lua/null-ls/builtins/diagnostics/revive.lua
+++ b/lua/null-ls/builtins/diagnostics/revive.lua
@@ -12,6 +12,9 @@ return h.make_builtin({
     meta = {
         url = "https://revive.run/",
         description = "Fast, configurable, extensible, flexible, and beautiful linter for Go.",
+        notes = {
+            "`extra_args` does not work with this linter, since it does not support additional non-file arguments after the first file or `./...` is specified. Overwrite `args` instead.",
+        },
     },
     method = methods.internal.DIAGNOSTICS_ON_SAVE,
     filetypes = { "go" },

--- a/lua/null-ls/builtins/diagnostics/staticcheck.lua
+++ b/lua/null-ls/builtins/diagnostics/staticcheck.lua
@@ -14,6 +14,9 @@ return h.make_builtin({
     meta = {
         url = "https://staticcheck.io/",
         description = "Advanced Go linter.",
+        notes = {
+            "`extra_args` does not work with this linter, since it does not support additional non-file arguments after the first file or `./...` is specified. Overwrite `args` instead.",
+        },
     },
     method = DIAGNOSTICS_ON_SAVE,
     filetypes = { "go" },


### PR DESCRIPTION
Those linters cannot correctly parse non-file arguments after the first
file is specified. This causes the extra_args feature of null-ls to not
work.

Seems like I put the notes in the wrong, old place in version 1 and they got overwritten by the auto-generation of the documents in this [commit](https://github.com/jose-elias-alvarez/null-ls.nvim/commit/82d5120c343b3e874da95946b1f6f1b79f72ae3b). Sorry for that sloppy mistake.