### PR TITLE
remove exit code checking from sqlfluff

### DIFF
--- a/lua/null-ls/builtins/diagnostics/sqlfluff.lua
+++ b/lua/null-ls/builtins/diagnostics/sqlfluff.lua
@@ -31,9 +31,6 @@ local sources = {
         from_stderr = true,
         to_stdin = true,
         format = "json",
-        check_exit_code = function(c)
-            return c <= 1
-        end,
         on_output = helpers.diagnostics.from_json({
             attributes = {
                 row = "line",


### PR DESCRIPTION
I never get diagnostic information unless I remove the `check_exit_code` from the `sqlfluff` configuration.