### PR TITLE
fix!: update command resolver signature to fix caching

### DIFF
--- a/lua/null-ls/builtins/code_actions/eslint.lua
+++ b/lua/null-ls/builtins/code_actions/eslint.lua
@@ -166,7 +166,7 @@ return h.make_builtin({
             params.messages = output[1].messages
             return code_action_handler(params)
         end,
-        dynamic_command = cmd_resolver.from_node_modules,
+        dynamic_command = cmd_resolver.from_node_modules(),
         cwd = h.cache.by_bufnr(function(params)
             return u.root_pattern(
                 -- https://eslint.org/docs/user-guide/configuring/configuration-files#configuration-file-formats

--- a/lua/null-ls/builtins/diagnostics/eslint.lua
+++ b/lua/null-ls/builtins/diagnostics/eslint.lua
@@ -42,7 +42,7 @@ return h.make_builtin({
         end,
         use_cache = true,
         on_output = handle_eslint_output,
-        dynamic_command = cmd_resolver.from_node_modules,
+        dynamic_command = cmd_resolver.from_node_modules(),
         cwd = h.cache.by_bufnr(function(params)
             return u.root_pattern(
                 -- https://eslint.org/docs/user-guide/configuring/configuration-files#configuration-file-formats

--- a/lua/null-ls/builtins/diagnostics/puglint.lua
+++ b/lua/null-ls/builtins/diagnostics/puglint.lua
@@ -34,7 +34,7 @@ return h.make_builtin({
                 groups = { "filename", "row", "col", "message" },
             },
         }),
-        dynamic_command = cmd_resolver.from_node_modules,
+        dynamic_command = cmd_resolver.from_node_modules(),
     },
     factory = h.generator_factory,
 })

--- a/lua/null-ls/builtins/diagnostics/standardjs.lua
+++ b/lua/null-ls/builtins/diagnostics/standardjs.lua
@@ -41,7 +41,7 @@ return h.make_builtin({
                 },
             },
         }),
-        dynamic_command = cmd_resolver.from_node_modules,
+        dynamic_command = cmd_resolver.from_node_modules(),
     },
     factory = h.generator_factory,
 })

--- a/lua/null-ls/builtins/diagnostics/stylelint.lua
+++ b/lua/null-ls/builtins/diagnostics/stylelint.lua
@@ -18,7 +18,7 @@ return h.make_builtin({
         to_stdin = true,
         format = "json_raw",
         from_stderr = true,
-        dynamic_command = cmd_resolver.from_node_modules,
+        dynamic_command = cmd_resolver.from_node_modules(),
         on_output = function(params)
             local output = params.output and params.output[1] and params.output[1].warnings or {}
 

--- a/lua/null-ls/builtins/diagnostics/stylint.lua
+++ b/lua/null-ls/builtins/diagnostics/stylint.lua
@@ -28,7 +28,7 @@ return h.make_builtin({
                 groups = { "row", "col", "severity", "message" },
             },
         }),
-        dynamic_command = cmd_resolver.from_node_modules,
+        dynamic_command = cmd_resolver.from_node_modules(),
     },
     factory = h.generator_factory,
 })

--- a/lua/null-ls/builtins/formatting/eslint.lua
+++ b/lua/null-ls/builtins/formatting/eslint.lua
@@ -42,7 +42,7 @@ return h.make_builtin({
                     },
                 }
         end,
