### PR TITLE
fix(builtins): handle mypy diagnostics without code

### DIFF
--- a/lua/null-ls/builtins/diagnostics/mypy.lua
+++ b/lua/null-ls/builtins/diagnostics/mypy.lua
@@ -44,11 +44,19 @@ benefits of dynamic (or "duck") typing and static typing.]],
         end,
         multiple_files = true,
         on_output = h.diagnostics.from_patterns({
+            -- see spec for pattern examples
             {
                 pattern = "([^:]+):(%d+):(%d+): (%a+): (.*)  %[([%a-]+)%]",
                 groups = { "filename", "row", "col", "severity", "message", "code" },
                 overrides = overrides,
             },
+            -- no error code
+            {
+                pattern = "([^:]+):(%d+):(%d+): (%a+): (.*)",
+                groups = { "filename", "row", "col", "severity", "message" },
+                overrides = overrides,
+            },
+            -- no column or error code
             {
                 pattern = "([^:]+):(%d+): (%a+): (.*)",
                 groups = { "filename", "row", "severity", "message" },

--- a/test/spec/builtins/diagnostics_spec.lua
+++ b/test/spec/builtins/diagnostics_spec.lua
@@ -1096,4 +1096,45 @@ describe("diagnostics", function()
             }, diagnostic)
         end)
     end)
+
+    describe("mypy", function()
+        local linter = diagnostics.mypy
+        local parser = linter._opts.on_output
+        it("should handle full diagnostic", function()
+            local output =
+                'test.py:1:1: error: Library stubs not installed for "requests" (or incompatible with Python 3.9)  [import]'
+            local diagnostic = parser(output, {})
+            assert.same({
+                row = "1",
+                col = "1",
+                severity = 1,
+                message = 'Library stubs not installed for "requests" (or incompatible with Python 3.9)',
+                filename = "test.py",
+                code = "import",
+            }, diagnostic)
+        end)
+
+        it("should diagnostic without code", function()
+            local output = 'test.py:1:1: note: Hint: "python3 -m pip install types-requests"'
+            local diagnostic = parser(output, {})
+            assert.same({
+                row = "1",
+                col = "1",
+                severity = 3,
+                message = 'Hint: "python3 -m pip install types-requests"',
+                filename = "test.py",
+            }, diagnostic)
+        end)
+
+        it("should handle diagnostic with no column or error code", function()
+            local output = [[tests/slack_app/conftest.py:10: error: Unused "type: ignore" comment]]
+            local diagnostic = parser(output, {})
+            assert.same({
+                row = "10",
+                severity = 1,
+                message = 'Unused "type: ignore" comment',
+                filename = "tests/slack_app/conftest.py",
+            }, diagnostic)
+        end)
+    end)
 end)


### PR DESCRIPTION
See #893 for context. 

I think this should be fine - I'm not thrilled about adding another pattern, but I don't think Lua has a way to handle `code` as an optional capture group. I also added test coverage to clarify the cases we're currently handling and prevent regressions if someone wants to improve this in the future, since this source has already been through a few iterations.