### PR TITLE
Enforce absolute paths in phpcs output 

### DIFF
--- a/lua/null-ls/builtins/diagnostics/phpcs.lua
+++ b/lua/null-ls/builtins/diagnostics/phpcs.lua
@@ -28,7 +28,8 @@ return h.make_builtin({
             "1",
             -- process stdin
             "--stdin-path=$FILENAME",
-            "-",
+            -- get absolute paths under params.output.files
+            "--basepath=",
         },
         format = "json_raw",
         to_stdin = true,


### PR DESCRIPTION
When using a configuration file to configure the basepath, like for instance here: https://github.com/doctrine/collections/blob/c2a8c5f0f806cc467b1103a418db3e73815e83b6/phpcs.xml.dist#L3, no diagnostic appears.
Overriding it again in the CLI allows to get absolute paths, and fixes the issue.