### PR TITLE
fix: added stricter pattern matching for cfn-lint runtime_condition

### DIFF
--- a/lua/null-ls/builtins/diagnostics/cfn_lint.lua
+++ b/lua/null-ls/builtins/diagnostics/cfn_lint.lua
@@ -10,7 +10,9 @@ return h.make_builtin({
         description = "Validate AWS CloudFormation yaml/json templates against the AWS CloudFormation Resource Specification",
         notes = {
             "Once a supported file type is opened null-ls will try and determine if the file looks like an AWS Cloudformation template.",
-            'A file will be considered an AWS Cloudformation template if it contains "Resources" or "AWSTemplateFormatVersion".',
+            'A file will be considered an AWS Cloudformation template if it contains a "Resources" or "AWSTemplateFormatVersion" key.',
+            'To prevent cfn-lint running on all YAML and JSON files that contain a "Resources" key.',
+            'The file must contain at least one AWS Cloudformation Resource Type, e.g "Type": "AWS::S3::Bucket"',
             "This check will run only once when entering the buffer.",
             'This means if "Resources" or "AWSTemplateFormatVersion" is added to a file after this check is run, the cfn-lint diagnostics will not be generated.',
             "To fix this you must restart Neovim.",
@@ -41,12 +43,35 @@ return h.make_builtin({
         runtime_condition = h.cache.by_bufnr(function(params)
             -- check if file looks like a cloudformation template
             local lines = vim.api.nvim_buf_get_lines(params.bufnr, 0, -1, false)
+
+            -- matches the word AWSTemplateFormatVersion optionally surrounded by quotes, zero to many spaces, followed by a colon
+            local template_format_version_pattern = '"?AWSTemplateFormatVersion"?%s*:'
+
+            -- matches the word Resources optionally surrounded by quotes, zero to many spaces, followed by a colon
+            local resources_pattern = '?"?Resources"?%s*:'
+
+            -- matches the word Type optionally surrounded by quotes, zero to many spaces, followed by a colon,
+            -- followed by 2-64 alphanumeric characters, separated by 2 colons, followed by 2-64 more alaphanumeric characters.
+            -- This pattern matches the naming convention of an AWS cloudformation resource type
+            local resource_type_pattern = '"?Type"?%s*:%s*"?\'?%w{2,64}::%w{2,64}'
+
+            local found_resources = false
             for _, line in ipairs(lines) do
-                if line:match("Resources") or line:match("AWSTemplateFormatVersion") then
+                if line:match(template_format_version_pattern) then
                     return true
                 end
+
+                if line:match(resources_pattern) then
+                    found_resources = true
+                end
+
+                -- file must contain both Resources as well as Type key which matches the aws resource type naming convention
+                if found_resources and line:match(resource_type_pattern) then
+                    return true
+                end
+
+                return false
             end
-            return false
         end),
     },
     factory = h.generator_factory,

--- a/lua/null-ls/builtins/diagnostics/cfn_lint.lua
+++ b/lua/null-ls/builtins/diagnostics/cfn_lint.lua
@@ -50,10 +50,11 @@ return h.make_builtin({
             -- matches the word Resources optionally surrounded by quotes, zero to many spaces, followed by a colon
             local resources_pattern = '?"?Resources"?%s*:'
 
+            -- This pattern matches the naming convention of an AWS cloudformation resource type "Type": "AWS::ProductIdentifier::ResourceType"
             -- matches the word Type optionally surrounded by quotes, zero to many spaces, followed by a colon,
-            -- followed by 2-64 alphanumeric characters, separated by 2 colons, followed by 2-64 more alaphanumeric characters.
-            -- This pattern matches the naming convention of an AWS cloudformation resource type
-            local resource_type_pattern = '"?Type"?%s*:%s*"?\'?%w{2,64}::%w{2,64}'
+            -- followed by AWS, 2 colons, 2-64 alphanumeric characters for the product identifier, separated by 2 colons,
+            -- followed by 2-64 more alaphanumeric characters for the resource type.
+            local resource_type_pattern = '"?Type"?%s*:%s*"?\'?AWS::%w{2,64}::%w{2,64}"?\'?'
 
             local found_resources = false
             for _, line in ipairs(lines) do

--- a/lua/null-ls/builtins/diagnostics/cfn_lint.lua
+++ b/lua/null-ls/builtins/diagnostics/cfn_lint.lua
@@ -45,16 +45,16 @@ return h.make_builtin({
             local lines = vim.api.nvim_buf_get_lines(params.bufnr, 0, -1, false)
 
             -- matches the word AWSTemplateFormatVersion optionally surrounded by quotes, zero to many spaces, followed by a colon
-            local template_format_version_pattern = '"?AWSTemplateFormatVersion"?%s*:'
+            local template_format_version_pattern = '%s*"?AWSTemplateFormatVersion"?%s*:'
 
             -- matches the word Resources optionally surrounded by quotes, zero to many spaces, followed by a colon
-            local resources_pattern = '?"?Resources"?%s*:'
+            local resources_pattern = '"?Resources"?%s*:'
 
             -- This pattern matches the naming convention of an AWS cloudformation resource type "Type": "AWS::ProductIdentifier::ResourceType"
             -- matches the word Type optionally surrounded by quotes, zero to many spaces, followed by a colon,
-            -- followed by AWS, 2 colons, 2-64 alphanumeric characters for the product identifier, separated by 2 colons,
-            -- followed by 2-64 more alaphanumeric characters for the resource type.
-            local resource_type_pattern = '"?Type"?%s*:%s*"?\'?AWS::%w{2,64}::%w{2,64}"?\'?'
+            -- followed by AWS, 2 colons, 1 or more alphanumeric characters for the product identifier, separated by 2 colons,
+            -- followed by one or more alaphanumeric characters for the resource type.
+            local resource_type_pattern = '"?Type"?%s*:%s*"?\'?AWS::%w+::%w+"?\'?'
 
             local found_resources = false
             for _, line in ipairs(lines) do
@@ -70,9 +70,9 @@ return h.make_builtin({
                 if found_resources and line:match(resource_type_pattern) then
                     return true
                 end
-
-                return false
             end
+
+            return false
         end),
     },
     factory = h.generator_factory,


### PR DESCRIPTION
- Added stricter pattern matching for cfn-lint runtime_condition function when determining if a file is a cloud formation template or not.
- Based on the following implementation used for the vs-code extension https://github.com/aws-cloudformation/cfn-lint-visual-studio-code/blob/master/server/src/server.ts#L144
	- This is not an exact match of this regex in the above link, the patterns in this PR have been modified slightly in some cases (shortened to use meta characters, being stricter by looking for an "AWS" prefix etc.)

- Screenshot of a cloud formation file with resource types defined under the Resources key (json).
<img width="538" alt="image" src="https://user-images.githubusercontent.com/9123129/176126966-dc1afb5d-b59f-41ca-a8e3-af2302e873fc.png">

- Screenshot of a cloud formation file with resource types defined under the Resources key (yaml).
<img width="495" alt="image" src="https://user-images.githubusercontent.com/9123129/176127276-43a2457e-971b-4e1e-b1d3-7ef5252e2a0c.png">

- Screenshot of AWSTemplateVersionFormat being used to attach cfn-lint to signal that the "Resources" key is invalid (json)
<img width="459" alt="image" src="https://user-images.githubusercontent.com/9123129/176127397-fe0e44f8-c663-4f27-9e31-1e94f7ae9c1b.png">

- Screenshot of AWSTemplateVersionFormat being used to attach cfn-lint to signal that the "Resources" key is invalid (yaml)
<img width="552" alt="image" src="https://user-images.githubusercontent.com/9123129/176127625-43d59865-0479-47dc-9982-6632d9a3b693.png">

- Standard json file with "Resouces" key not producing cfn-lint diagnostics
<img width="275" alt="image" src="https://user-images.githubusercontent.com/9123129/176127999-36900185-9b25-4f90-a349-891fddd017dc.png">

- Standard yaml file with "Resouces" key not producing cfn-lint diagnostics
<img width="298" alt="image" src="https://user-images.githubusercontent.com/9123129/176128033-6b3d3458-4215-4db8-8751-68cc17361bbb.png">

