### PR TITLE
feat(loop): check if command is executable by handling spawn failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,15 @@ plugin before sending anything upstream.
    feature, open an issue and provide the information requested in the issue
    template.
 
+### My `:checkhealth` output is wrong! What do I do?
+
+Checking whether a given command is executable is tricky, and null-ls' health
+check doesn't handle all cases. null-ls' internal command resolution is
+independent of its health check output, which is for informational purposes.
+
+If you're not sure whether a given command is running as expected, enable debug
+mode and check your log (see below).
+
 ### How do I format files?
 
 null-ls formatters run when you call `vim.lsp.buf.formatting()` or

--- a/lua/null-ls/health.lua
+++ b/lua/null-ls/health.lua
@@ -11,8 +11,8 @@ local messages = {
 
 local function report(source)
     local name = source.name
-    local only_local = source.generator.opts and source.generator.opts.only_local
-    local command = source.generator.opts and source.generator.opts.command
+    local opts = source.generator.opts or {}
+    local command, only_local, prefer_local = opts.command, opts.only_local, opts.prefer_local
 
     if type(command) ~= "string" then
         health.report_info(string.format(messages["unable"], name, command))
@@ -24,7 +24,7 @@ local function report(source)
         return
     end
 
-    if only_local then
+    if only_local or prefer_local then
         health.report_warn(string.format(messages["executable-local"], name, command))
         return
     end

--- a/lua/null-ls/helpers/generator_factory.lua
+++ b/lua/null-ls/helpers/generator_factory.lua
@@ -174,14 +174,6 @@ return function(opts)
             opts.command = command
         end
 
-        if not dynamic_command then
-            local is_executable, err_msg = u.is_executable(command)
-            if not is_executable then
-                log:error(err_msg)
-                return false
-            end
-        end
-
         return true
     end
 

--- a/lua/null-ls/utils.lua
+++ b/lua/null-ls/utils.lua
@@ -83,13 +83,9 @@ end
 
 --- checks if a given command is executable
 ---@param cmd string? command to check
----@return boolean, string is_executable, string|nil error_message
+---@return boolean
 M.is_executable = function(cmd)
-    if cmd and vim.fn.executable(cmd) == 1 then
-        return true
-    end
-
-    return false, string.format("command %s is not executable (make sure it's installed and on your $PATH)", cmd)
+    return cmd and vim.fn.executable(cmd) == 1 or false
 end
 
 ---@alias NullLsRange table<"'row'"|"'col'"|"'end_row'"|"'end_col'", number>

--- a/test/spec/helpers/generator_factory_spec.lua
+++ b/test/spec/helpers/generator_factory_spec.lua
@@ -320,27 +320,6 @@ describe("generator_factory", function()
     end)
 
     describe("command", function()
-        it("should trigger deregistration if command is not executable", function()
-            generator_opts.command = "nonexistent"
-
-            local generator = helpers.generator_factory(generator_opts)
-            generator.fn({}, done)
-
-            assert.stub(done).was_called_with({ _should_deregister = true })
-        end)
-
-        it("should not validate command if dynamic_command is set", function()
-            generator_opts.command = "nonexistent"
-            generator_opts.dynamic_command = function()
-                return "cat"
-            end
-
-            local generator = helpers.generator_factory(generator_opts)
-            generator.fn({}, done)
-
-            assert.stub(done).was_not_called()
-        end)
-
         it("should call command function with params ", function()
             local params
             generator_opts.command = function(_params)

--- a/test/spec/utils_spec.lua
+++ b/test/spec/utils_spec.lua
@@ -119,22 +119,20 @@ describe("utils", function()
             assert.stub(executable).was_called_with("mock-command")
         end)
 
-        it("should return true and nil if result is > 0", function()
+        it("should return true if result is > 0", function()
             executable.returns(1)
 
-            local is_executable, err_msg = u.is_executable("mock-command")
+            local is_executable = u.is_executable("mock-command")
 
             assert.truthy(is_executable)
-            assert.falsy(err_msg)
         end)
 
-        it("should return false and error message if result is 0", function()
+        it("should return false if result is 0", function()
             executable.returns(0)
 
-            local is_executable, err_msg = u.is_executable("mock-command")
+            local is_executable = u.is_executable("mock-command")
 
             assert.falsy(is_executable)
-            assert.truthy(err_msg:find("is not executable"))
         end)
     end)
 


### PR DESCRIPTION
Supersedes #892. The purpose of that PR was to improve messaging in dynamically-resolved `node_modules` commands. This PR implements the approach I described in a comment:

> If you're up for it, a more robust solution might be to determine the ability to execute a command based on the result of vim.loop.spawn, since vim.fn.executable doesn't account for all cases. Neovim switched to this approach for LSP servers in https://github.com/neovim/neovim/pull/16430, and I've been meaning to switch over to it, too (except for healthchecks).

This should also improve the situation that #1017 was intended to fix, since null-ls doesn't have to check whether a command is executable before attempting to spawn it. @jceb Could you check if this works for you when using symlinks?

Unfortunately, this approach only works if we can actually spawn the command on success. We're not able to do so in health checks, so this PR also improves messaging and closes #912. Health checks are really for informational purposes, so as long as users are aware that the result of the checks doesn't affect how null-ls works, I think we're in the clear. 