### PR TITLE
Adds default file patterns to ktlint (#1044)

### DIFF
--- a/lua/null-ls/builtins/diagnostics/ktlint.lua
+++ b/lua/null-ls/builtins/diagnostics/ktlint.lua
@@ -16,6 +16,8 @@ return h.make_builtin({
         args = {
             "--relative",
             "--reporter=json",
+            "**/*.kt",
+            "**/*.kts",
         },
         to_stdin = true,
         format = "json",

--- a/lua/null-ls/builtins/formatting/ktlint.lua
+++ b/lua/null-ls/builtins/formatting/ktlint.lua
@@ -16,6 +16,8 @@ return h.make_builtin({
         args = {
             "--format",
             "--stdin",
+            "**/*.kt",
+            "**/*.kts",
         },
         to_stdin = true,
     },


### PR DESCRIPTION
This resolves issue #1044 by adding the default file patterns to the ktlint executable params. 

There's a info log that outputs if these are missing, so if we add these then that goes away. Since these are the default, adding them in is the same as not adding them in.