### PR TITLE
WIP: showcase automatic vimdoc conversion with ts-vimdoc

### DIFF
--- a/.github/workflows/vimdoc.yaml
+++ b/.github/workflows/vimdoc.yaml
@@ -1,0 +1,60 @@
+name: vimdoc
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  vimdocgen:
+    runs-on: [ubuntu-latest]
+    steps:
+      - uses: actions/checkout@v2
+      - run: date +%F > todays-date
+      - name: Restore cache for today's nightly.
+        uses: actions/cache@v2
+        with:
+          path: build
+          key: ${{ runner.os }}-appimage-${{ hashFiles('todays-date') }}
+
+      - name: Setup neovim nightly and install plugins
+        run: |
+          test -d build || {
+            mkdir -p build
+            wget https://github.com/neovim/neovim/releases/download/nightly/nvim.appimage
+            chmod +x nvim.appimage
+            mv nvim.appimage ./build/nvim
+          }
+          mkdir -p ~/.local/share/nvim/site/pack/vendor/start
+          git clone --depth 1 https://github.com/ibhagwan/ts-vimdoc.nvim ~/.local/share/nvim/site/pack/vendor/start/ts-vimdoc.nvim
+          git clone --depth 1 https://github.com/nvim-treesitter/nvim-treesitter ~/.local/share/nvim/site/pack/vendor/start/nvim-treesitter
+      - name: Build parser
+        run: |
+          export PACKPATH=$HOME/.local/share/nvim/site
+          ./build/nvim --headless -u ~/.local/share/nvim/site/pack/vendor/start/ts-vimdoc.nvim/scripts/init.lua -c "TSUpdateSync markdown" -c "TSUpdateSync markdown_inline" -c "qa"
+      - name: Generating docs
+        run: |
+          export PATH="${PWD}/build/:${PATH}"
+          export PACKPATH=$HOME/.local/share/nvim/site
+          ./build/nvim --headless -u ~/.local/share/nvim/site/pack/vendor/start/ts-vimdoc.nvim/scripts/init.lua  -c "lua require('ts-vimdoc').docgen({input_file='README.md', output_file='doc/null-ls.txt', project_name='null-ls'})" -c "qa"
+          ./build/nvim --headless -u ~/.local/share/nvim/site/pack/vendor/start/ts-vimdoc.nvim/scripts/init.lua  -c "lua require('ts-vimdoc').docgen({input_file='doc/BUILTINS.md', output_file='doc/BUILTINS.txt', project_name='null-ls'})" -c "qa"
+          ./build/nvim --headless -u ~/.local/share/nvim/site/pack/vendor/start/ts-vimdoc.nvim/scripts/init.lua  -c "lua require('ts-vimdoc').docgen({input_file='doc/BUILTIN_CONFIG.md', output_file='doc/BUILTIN_CONFIG.txt', project_name='null-ls'})" -c "qa"
+          ./build/nvim --headless -u ~/.local/share/nvim/site/pack/vendor/start/ts-vimdoc.nvim/scripts/init.lua  -c "lua require('ts-vimdoc').docgen({input_file='doc/CONFIG.md', output_file='doc/CONFIG.txt', project_name='null-ls'})" -c "qa"
+          ./build/nvim --headless -u ~/.local/share/nvim/site/pack/vendor/start/ts-vimdoc.nvim/scripts/init.lua  -c "lua require('ts-vimdoc').docgen({input_file='doc/CONTRIBUTING.md', output_file='doc/CONTRIBUTING.txt', project_name='null-ls'})" -c "qa"
+          ./build/nvim --headless -u ~/.local/share/nvim/site/pack/vendor/start/ts-vimdoc.nvim/scripts/init.lua  -c "lua require('ts-vimdoc').docgen({input_file='doc/HELPERS.md', output_file='doc/HELPERS.txt', project_name='null-ls'})" -c "qa"
+          ./build/nvim --headless -u ~/.local/share/nvim/site/pack/vendor/start/ts-vimdoc.nvim/scripts/init.lua  -c "lua require('ts-vimdoc').docgen({input_file='doc/MAIN.md', output_file='doc/MAIN.txt', project_name='null-ls'})" -c "qa"
+          ./build/nvim --headless -u ~/.local/share/nvim/site/pack/vendor/start/ts-vimdoc.nvim/scripts/init.lua  -c "lua require('ts-vimdoc').docgen({input_file='doc/SOURCES.md', output_file='doc/SOURCES.txt', project_name='null-ls'})" -c "qa"
+          ./build/nvim --headless -u ~/.local/share/nvim/site/pack/vendor/start/ts-vimdoc.nvim/scripts/init.lua  -c "lua require('ts-vimdoc').docgen({input_file='doc/TESTING.md', output_file='doc/TESTING.txt', project_name='null-ls'})" -c "qa"
+      - name: Commit changes
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMMIT_MSG: |
+            [docgen] CI: autogenerate vimdoc
+            skip-checks: true
+        run: |
+          git config user.email "actions@github"
+          git config user.name "Github Actions"
+          git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
+          git add doc/
+          # Only commit and push if we have changes
+          git diff --quiet && git diff --staged --quiet || (git commit -m "${COMMIT_MSG}"; git push origin HEAD:${GITHUB_REF})


### PR DESCRIPTION
Hi @jose-elias-alvarez,

I'm sure you've heard this before many times, nevertheless, thank you for your wonderful work :-)

Browsing through the issues (to familirize myself better with the plugin and its lesser known options), I noticed this comment from: https://github.com/jose-elias-alvarez/null-ls.nvim/issues/859#issuecomment-1124124737:

> Because it takes a lot of work to write a separate help page + the existing documentation. There's scripts to convert them automatically but I haven't had the time to look into them, and given the structure of our documentation I'm not sure the conversion would produce good results.

Remebering I also had a similar stance against automated conversions (you can read my initial reaction to the idea... https://github.com/ibhagwan/fzf-lua/pull/81) I thought I'd showcase what I was able to achieve with my improved version of what used to be `babelfish.nvim`, now named [`ts-vimdoc`](https://github.com/ibhagwan/ts-vimdoc.nvim).

At the end of the day I didn't see myself maintining a full-on separate vimdoc file (and I don't think you want that either) and the conversion tools are a very decent compromise.

IMHO, the conversion came out quite nice, aside from some very long titles which can be adjusted in the `.md` file I think it's very workable, the file `null-ls.txt` is the conversion of the main `README.md`, the rest of the txt files under `/doc` are self explanatory, all were generated pretty easily by doing this (which can also be turned into github CI action):
```#
git clone https://github.com/jose-elias-alvarez/null-ls.nvim
git clone https://github.com/ibhagwan/ts-vimdoc.nvim
cd null-ls.nvim
../ts-vimdoc.nvim/scripts/docgen.sh README.md ./doc/null-ls.txt null-ls
../ts-vimdoc.nvim/scripts/docgen.sh doc/CONFIG.md doc/CONFIG.txt null-ls
<repeat for all .md files>
```

There's also the much more mature [`panvimdoc`](https://github.com/kdheepak/panvimdoc) by @khdeepak which I highly recommend, test it out and see which output fits your needs better.

If you don't feel this meets the project's goals, I totally understand but I do beleive there's some added value in having the documentation searchable through `:help`.