### PR TITLE
Revert "fix(utils): resolve symlinks before testing executable bit"

### DIFF
--- a/lua/null-ls/utils.lua
+++ b/lua/null-ls/utils.lua
@@ -85,7 +85,7 @@ end
 ---@param cmd string? command to check
 ---@return boolean, string is_executable, string|nil error_message
 M.is_executable = function(cmd)
-    if cmd and vim.fn.executable(vim.fn.resolve(vim.fn.exepath(cmd))) == 1 then
+    if cmd and vim.fn.executable(cmd) == 1 then
         return true
     end
 

--- a/test/spec/utils_spec.lua
+++ b/test/spec/utils_spec.lua
@@ -104,12 +104,8 @@ describe("utils", function()
 
     describe("is_executable", function()
         local executable
-        local resolve
-        local exepath
         before_each(function()
             executable = stub(vim.fn, "executable")
-            resolve = stub(vim.fn, "resolve")
-            exepath = stub(vim.fn, "exepath")
         end)
         after_each(function()
             executable:revert()
@@ -117,13 +113,9 @@ describe("utils", function()
 
         it("should call executable with command", function()
             executable.returns(0)
-            resolve.returns("mock-command")
-            exepath.returns("mock-command")
 
             u.is_executable("mock-command")
 
-            assert.stub(exepath).was_called_with("mock-command")
-            assert.stub(resolve).was_called_with("mock-command")
             assert.stub(executable).was_called_with("mock-command")
         end)
 


### PR DESCRIPTION
Reverts jose-elias-alvarez/null-ls.nvim#1017. @jceb 

I believe this is the cause of the issues described in #1047, though I don't know exactly why. If I had to guess, I'd say that `vim.fn.resolve` and `vim.fn.exepath` have different behavior on different platforms, so one potential alternative  would be to use libuv's [fs_realpath](https://github.com/luvit/luv/blob/master/docs.md#uvfs_realpathpath-callback). Either way, I think it's safest to revert this for now. 