### PR TITLE
feat(loop): create temp files at source location

### DIFF
--- a/lua/null-ls/helpers/generator_factory.lua
+++ b/lua/null-ls/helpers/generator_factory.lua
@@ -18,7 +18,7 @@ local get_content = function(params)
     end
 
     -- otherwise, get content directly
-    return u.buf.content(params.bufnr, true)
+    return u.buf.content(params.bufnr, true) --[[@as string]]
 end
 
 local parse_args = function(args, params)
@@ -306,23 +306,13 @@ return function(opts)
             }
 
             if to_temp_file then
-                local filename = vim.fn.fnamemodify(params.bufname, ":e")
-                local temp_path, cleanup = loop.temp_file(get_content(params), filename)
+                local content = get_content(params)
+                local temp_path, cleanup = loop.temp_file(content, params.bufname)
 
                 spawn_opts.on_stdout_end = function()
                     if from_temp_file then
-                        -- wrap to make sure temp file is always cleaned up
-                        local ok, err = pcall(function()
-                            local fd = vim.loop.fs_open(temp_path, "r", 438)
-                            local stat = vim.loop.fs_fstat(fd)
-                            params.output = vim.loop.fs_read(fd, stat.size, 0)
-                            vim.loop.fs_close(fd)
-                        end)
-                        if not ok then
-                            log:warn("failed to read from temp file: " .. err)
-                        end
+                        params.output = loop.read_file(temp_path)
                     end
-
                     cleanup()
                 end
                 params.temp_path = temp_path

--- a/lua/null-ls/loop.lua
+++ b/lua/null-ls/loop.lua
@@ -48,7 +48,8 @@ M.spawn = function(cmd, args, opts)
     local handler, input, check_exit_code, timeout, on_stdout_end, env =
         opts.handler, opts.input, opts.check_exit_code, opts.timeout, opts.on_stdout_end, opts.env
 
-    local output, error_output = "", ""
+    local output, error_output
+    output, error_output = "", ""
     local handle_stdout = function(err, chunk)
         if err then
             on_error("stdout", err)
@@ -203,64 +204,45 @@ M.timer = function(timeout, interval, should_start, callback)
     }
 end
 
-local tmp_dir
-local get_temp_dir = function()
-    if tmp_dir then
-        return tmp_dir
-    end
+--- creates a temp file at a given file's location
+---@param content string
+---@param bufname string
+---@return string temp_path, fun() cleanup
+M.temp_file = function(content, bufname)
+    local dirname = vim.fn.fnamemodify(bufname, ":h")
+    local base_name = vim.fn.fnamemodify(bufname, ":t")
 
-    if u.path.is_windows then
-        tmp_dir = vim.env.TEMP
-        return tmp_dir
-    end
+    local filename = string.format("_null-ls_%d_%s", math.random(100000, 999999), base_name)
+    local temp_path = u.path.join(dirname, filename)
 
-    local xdg_runtime_dir = vim.env.XDG_RUNTIME_DIR
-    if xdg_runtime_dir then
-        tmp_dir = xdg_runtime_dir .. "/nvim"
-        if uv.fs_stat(tmp_dir) == nil then
-            uv.fs_mkdir(tmp_dir, tonumber("700", 8))
-        end
-        return tmp_dir
-    end
-
-    tmp_dir = "/tmp"
-    return tmp_dir
-end
-
-M._revert_tmp_dir = function()
-    tmp_dir = nil
-end
-
-M.temp_file = function(content, extension)
-    local fd, tmp_path
-    if uv.fs_mkstemp then
-        -- prefer fs_mkstemp, since we can modify the directory
-        fd, tmp_path = uv.fs_mkstemp(u.path.join(get_temp_dir(), "null-ls_XXXXXX"))
-    else
-        -- fall back to os.tmpname, which is Unix-only
-        tmp_path = os.tmpname()
-    end
-
-    -- close handle if open and rename temp file to add extension
-    if extension then
-        if fd then
-            uv.fs_close(fd)
-            fd = nil
-        end
-
-        local path_with_ext = tmp_path .. "." .. extension
-        uv.fs_rename(tmp_path, path_with_ext)
-        tmp_path = path_with_ext
-    end
-
-    -- if not open, open with (0700) permissions
-    fd = fd or uv.fs_open(tmp_path, "w", 384)
+    local fd = uv.fs_open(temp_path, "w", 384)
     uv.fs_write(fd, content, -1)
     uv.fs_close(fd)
 
