### PR TITLE
Fix #1052

### DIFF
--- a/lua/null-ls/rpc.lua
+++ b/lua/null-ls/rpc.lua
@@ -159,6 +159,12 @@ M.start = function(dispatchers)
                 stopped = true
             end,
         },
+        is_closing = function()
+            return stopped
+        end,
+        terminate = function()
+            stopped = true
+        end,
     }
 end
 


### PR DESCRIPTION
Fix  #1052  null-ls is incompatible with the latest nightly: attempt to call field 'is_closing'