### PR TITLE
feat(commitlint): add diagnostics for commit messages

### DIFF
--- a/lua/null-ls/builtins/diagnostics/commitlint.lua
+++ b/lua/null-ls/builtins/diagnostics/commitlint.lua
@@ -55,7 +55,7 @@ return h.make_builtin({
         command = "commitlint",
         args = { "--format", "commitlint-format-json" },
         to_stdin = true,
-        format = "json_raw",
+        format = "json",
         check_exit_code = function(code)
             return code <= 1
         end,

--- a/lua/null-ls/builtins/diagnostics/commitlint.lua
+++ b/lua/null-ls/builtins/diagnostics/commitlint.lua
@@ -48,6 +48,10 @@ return h.make_builtin({
     meta = {
         url = "https://commitlint.js.org",
         description = "commitlint checks if your commit messages meet the conventional commit format.",
+        notes = {
+            "Needs npm packages commitlint and a json formatter: `@commitlint/{config-conventional,cli}` and `commitlint-format-json`.",
+            "It works with the packages installed globally but watch out for [some common issues](https://github.com/conventional-changelog/commitlint/issues/613).",
+        },
     },
     method = DIAGNOSTICS,
     filetypes = { "gitcommit" },

--- a/lua/null-ls/builtins/diagnostics/commitlint.lua
+++ b/lua/null-ls/builtins/diagnostics/commitlint.lua
@@ -57,7 +57,7 @@ return h.make_builtin({
         command = "commitlint",
         args = { "--format", "commitlint-format-json" },
         to_stdin = true,
-        format = "json",
+        format = "json_raw",
         check_exit_code = function(code)
             return code <= 1
         end,

--- a/lua/null-ls/builtins/diagnostics/commitlint.lua
+++ b/lua/null-ls/builtins/diagnostics/commitlint.lua
@@ -1,0 +1,67 @@
+local h = require("null-ls.helpers")
+local methods = require("null-ls.methods")
+
+local DIAGNOSTICS = methods.internal.DIAGNOSTICS
+
+local violation_to_diagnostic = function(violation)
+    local diagnostic = nil
+
+    diagnostic = {
+        ruleId = violation.name,
+        message = violation.message,
+        level = violation.level,
+    }
+
+    if violation.name == "body-leading-blank" then
+        diagnostic = vim.tbl_extend("force", diagnostic, { line = 2 })
+    elseif vim.startswith(violation.name, "body") then
+        diagnostic = vim.tbl_extend("force", diagnostic, { line = 3 })
+    end
+
+    return diagnostic
+end
+
+local handle_commitlint_output = function(params)
+    if params.output and params.output.results then
+        local output = params.output.results[1]
+
+        local parser = h.diagnostics.from_json({
+            severities = {
+                [1] = h.diagnostics.severities.warning,
+                [2] = h.diagnostics.severities.error,
+            },
+        })
+
+        local violations = {}
+        for _, violation in ipairs(output.errors) do
+            table.insert(violations, violation_to_diagnostic(violation))
+        end
+
+        for _, violation in ipairs(output.warnings) do
+            table.insert(violations, violation_to_diagnostic(violation))
+        end
+
+        return parser({ output = violations })
+    end
+end
+
+return h.make_builtin({
+    name = "commitlint",
+    meta = {
+        url = "https://commitlint.js.org",
+        description = "commitlint checks if your commit messages meet the conventional commit format.",
+    },
+    method = DIAGNOSTICS,
+    filetypes = { "gitcommit", "text" },
+    generator_opts = {
+        command = "commitlint",
+        args = { "--format", "commitlint-format-json" },
+        to_stdin = true,
+        format = "json",
+        check_exit_code = function(code)
+            return code <= 1
+        end,
+        on_output = handle_commitlint_output,
+    },
+    factory = h.generator_factory,
+})

--- a/lua/null-ls/builtins/diagnostics/commitlint.lua
+++ b/lua/null-ls/builtins/diagnostics/commitlint.lua
@@ -52,7 +52,7 @@ return h.make_builtin({
         description = "commitlint checks if your commit messages meet the conventional commit format.",
     },
     method = DIAGNOSTICS,
-    filetypes = { "gitcommit", "text" },
+    filetypes = { "gitcommit" },
     generator_opts = {
         command = "commitlint",
         args = { "--format", "commitlint-format-json" },

--- a/lua/null-ls/builtins/diagnostics/commitlint.lua
+++ b/lua/null-ls/builtins/diagnostics/commitlint.lua
@@ -4,18 +4,16 @@ local methods = require("null-ls.methods")
 local DIAGNOSTICS = methods.internal.DIAGNOSTICS
 
 local violation_to_diagnostic = function(violation)
-    local diagnostic = nil
-
-    diagnostic = {
+    local diagnostic = {
         ruleId = violation.name,
         message = violation.message,
         level = violation.level,
     }
 
     if violation.name == "body-leading-blank" then
-        diagnostic = vim.tbl_extend("force", diagnostic, { line = 2 })
+        diagnostic.line = 2
     elseif vim.startswith(violation.name, "body") then
-        diagnostic = vim.tbl_extend("force", diagnostic, { line = 3 })
+        diagnostic.line = 3
     end
 
     return diagnostic


### PR DESCRIPTION
[commitlint](https://commitlint.js.org/) checks if your commit messages meet the conventional commit format.

this is a cli tool that doesn't return line numbers. so, i've done some formatting to try and prevent all warnings from showing up on line 0, column 0.

you'll need commitlint and the json formatter packages:

``` shell
yarn global add @commitlint/{config-conventional,cli} 
yarn global add commitlint-format-json
```

then create a `commitlint.config.js` in the root of your project:

``` javascript
const Configuration = {
  extends: ["@commitlint/config-conventional"],
  formatter: "commitlint-format-json",
  rules: {
    "header-max-length": [2, "always", 72],
    "body-max-line-length": [2, "always", 72],
  },
};

module.exports = Configuration;
```

also, you can override the config file with an `extra_args` of `--config` to null-ls. if you don't have a config file, the first lint warning is a helpful guide to creating one.