### PR TITLE
feat(diagnostics): add cpplint

### DIFF
--- a/lua/null-ls/builtins/diagnostics/cpplint.lua
+++ b/lua/null-ls/builtins/diagnostics/cpplint.lua
@@ -1,0 +1,37 @@
+local h = require("null-ls.helpers")
+local methods = require("null-ls.methods")
+
+local DIAGNOSTICS = methods.internal.DIAGNOSTICS
+
+return h.make_builtin({
+    name = "cpplint",
+    meta = {
+        url = "https://github.com/cpplint/cpplint",
+        description = "Cpplint is a command-line tool to check C/C++ files for style issues following Google's C++ style guide",
+    },
+    method = DIAGNOSTICS,
+    filetypes = { "cpp", "c" },
+    generator_opts = {
+        command = "cpplint",
+        args = {
+            "$FILENAME",
+        },
+        format = "line",
+        to_stdin = false,
+        from_stderr = true,
+        to_temp_file = true,
+        on_output = h.diagnostics.from_pattern("[^:]+:(%d+):  (.+)  %[(.+)%/.+%] %[%d+%]", { "row", "message", "severity" }, {
+            severities = {
+                build = h.diagnostics.severities["warning"],
+                whitespace = h.diagnostics.severities["hint"],
+                runtime = h.diagnostics.severities["warning"],
+                legal = h.diagnostics.severities["information"],
+                readability = h.diagnostics.severities["information"]
+            },
+        }),
+        check_exit_code = function(code)
+            return code >= 1
+        end,
+    },
+    factory = h.generator_factory,
+})


### PR DESCRIPTION
[cpplint](https://github.com/cpplint/cpplint) support, which mentioned at https://github.com/jose-elias-alvarez/null-ls.nvim/issues/508

Tested with `cpplint` that installed by `brew` and [`Mason`](https://github.com/williamboman/mason.nvim)

Preview:
<img width="1347" alt="image" src="https://user-images.githubusercontent.com/16725418/186987468-c9f3491d-4b64-4669-a6eb-1c038aed09b6.png">
