### PR TITLE
Add code action and diagnostic builtins for typos

### DIFF
--- a/lua/null-ls/builtins/code_actions/typos.lua
+++ b/lua/null-ls/builtins/code_actions/typos.lua
@@ -1,0 +1,51 @@
+local h = require("null-ls.helpers")
+local methods = require("null-ls.methods")
+
+local CODE_ACTION = methods.internal.CODE_ACTION
+
+local typos_diagnostics = function(bufnr, lnum, cursor_col)
+    local diagnostics = {}
+    for _, diagnostic in ipairs(vim.diagnostic.get(bufnr, { lnum = lnum })) do
+        if diagnostic.source == "typos" and cursor_col >= diagnostic.col and cursor_col < diagnostic.end_col then
+            table.insert(diagnostics, diagnostic)
+        end
+    end
+    return diagnostics
+end
+
+return h.make_builtin({
+    name = "typos",
+    meta = {
+        url = "https://github.com/crate-ci/typos",
+        description = "Source code spell checker written in Rust.",
+    },
+    method = CODE_ACTION,
+    filetypes = {},
+    generator = {
+        fn = function(params)
+            local actions = {}
+            local diagnostics = typos_diagnostics(params.bufnr, params.row - 1, params.col)
+            if vim.tbl_isempty(diagnostics) then
+                return nil
+            end
+            for _, diagnostic in ipairs(diagnostics) do
+                for _, correction in ipairs(diagnostic.user_data.corrections) do
+                    table.insert(actions, {
+                        title = string.format("Use `%s`", correction),
+                        action = function()
+                            vim.api.nvim_buf_set_text(
+                                diagnostic.bufnr,
+                                diagnostic.lnum,
+                                diagnostic.col,
+                                diagnostic.end_lnum,
+                                diagnostic.end_col,
+                                { correction }
+                            )
+                        end,
+                    })
+                end
+            end
+            return actions
+        end,
+    },
+})

--- a/lua/null-ls/builtins/diagnostics/typos.lua
+++ b/lua/null-ls/builtins/diagnostics/typos.lua
@@ -1,0 +1,53 @@
+local h = require("null-ls.helpers")
+local methods = require("null-ls.methods")
+
+local DIAGNOSTICS = methods.internal.DIAGNOSTICS
+
+return h.make_builtin({
+    name = "typos",
+    meta = {
+        url = "https://github.com/crate-ci/typos",
+        description = "Source code spell checker written in Rust.",
+    },
+    method = DIAGNOSTICS,
+    filetypes = {},
+    generator_opts = {
+        command = "typos",
+        args = {
+            "--format",
+            "json",
+            "$FILENAME",
+        },
+        to_stdin = true,
+        format = "line",
+        check_exit_code = function(code)
+            return code == 2
+        end,
+        on_output = function(line, params)
+            local ok, decoded = pcall(vim.json.decode, line)
+            if not ok then
+                return
+            end
+
+            local typo = decoded.typo
+            local col = decoded.byte_offset + 1
+            local corrections = decoded.corrections
+            local message = "`" .. typo .. "` should be "
+
+            for _, correction in ipairs(corrections) do
+                message = message .. "`" .. correction .. "`, "
+            end
+
+            return {
+                row = decoded.line_num,
+                col = col,
+                end_col = col + typo:len(),
+                message = message:gsub(", $", ""),
+                severity = h.diagnostics.severities.error,
+                -- Custom data for the code action builtin
+                user_data = { corrections = corrections },
+            }
+        end,
+    },
+    factory = h.generator_factory,
+})

--- a/test/spec/builtins/diagnostics_spec.lua
+++ b/test/spec/builtins/diagnostics_spec.lua
@@ -1138,6 +1138,25 @@ describe("diagnostics", function()
         end)
     end)
 
+    describe("typos", function()
+        local linter = diagnostics.typos
+        local parser = linter._opts.on_output
+
+        it("should create a diagnostic with error severity", function()
+            local output = [[{"type":"typo","path":"diagnostics_spec.lua","line_num":1154,"byte_offset":32,"typo":"Ba","corrections":["By","Be"]}]]
+            local diagnostic = parser({ output = output })
+            assert.same({
+                {
+                    row = 1154,
+                    col = 33,
+                    end_col = 35,
+                    severity = 1,
+                    message = "`Ba` should be `By`, `Be`",
+                    user_data = { corrections = { "By", "Be" } }
+                },
+            }, diagnostic)
+    end)
+
     describe("opacheck", function()
         local linter = diagnostics.opacheck
         local parser = linter._opts.on_output


### PR DESCRIPTION
[typos](https://github.com/crate-ci/typos) is a code spell checker for common misspelled words written in Rust.

`typos` has a brief format for output which is easier to parse for diagnostic source but I decided to go for json format instead (it outputs 1 json object per typo). The code action is entirely yanked from https://github.com/jose-elias-alvarez/null-ls.nvim/pull/915.

A screenshot for diagnostic:

![2022-08-06-235436_grim](https://user-images.githubusercontent.com/67634026/183258932-a3d2c209-f983-4b9f-8670-cd5390c4058b.png)

And here is the output formats:
```bash
$ typos diagnostics_spec.lua
error: `langauge` should be `language`
  --> diagnostics_spec.lua:757:30
    |
757 |                 message = [["langauge" is a misspelling of "language"]],
    |                              ^^^^^^^^
    |
error: `Ba` should be `By`, `Be`
  --> diagnostics_spec.lua:1154:33
     |
1154 |                     message = "`Ba` should be `By`, `Be`",
     |                                 ^^
     |

$ typos --format brief diagnostics_spec.lua
diagnostics_spec.lua:757:29: `langauge` -> `language`
diagnostics_spec.lua:1154:32: `Ba` -> `By`, `Be`

$ typos --format json diagnostics_spec.lua
{"type":"typo","path":"diagnostics_spec.lua","line_num":757,"byte_offset":29,"typo":"langauge","corrections":["language"]}
{"type":"typo","path":"diagnostics_spec.lua","line_num":1146,"byte_offset":115,"typo":"Ba","corrections":["By","Be"]}
```