### PR TITLE
add severities for common flake8 plugins

### DIFF
--- a/lua/null-ls/builtins/diagnostics/flake8.lua
+++ b/lua/null-ls/builtins/diagnostics/flake8.lua
@@ -82,6 +82,8 @@ return h.make_builtin({
                     S = h.diagnostics.severities["warning"],
                     I = h.diagnostics.severities["warning"],
                     C = h.diagnostics.severities["warning"],
+                    B = h.diagnostics.severities["warning"], -- flake8-bugbear
+                    N = h.diagnostics.severities["information"], -- pep8-naming
                 },
             }
         ),


### PR DESCRIPTION
These are some commonly used plugins for flake8. It's tricky to customize the severities for them, and it doesn't hurt to have them here if they aren't installed, so might as well have them for folks that use them.