### PR TITLE
fix sqlfluff diagnostics

### DIFF
--- a/lua/null-ls/builtins/diagnostics/sqlfluff.lua
+++ b/lua/null-ls/builtins/diagnostics/sqlfluff.lua
@@ -28,7 +28,7 @@ local sources = {
             "--disable_progress_bar",
             "-",
         },
-        from_stderr = true,
+        from_stderr = false,
         to_stdin = true,
         format = "json",
         check_exit_code = function(c)


### PR DESCRIPTION
This is coming from #1054. 

While I don't know yet which part of the spawn / generator-factory leads to the output being ignored here,

but I definitely know that sqlfluff _does_ output to `stdout`.

And setting `from_stderr=false` solves the issue that diagnostics are not shown. 