### PR TITLE
fix: properly parse actionlint path for Windows

### DIFF
--- a/lua/null-ls/builtins/diagnostics/actionlint.lua
+++ b/lua/null-ls/builtins/diagnostics/actionlint.lua
@@ -26,7 +26,7 @@ return h.make_builtin({
             },
         }),
         runtime_condition = h.cache.by_bufnr(function(params)
-            return params.bufname:find(vim.pesc(vim.fn.fnamemodify(".github/workflows", ":."))) ~= nil
+            return params.bufname:find("%.github[\\/]workflows") ~= nil
         end),
     },
     factory = h.generator_factory,

--- a/lua/null-ls/builtins/diagnostics/actionlint.lua
+++ b/lua/null-ls/builtins/diagnostics/actionlint.lua
@@ -26,7 +26,7 @@ return h.make_builtin({
             },
         }),
         runtime_condition = h.cache.by_bufnr(function(params)
-            return params.bufname:find(vim.pesc(".github/workflows")) ~= nil
+            return params.bufname:find(vim.pesc(vim.fn.fnamemodify(".github/workflows", ":."))) ~= nil
         end),
     },
     factory = h.generator_factory,


### PR DESCRIPTION
Use `fnamemodify` to convert the forward slashes to backward slashes in Windows.