### PR TITLE
Use stdin for npm-groovy-lint and add filetype

### DIFF
--- a/lua/null-ls/builtins/formatting/npm_groovy_lint.lua
+++ b/lua/null-ls/builtins/formatting/npm_groovy_lint.lua
@@ -10,11 +10,11 @@ return h.make_builtin({
         description = "Lint, format and auto-fix Groovy, Jenkinsfile, and Gradle files.",
     },
     method = FORMATTING,
-    filetypes = { "groovy", "java" },
+    filetypes = { "groovy", "java", "Jenkinsfile" },
     generator_opts = {
         command = "npm-groovy-lint",
-        args = { "--format", "--files", "$FILENAME" },
-        to_temp_file = true,
+        args = { "--format", "-" },
+        to_stdin = true,
     },
     factory = h.formatter_factory,
 })


### PR DESCRIPTION
Following couple of issues I created for npm-groovy-lint to accept stdout and single filenames:
https://github.com/nvuillam/npm-groovy-lint/pull/236
https://github.com/nvuillam/npm-groovy-lint/issues/227
npm-groovy-lint now works better with stdin and all.
Also, `Jenkinsfile` is a valid filetype for groovy formatting, this should be enabled by default.
Thanks!