### PR TITLE
fix(builtins): fix tidy diagnostics lang spec

### DIFF
--- a/lua/null-ls/builtins/diagnostics/tidy.lua
+++ b/lua/null-ls/builtins/diagnostics/tidy.lua
@@ -23,6 +23,8 @@ return h.make_builtin({
             local common_args = {
                 "-quiet",
                 "-errors",
+                "-lang",
+                "en",
             }
 
             if params.ft == "xml" then


### PR DESCRIPTION
Add option -lang en to the call to tidy to get right output.
Fix #1064 