-        dynamic_command = cmd_resolver.from_node_modules,
+        dynamic_command = cmd_resolver.from_node_modules(),
         check_exit_code = { 0, 1 },
         cwd = h.cache.by_bufnr(function(params)
             return u.root_pattern(

--- a/lua/null-ls/builtins/formatting/prettier.lua
+++ b/lua/null-ls/builtins/formatting/prettier.lua
@@ -41,7 +41,7 @@ return h.make_builtin({
             "$FILENAME",
         }, "--range-start", "--range-end", { row_offset = -1, col_offset = -1 }),
         to_stdin = true,
-        dynamic_command = cmd_resolver.from_node_modules,
+        dynamic_command = cmd_resolver.from_node_modules(),
         cwd = h.cache.by_bufnr(function(params)
             return u.root_pattern(
                 -- https://prettier.io/docs/en/configuration.html

--- a/lua/null-ls/builtins/formatting/prettier_d_slim.lua
+++ b/lua/null-ls/builtins/formatting/prettier_d_slim.lua
@@ -43,7 +43,7 @@ return h.make_builtin({
             { row_offset = -1, col_offset = -1 }
         ),
         to_stdin = true,
-        dynamic_command = cmd_resolver.from_node_modules,
+        dynamic_command = cmd_resolver.from_node_modules(),
         cwd = h.cache.by_bufnr(function(params)
             return u.root_pattern(
                 -- https://prettier.io/docs/en/configuration.html

--- a/lua/null-ls/builtins/formatting/prettier_standard.lua
+++ b/lua/null-ls/builtins/formatting/prettier_standard.lua
@@ -17,7 +17,7 @@ return h.make_builtin({
         command = "prettier-standard",
         args = { "--stdin" },
         to_stdin = true,
-        dynamic_command = cmd_resolver.from_node_modules,
+        dynamic_command = cmd_resolver.from_node_modules(),
         cwd = h.cache.by_bufnr(function(params)
             return u.root_pattern(
                 -- https://prettier.io/docs/en/configuration.html

--- a/lua/null-ls/builtins/formatting/prettierd.lua
+++ b/lua/null-ls/builtins/formatting/prettierd.lua
@@ -32,7 +32,7 @@ return h.make_builtin({
     generator_opts = {
         command = "prettierd",
         args = { "$FILENAME" },
-        dynamic_command = cmd_resolver.from_node_modules,
+        dynamic_command = cmd_resolver.from_node_modules(),
         to_stdin = true,
         cwd = h.cache.by_bufnr(function(params)
             return u.root_pattern(

--- a/lua/null-ls/builtins/formatting/rescript.lua
+++ b/lua/null-ls/builtins/formatting/rescript.lua
@@ -19,7 +19,7 @@ return h.make_builtin({
         args = function(params)
             return { "format", "-stdin", "." .. vim.fn.fnamemodify(params.bufname, ":e") }
         end,
-        dynamic_command = cmd_resolver.from_node_modules,
+        dynamic_command = cmd_resolver.from_node_modules(),
         to_stdin = true,
     },
     factory = h.formatter_factory,

--- a/lua/null-ls/builtins/formatting/rustywind.lua
+++ b/lua/null-ls/builtins/formatting/rustywind.lua
@@ -24,7 +24,7 @@ return h.make_builtin({
         command = "rustywind",
         args = { "--stdin" },
         to_stdin = true,
-        dynamic_command = cmd_resolver.from_node_modules,
+        dynamic_command = cmd_resolver.from_node_modules(),
     },
     factory = h.formatter_factory,
 })

--- a/lua/null-ls/builtins/formatting/standardjs.lua
+++ b/lua/null-ls/builtins/formatting/standardjs.lua
@@ -16,7 +16,7 @@ return h.make_builtin({
         command = "standard",
         args = { "--stdin", "--fix" },
         to_stdin = true,
-        dynamic_command = cmd_resolver.from_node_modules,
+        dynamic_command = cmd_resolver.from_node_modules(),
     },
     factory = h.formatter_factory,
 })

--- a/lua/null-ls/builtins/formatting/stylelint.lua
+++ b/lua/null-ls/builtins/formatting/stylelint.lua
@@ -17,7 +17,7 @@ return h.make_builtin({
         args = { "--fix", "--stdin", "--stdin-filename", "$FILENAME" },
         to_stdin = true,
         from_stderr = true,
-        dynamic_command = cmd_resolver.from_node_modules,
+        dynamic_command = cmd_resolver.from_node_modules(),
     },
     factory = h.formatter_factory,
 })

--- a/lua/null-ls/helpers/make_builtin.lua
+++ b/lua/null-ls/helpers/make_builtin.lua
@@ -81,7 +81,7 @@ local function make_builtin(opts)
     if prefer_local or only_local then
         local maybe_prefix = prefer_local or only_local
         local prefix = type(maybe_prefix) == "string" and maybe_prefix or nil
-        local resolver = cmd_resolver.make_generic_resolver(prefix)
+        local resolver = cmd_resolver.generic(prefix)
 
         generator_opts.dynamic_command = function(params)
             local resolved_command = resolver(params) or (prefer_local and params.command)


### PR DESCRIPTION
Follow-up to #1063. I tried to avoid breaking the signature of existing command resolvers, but the structure wasn't compatible with the `by_bufnr` cache helper. 

This change means that anyone using `from_node_modules` or `from_yarn_pnp` directly needs to update their usage a bit:

```lua
local null_ls = require("null-ls")
local command_resolver = require("null-ls.helpers.command_resolver")

local prettier = null_ls.builtins.formatting.prettier.with({
    -- old
    -- dynamic_command = command_resolver.from_node_modules,

    -- new
    dynamic_command = command_resolver.from_node_modules(),
})
```