### PR TITLE
fix: diagnostics.stylelint not using local binary

### DIFF
--- a/lua/null-ls/builtins/diagnostics/stylelint.lua
+++ b/lua/null-ls/builtins/diagnostics/stylelint.lua
@@ -1,4 +1,5 @@
 local h = require("null-ls.helpers")
+local cmd_resolver = require("null-ls.helpers.command_resolver")
 local methods = require("null-ls.methods")
 
 local DIAGNOSTICS = methods.internal.DIAGNOSTICS
@@ -17,6 +18,7 @@ return h.make_builtin({
         to_stdin = true,
         format = "json_raw",
         from_stderr = true,
+        dynamic_command = cmd_resolver.from_node_modules,
         on_output = function(params)
             local output = params.output and params.output[1] and params.output[1].warnings or {}
 


### PR DESCRIPTION
Hi, thanks for making this awesome plugin!

I noticed `builtins.diagnostics.stylelint` does not look up local installations of Stylelint in `node_modules`.
I fixed it by using the `from_node_modules` command resolver like `builtins.formatting.stylelint` already does.