### PR TITLE
Add FILENAME to dprint --stdin

### DIFF
--- a/lua/null-ls/builtins/formatting/dprint.lua
+++ b/lua/null-ls/builtins/formatting/dprint.lua
@@ -29,6 +29,7 @@ return h.make_builtin({
         args = {
             "fmt",
             "--stdin",
+            "$FILENAME",
         },
         to_stdin = true,
     },


### PR DESCRIPTION
dprint currently does not work with null-ls. This is because --stdin needs the filename to determine the filetype and use the configuration file of the project.

See https://dprint.dev/cli/ under "Formatting Standard Input":
> Use dprint fmt --stdin <file-path/file-name/extension> and provide the input file text to stdin. The output will be directed by the CLI to stdout.
> Provide a full file path to format with inclusion/exclusion rules of your dprint configuration file or provide only a file name or extension to always format the file.