-    return tmp_path, function()
-        uv.fs_unlink(tmp_path)
+    local cleanup = function()
+        uv.fs_unlink(temp_path)
     end
+
+    return temp_path, cleanup
+end
+
+--- read from file at path
+---@param path string
+---@return string content
+M.read_file = function(path)
+    local content
+    local ok, err = pcall(function()
+        local fd = uv.fs_open(path, "r", 438)
+        local stat = uv.fs_fstat(fd)
+        content = uv.fs_read(fd, stat.size, 0)
+        uv.fs_close(fd)
+    end)
+
+    if not ok then
+        log:error(string.format("failed to read from file at %s: %s ", path, err))
+    end
+
+    return content or ""
 end
 
 ---@param path string

--- a/test/spec/helpers/generator_factory_spec.lua
+++ b/test/spec/helpers/generator_factory_spec.lua
@@ -1,3 +1,4 @@
+local mock = require("luassert.mock")
 local stub = require("luassert.stub")
 
 local c = require("null-ls.config")
@@ -5,12 +6,15 @@ local helpers = require("null-ls.helpers")
 local loop = require("null-ls.loop")
 local s = require("null-ls.state")
 
+mock(require("null-ls.logger"), true)
+
 local test_utils = require("null-ls.test-utils")
 local root = vim.fn.getcwd()
 
 describe("generator_factory", function()
     stub(loop, "spawn")
     stub(loop, "temp_file")
+    stub(loop, "read_file")
     stub(s, "get_cache")
     stub(s, "set_cache")
 
@@ -40,6 +44,7 @@ describe("generator_factory", function()
 
         loop.spawn:clear()
         loop.temp_file:clear()
+        loop.read_file:clear()
 
         s.get_cache:clear()
         s.set_cache:clear()
@@ -574,8 +579,8 @@ describe("generator_factory", function()
                 cleanup:clear()
             end)
 
-            it("should call loop.temp_file with content and file extension", function()
-                assert.stub(loop.temp_file).was_called_with("buffer content", "lua")
+            it("should call loop.temp_file with content and bufname", function()
+                assert.stub(loop.temp_file).was_called_with("buffer content", params.bufname)
             end)
 
             it("should replace $FILENAME arg with temp path", function()
@@ -597,20 +602,11 @@ describe("generator_factory", function()
 
         describe("from_temp_file", function()
             local cleanup = stub.new()
-            stub(vim.loop, "fs_open")
-            stub(vim.loop, "fs_fstat")
-            stub(vim.loop, "fs_read")
-            stub(vim.loop, "fs_close")
-
-            local mock_fd = 99
-            local mock_stat = { size = 100 }
 
             local params
             local on_stdout_end
             before_each(function()
                 loop.temp_file.returns("temp-path", cleanup)
-                vim.loop.fs_open.returns(99)
-                vim.loop.fs_fstat.returns(mock_stat)
 
                 generator_opts.to_temp_file = true
                 generator_opts.from_temp_file = true
@@ -621,22 +617,17 @@ describe("generator_factory", function()
                 on_stdout_end = loop.spawn.calls[1].refs[3].on_stdout_end
             end)
             after_each(function()
-                vim.loop.fs_open:clear()
-                vim.loop.fs_fstat:clear()
                 cleanup:clear()
             end)
 
-            it("should call vim.loop methods", function()
+            it("should call loop.read_file with temp path", function()
                 on_stdout_end()
 
-                assert.stub(vim.loop.fs_open).was_called_with("temp-path", "r", 438)
-                assert.stub(vim.loop.fs_fstat).was_called_with(mock_fd)
-                assert.stub(vim.loop.fs_read).was_called_with(mock_fd, mock_stat.size, 0)
-                assert.stub(vim.loop.fs_close).was_called_with(mock_fd)
+                assert.stub(loop.read_file).was_called_with("temp-path")
             end)
 
             it("should set params.output to temp file content", function()
-                vim.loop.fs_read.returns("content")
+                loop.read_file.returns("content")
 
                 on_stdout_end()
 

--- a/test/spec/loop_spec.lua
+++ b/test/spec/loop_spec.lua
@@ -1,12 +1,15 @@
 local stub = require("luassert.stub")
 local mock = require("luassert.mock")
 
-local u = require("null-ls.utils")
-
 local uv = mock(vim.loop, true)
 
 describe("loop", function()
     stub(vim, "schedule_wrap")
+
+    local random = stub(math, "random")
+    local mock_random = 123456
+    random.returns(mock_random)
+
     after_each(function()
         vim.schedule_wrap:clear()
         uv.os_environ.returns({})
@@ -581,127 +584,42 @@ describe("loop", function()
 
     describe("temp_file", function()
         local mock_content = "write me to a temp file"
-        local mock_fd, mock_path = 57, "/tmp/null-ls-123456"
-        local fs_mkstemp = uv.fs_mkstemp
-        local tmpname
+        local mock_fd, mock_bufname = 57, "/Users/jose/my-file.lua"
         before_each(function()
-            u.path.is_windows = false
-            vim.env.XDG_RUNTIME_DIR = nil
-            vim.env.TEMP = nil
-
-            tmpname = stub(os, "tmpname")
-
-            tmpname.returns(mock_path)
-            uv.fs_mkstemp.returns(mock_fd, mock_path)
             uv.fs_open.returns(mock_fd)
         end)
         after_each(function()
-            tmpname:revert()
-            loop._revert_tmp_dir()
+            uv.fs_open:clear()
             uv.fs_write:clear()
             uv.fs_close:clear()
             uv.fs_unlink:clear()
-            uv.fs_mkstemp = fs_mkstemp
-            uv.fs_mkstemp:clear()
-            uv.fs_rename:clear()
         end)
 
-        it("should call uv.fs_mkstemp with path + pattern using /tmp", function()
-            loop.temp_file(mock_content)
+        it("should call uv.fs_open with temp path", function()
+            local temp_path = loop.temp_file(mock_content, mock_bufname)
 
-            assert.stub(uv.fs_mkstemp).was_called_with(u.path.join("/tmp", "null-ls_XXXXXX"))
+            assert.equals(temp_path, string.format("/Users/jose/_null-ls_%d_my-file.lua", mock_random))
+            assert.stub(uv.fs_open).was_called_with(temp_path, "w", 384)
         end)
 
-        it("should call uv.fs_mkstemp with path + pattern using XDG_RUNTIME_DIR", function()
-            vim.env.XDG_RUNTIME_DIR = "/run/user/1000"
-
-            loop.temp_file(mock_content)
-
-            assert.stub(uv.fs_mkstemp).was_called_with(u.path.join(vim.env.XDG_RUNTIME_DIR, "/nvim/null-ls_XXXXXX"))
-        end)
-
-        it("should call uv.fs_mkstemp with path + pattern on windows", function()
-            u.path.is_windows = true
-            vim.env.TEMP = "C:\\temp"
-
-            loop.temp_file(mock_content)
-
-            assert.stub(uv.fs_mkstemp).was_called_with(u.path.join(vim.env.TEMP, "null-ls_XXXXXX"))
-        end)
-
-        it("should not call uv.fs_open if fd from fs_mkstemp is already open", function()
-            loop.temp_file(mock_content)
-
-            assert.stub(uv.fs_open).was_not_called()
-        end)
-
-        it("should call os.tmpname if no uv.fs_mkstemp", function()
-            uv.fs_mkstemp = nil
-
-            loop.temp_file(mock_content)
-
-            assert.stub(tmpname).was_called()
-        end)
-
-        it("should call uv.fs_open with path and permissions", function()
-            loop.temp_file(mock_content)
-
-            assert.stub(uv.fs_open).was_called_with(mock_path, "w", 384)
-        end)
-
-        describe("extension", function()
-            local mock_extension = "lua"
-
-            it("should call uv.fs_close on original handle", function()
-                local original_handle = 19
-                uv.fs_mkstemp.returns(original_handle, mock_path)
-
-                loop.temp_file(mock_content, mock_extension)
-
-                assert.stub(uv.fs_close).was_called_with(original_handle)
-            end)
-
-            it("should set original handle to nil and get new handle from fs_open", function()
-                local original_handle = 19
-                uv.fs_mkstemp.returns(original_handle, mock_path)
-
-                loop.temp_file(mock_content, mock_extension)
-
-                assert.stub(uv.fs_open).was_called()
-            end)
-
-            it("should call fs_rename with original path and path with extension", function()
-                loop.temp_file(mock_content, mock_extension)
-
-                assert.stub(uv.fs_rename).was_called_with(mock_path, mock_path .. ".lua")
-            end)
-
-            it("should set tmp_path to path with extension", function()
-                loop.temp_file(mock_content, mock_extension)
-
-                assert.stub(uv.fs_open).was_called_with(mock_path .. ".lua", "w", 384)
-            end)
-        end)
-
-        it("should call fs_write and fs_close with fd and content", function()
-            loop.temp_file(mock_content)
+        it("should call uv.fs_write with content", function()
+            loop.temp_file(mock_content, mock_bufname)
 
             assert.stub(uv.fs_write).was_called_with(mock_fd, mock_content, -1)
+        end)
+
+        it("should call uv.fs_close with fd", function()
+            loop.temp_file(mock_content, mock_bufname)
+
             assert.stub(uv.fs_close).was_called_with(mock_fd)
         end)
 
-        it("should return tmp_path", function()
-            local path = loop.temp_file(mock_content)
+        it("should call fs_unlink with path on cleanup", function()
+            local temp_path, cleanup = loop.temp_file(mock_content, mock_bufname)
 
-            assert.equals(path, mock_path)
-        end)
+            cleanup()
 
-        it("should call fs_unlink with path on callback", function()
-            local _, callback = loop.temp_file(mock_content)
-
-            callback()
-
-            assert.stub(uv.fs_unlink).was_called_with(mock_path)
+            assert.stub(uv.fs_unlink).was_called_with(temp_path)
         end)
     end)
 end)


### PR DESCRIPTION
Discussed in #1069. @andrewferrier 

Our current temp file creation mechanism uses a dedicated temporary directory (`$TEMP` on Windows, `$XDG_RUNTIME_DIR` if set, and `/tmp` otherwise). The issue, which has come up before, is that some linters / formatters use file paths to resolve config files. Well-behaved CLIs like [`black`](https://github.com/jose-elias-alvarez/null-ls.nvim/blob/main/lua/null-ls/builtins/formatting/black.lua) use an additional flag to specify the "actual" filepath, even when using `stdin`, but we can't expect this behavior for all CLIs (using a temp file is itself a hack to improve behavior when `stdin` is not supported).

I resisted making this change in the past because I didn't like the idea of writing to an actual project, even temporarily, and I worried about potential bad interactions with file watchers. I've since learned that [formatter.nvim](https://github.com/mhartington/formatter.nvim/blob/master/lua/formatter/tempfile.lua) already does something similar, and I haven't seen any related issues there, so I think this should be okay. The change also removes a decent amount of complexity related to getting the right temp directory and adding a file extension to the generated path.

I think this is worth trying out and potentially reverting / making it opt-in if we get reports of issues, but I'm happy to hear thoughts from anyone who happens to see this. 