### PR TITLE
feat: buf format via stdin

### DIFF
--- a/lua/null-ls/builtins/formatting/buf.lua
+++ b/lua/null-ls/builtins/formatting/buf.lua
@@ -10,14 +10,12 @@ return h.make_builtin({
         description = "A new way of working with Protocol Buffers.",
     },
     method = FORMATTING,
-    to_temp_file = true,
-    from_temp_file = true,
+    to_stdin = true,
     filetypes = { "proto" },
     generator_opts = {
         command = "buf",
         args = {
             "format",
-            "-w",
             "$FILENAME",
         },
     },


### PR DESCRIPTION
[buf](https://buf.build/) now support format files via stdin.

This would be more efficient than the current temp_file settings. (Additionally, temp_file settings don't work out-of-the-box in my environment)