### PR TITLE
feat(hover): add support for printenv

### DIFF
--- a/lua/null-ls/builtins/hover/printenv.lua
+++ b/lua/null-ls/builtins/hover/printenv.lua
@@ -12,16 +12,14 @@ return h.make_builtin({
             -- Get word under cursor
             local cword = vim.fn.expand("<cword>")
 
-            -- Gets table of environment variables
-            local env_vars = vim.fn.environ()
-
-            -- Checks if cword is in table of environment variables
-            -- If not in table of environment variables, show in hover window "Error! `cword` is not an environment variable!"
-            -- Else show in hover window value of environment variable
-            if env_vars[cword] == nil then
-                done({ "Error! " .. cword .. " is not an environment variable!" })
+            -- Checks if cword is an environment variable
+            -- If cword is environment variable and value not nil, show in hover window value of environment variable
+            -- Else show in hover window "Error! `cword` is not an environment variable!"
+            local ok, value = pcall(vim.loop.os_getenv, cword)
+            if ok and (value ~= nil) then
+                done({ cword .. ": " .. value })
             else
-                done({ cword .. ": " .. env_vars[cword] })
+                done({ "Error! " .. cword .. " is not an environment variable!" })
             end
         end,
         async = true,
@@ -29,7 +27,7 @@ return h.make_builtin({
     meta = {
         description = "Shows the value for the current environment variable under the cursor.",
         notes = {
-            "This source is similar in function to `printenv` where it shows value of environment variable, however this source uses `vim.fn.environ()` instead of `printenv` thus making it cross-platform.",
+            "This source is similar in function to `printenv` where it shows value of environment variable, however this source uses `vim.loop.os_getenv` instead of `printenv` thus making it cross-platform.",
         },
     },
 })

--- a/lua/null-ls/builtins/hover/printenv.lua
+++ b/lua/null-ls/builtins/hover/printenv.lua
@@ -1,0 +1,35 @@
+local h = require("null-ls.helpers")
+local methods = require("null-ls.methods")
+
+local HOVER = methods.internal.HOVER
+
+return h.make_builtin({
+    name = "printenv",
+    method = HOVER,
+    filetypes = { "sh", "dosbatch", "ps1" },
+    generator = {
+        fn = function(_, done)
+            -- Get word under cursor
+            local cword = vim.fn.expand("<cword>")
+
+            -- Gets table of environment variables
+            local env_vars = vim.fn.environ()
+
+            -- Checks if cword is in table of environment variables
+            -- If not in table of environment variables, show in hover window "Error! `cword` is not an environment variable!"
+            -- Else show in hover window value of environment variable
+            if env_vars[cword] == nil then
+                done({ "Error! " .. cword .. " is not an environment variable!" })
+            else
+                done({ cword .. ": " .. env_vars[cword] })
+            end
+        end,
+        async = true,
+    },
+    meta = {
+        description = "Shows the value for the current environment variable under the cursor.",
+        notes = {
+            "This source is similar in function to `printenv` where it shows value of environment variable, however this source uses `vim.fn.environ()` instead of `printenv` thus making it cross-platform.",
+        },
+    },
+})


### PR DESCRIPTION
Shows the value for the current environment variable under the cursor.

This source is similar in function to `printenv` where it shows value of environment variable, however this source uses `vim.fn.environ()` instead of `printenv` thus making it cross-platform.