### PR TITLE
fix(builtins): allow use of local .sqlfluff file

### DIFF
--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -1455,11 +1455,11 @@ local sources = {
 - Filetypes: `{ "sql" }`
 - Method: `diagnostics`
 - Command: `sqlfluff`
-- Args: `{ "lint", "-f", "github-annotation", "-n", "--disable_progress_bar", "-" }`
+- Args: `{ "lint", "-f", "github-annotation", "-n", "--disable_progress_bar" }`
 
 #### Notes
 
-- SQLFluff needs a mandatory `--dialect` argument. Use `extra_args` to add yours. `extra_args` can also be a function to build more sophisticated logic.
+- SQLFluff needs a mandatory `--dialect` argument. Use `extra_args` to add yours, or create a .sqlfluff file in the same directory as the SQL file to specify the dialect (see the sqlfluff docs for details). `extra_args` can also be a function to build more sophisticated logic.
 
 ### [standardjs](https://standardjs.com/)
 

--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -1455,7 +1455,7 @@ local sources = {
 - Filetypes: `{ "sql" }`
 - Method: `diagnostics`
 - Command: `sqlfluff`
-- Args: `{ "lint", "-f", "github-annotation", "-n", "--disable_progress_bar" }`
+- Args: `{ "lint", "-f", "github-annotation", "-n", "--disable_progress_bar", "$FILENAME" }`
 
 #### Notes
 

--- a/lua/null-ls/builtins/diagnostics/sqlfluff.lua
+++ b/lua/null-ls/builtins/diagnostics/sqlfluff.lua
@@ -26,9 +26,11 @@ local sources = {
             "github-annotation",
             "-n",
             "--disable_progress_bar",
+            "$FILENAME"
         },
         from_stderr = false,
         to_stdin = false,
+        to_temp_file = true,
         format = "json",
         check_exit_code = function(c)
             return c <= 1

--- a/lua/null-ls/builtins/diagnostics/sqlfluff.lua
+++ b/lua/null-ls/builtins/diagnostics/sqlfluff.lua
@@ -7,7 +7,7 @@ return helpers.make_builtin({
         url = "https://github.com/sqlfluff/sqlfluff",
         description = "A SQL linter and auto-formatter for Humans",
         notes = {
-            "SQLFluff needs a mandatory `--dialect` argument. Use `extra_args` to add yours. `extra_args` can also be a function to build more sophisticated logic.",
+            "SQLFluff needs a mandatory `--dialect` argument. Use `extra_args` to add yours, or create a .sqlfluff file in the same directory as the SQL file to specify the dialect (see the sqlfluff docs for details). `extra_args` can also be a function to build more sophisticated logic.",
         },
         usage = [[
 local sources = {
@@ -26,10 +26,9 @@ local sources = {
             "github-annotation",
             "-n",
             "--disable_progress_bar",
-            "-",
         },
         from_stderr = false,
-        to_stdin = true,
+        to_stdin = false,
         format = "json",
         check_exit_code = function(c)
             return c <= 1


### PR DESCRIPTION
The previous behaviour had null-ls pass in the contents of a SQL file to stdin. This doesn't work if the user has created a local .sqlfluff file (for example to specify the dialect), as sqlfluff cannot tell where the file is on the filesystem. This commit changes that behaviour.