### PR TITLE
feat(builtin): Add `textlint` formatting

### DIFF
--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -3534,6 +3534,23 @@ local sources = { null_ls.builtins.formatting.terraform_fmt }
 - Command: `terraform`
 - Args: `{ "fmt", "-" }`
 
+### [textlint](https://github.com/textlint/textlint)
+
+The pluggable linting tool for text and Markdown.
+
+#### Usage
+
+```lua
+local sources = { null_ls.builtins.formatting.textlint }
+```
+
+#### Defaults
+
+- Filetypes: `{}`
+- Method: `formatting`
+- Command: `textlint`
+- Args: `{ "--fix", "$FILENAME" }`
+
 ### [tidy](https://www.html-tidy.org/)
 
 Tidy corrects and cleans up HTML and XML documents by fixing markup errors and upgrading legacy code to modern standards.

--- a/lua/null-ls/builtins/formatting/textlint.lua
+++ b/lua/null-ls/builtins/formatting/textlint.lua
@@ -1,0 +1,20 @@
+local h = require("null-ls.helpers")
+local methods = require("null-ls.methods")
+
+local FORMATTING = methods.internal.FORMATTING
+
+return h.make_builtin({
+    name = "textlint",
+    meta = {
+        url = "https://github.com/textlint/textlint",
+        description = "The pluggable linting tool for text and Markdown.",
+    },
+    method = FORMATTING,
+    filetypes = {},
+    generator_opts = {
+        command = "textlint",
+        args = { "--fix", "$FILENAME" },
+        to_temp_file = true,
+    },
+    factory = h.formatter_factory,
+})


### PR DESCRIPTION
I implemented textlint formatting with reference to #532 and [markdownlint](https://github.com/jose-elias-alvarez/null-ls.nvim/blob/8c90ccf7ffbdeb49da415837ec45e6ac457d5c60/lua/null-ls/builtins/formatting/markdownlint.lua).