### PR TITLE
Fix fourmolu formatting builitin

### DIFF
--- a/lua/null-ls/builtins/formatting/fourmolu.lua
+++ b/lua/null-ls/builtins/formatting/fourmolu.lua
@@ -13,6 +13,7 @@ return h.make_builtin({
     filetypes = { "haskell" },
     generator_opts = {
         command = "fourmolu",
+        args = { "--stdin-input-file", "$FILEPATH" },
         to_stdin = true,
     },
     factory = h.formatter_factory,


### PR DESCRIPTION
I upgraded to Fourmolu 0.7.0.1 and it requires the `--stdin-input-file` argument when using stdin.