### PR TITLE
feat: added default runtime condition for cfn_lint diagnostics source

### DIFF
--- a/lua/null-ls/builtins/diagnostics/cfn_lint.lua
+++ b/lua/null-ls/builtins/diagnostics/cfn_lint.lua
@@ -41,6 +41,13 @@ return h.make_builtin({
             end
             return false
         end),
+        notes = {
+            "Once a supported file type is opened null-ls will try and determine if the file looks like an AWS Cloudformation template.",
+            'A file will be considered an AWS Cloudformation template if it contains "Resources" or "AWSTemplateFormatVersion".',
+            "This check will run only once when entering the buffer.",
+            'This means if "Resources" or "AWSTemplateFormatVersion" is added to a file after this check is run, the cfn-lint diagnostics will not be generated.',
+            "To fix this you must restart neovim.",
+        },
     },
     factory = h.generator_factory,
 })

--- a/lua/null-ls/builtins/diagnostics/cfn_lint.lua
+++ b/lua/null-ls/builtins/diagnostics/cfn_lint.lua
@@ -31,6 +31,16 @@ return h.make_builtin({
                 },
             }
         ),
+        runtime_condition = h.cache.by_bufnr(function(params)
+            -- check if file looks like a cloudformation template
+            local lines = vim.api.nvim_buf_get_lines(params.bufnr, 0, -1, false)
+            for _, line in ipairs(lines) do
+                if line:match("Resources") or line:match("AWSTemplateFormatVersion") then
+                    return true
+                end
+            end
+            return false
+        end),
     },
     factory = h.generator_factory,
 })


### PR DESCRIPTION
- Added runtime_condition for cfn_lint diagnostics to only produce cfn-lint diagnostics when the file looks like an AWS Cloudfromation template.
- This prevents diagnostics from being run on all JSON and YAML files being edited.

**NOTE**
- @jose-elias-alvarez from our [discussion](https://github.com/jose-elias-alvarez/null-ls.nvim/discussions/910) I found some behaviour which might not be as expected.

Screenshot of a YAML file where cfn-lint diagnostics are not being produced (the desired result), however the cfn-lint source still appears as attached. Not sure if this is expected.
<img width="455" alt="image" src="https://user-images.githubusercontent.com/9123129/173245305-e4571b0f-b49f-41ea-9ce3-0ac41714660e.png">

Screenshot of adding `AWSTemplateFormatVersion` to the same YAML file, which then results in cfn-lint starting to produce diagnostics. I believe we were expecting the buffer cache to prevent cfn-lint from producing diagnostics as the cache would have previously marked the buffer as not being a cloud formation template, and we were expecting the user to have to reload the buffer for the cfn-lint diagnostics to be produced.

<img width="489" alt="image" src="https://user-images.githubusercontent.com/9123129/173245408-998b66e9-987c-4c3a-a4c1-e8ac3b9f1c82.png">

After removing `AWSTemplateFormatVersion` from the file, the file is still considered to be a cloudformation template which is fair enough, a restart of neovim fixes this.

I expect we have to add some documentation around the behaviour to this PR, but I want to verify the behaviour I am seeing with you first, and I can modify the PR as we need.