### PR TITLE
diagnostics: add LanguageTool support (by ltrs)

### DIFF
--- a/lua/null-ls/builtins/code_actions/ltrs.lua
+++ b/lua/null-ls/builtins/code_actions/ltrs.lua
@@ -1,0 +1,49 @@
+local h = require("null-ls.helpers")
+local methods = require("null-ls.methods")
+
+local CODE_ACTION = methods.internal.CODE_ACTION
+
+local handle_ltrs_output = function(params)
+    local actions = {}
+
+    for _, m in ipairs(params.output.matches) do
+        if m.replacements ~= vim.NIL and params.row == m.moreContext.line_number then
+            local row = m.moreContext.line_number - 1
+            local col_beg = m.moreContext.line_offset
+            local col_end = m.moreContext.line_offset + m.length
+
+            for _, r in ipairs(m.replacements) do
+                if string.find(r.value, "not shown") == nil then
+                    table.insert(actions, {
+                        title = "Replace with “" .. r.value .. "”",
+                        action = function()
+                            vim.api.nvim_buf_set_text(params.bufnr, row, col_beg, row, col_end, { r.value })
+                        end,
+                    })
+                end
+            end
+        end
+    end
+
+    return actions
+end
+
+return h.make_builtin({
+    name = "ltrs",
+    meta = {
+        url = "https://github.com/jeertmans/languagetool-rust",
+        description = "LanguageTool-Rust (LTRS) is both an executable and a Rust library that aims to provide correct and safe bindings for the LanguageTool API.",
+    },
+    method = CODE_ACTION,
+    filetypes = { "text", "markdown" },
+    generator_opts = {
+        command = "ltrs",
+        args = { "check", "-m", "-r", "--text", "$TEXT" },
+        format = "json",
+        check_exit_code = function(c)
+            return c <= 1
+        end,
+        on_output = handle_ltrs_output,
+    },
+    factory = h.generator_factory,
+})

--- a/lua/null-ls/builtins/diagnostics/ltrs.lua
+++ b/lua/null-ls/builtins/diagnostics/ltrs.lua
@@ -1,0 +1,60 @@
+local h = require("null-ls.helpers")
+local methods = require("null-ls.methods")
+
+local DIAGNOSTICS = methods.internal.DIAGNOSTICS
+
+local handle_ltrs_output = function(params)
+    local file = params.output
+    if file and file.matches then
+        local parser = h.diagnostics.from_json({
+            severities = {
+                ERROR = h.diagnostics.severities.error,
+            },
+        })
+
+        local offenses = {}
+
+        for _, m in ipairs(file.matches) do
+            local tip = table.concat(
+                vim.tbl_map(function(r)
+                    return "“" .. r.value .. "”"
+                end, m.replacements),
+                ", "
+            )
+
+            table.insert(offenses, {
+                message = m.message .. " Try: " .. tip,
+                ruleId = m.rule.id,
+                level = "ERROR",
+                line = m.moreContext.line_number,
+                column = m.moreContext.line_offset + 1,
+                endLine = m.moreContext.line_number,
+                endColumn = m.moreContext.line_offset + m.length + 1,
+            })
+        end
+
+        return parser({ output = offenses })
+    end
+
+    return {}
+end
+
+return h.make_builtin({
+    name = "ltrs",
+    meta = {
+        url = "https://github.com/jeertmans/languagetool-rust",
+        description = "LanguageTool-Rust (LTRS) is both an executable and a Rust library that aims to provide correct and safe bindings for the LanguageTool API.",
+    },
+    method = DIAGNOSTICS,
+    filetypes = { "text", "markdown", "markdown" },
+    generator_opts = {
+        command = "ltrs",
+        args = { "check", "-m", "-r", "--text", "$TEXT" },
+        format = "json",
+        check_exit_code = function(c)
+            return c <= 1
+        end,
+        on_output = handle_ltrs_output,
+    },
+    factory = h.generator_factory,
+})


### PR DESCRIPTION
Adding support for LanguageTool. LanguageTool is an online service to help you to correct blocks of text. It is a writing assistant, quite similar to other services like Grammarly.

More info: https://languagetool.org/

I think it can be handy to have an integration in NeoVim to help people to write better documentation, commit messages, etc.

This integration is performed thanks to [languagetool-rust](https://github.com/jeertmans/languagetool-rust/). A Rust implementation that interact with LanguageTool API.

This Null-ls Builtin adds diagnostics and code actions capabilities.

Some screenshots:

![image](https://user-images.githubusercontent.com/135988/181446110-9d6055fb-acfa-4a1f-afb7-49ab9bed0d50.png)
![image](https://user-images.githubusercontent.com/135988/181446163-4d5020c6-9350-46b7-9187-b9da2cc8048e.png)