### PR TITLE
feat(builtins): allow configuring diagnostics display

### DIFF
--- a/doc/BUILTIN_CONFIG.md
+++ b/doc/BUILTIN_CONFIG.md
@@ -191,6 +191,29 @@ local sources = {
 }
 ```
 
+### Diagnostic config
+
+You can configure how Neovim displays source diagnostics by setting
+`diagnostic_config`:
+
+```lua
+local sources = {
+    null_ls.builtins.diagnostics.shellcheck.with({
+        diagnostic_config = {
+            -- see :help vim.diagnostic.config()
+            underline = true,
+            virtual_text = false,
+            signs = true,
+            update_in_insert = false,
+            severity_sort = true,
+        },
+    }),
+}
+```
+
+- Specifying `diagnostic_config` for a built-in will override your global
+  `diagnostic_config` for that source.
+
 ### Diagnostics format
 
 For diagnostics sources, you can change the format of diagnostic messages by

--- a/doc/CONFIG.md
+++ b/doc/CONFIG.md
@@ -50,6 +50,7 @@ local defaults = {
     debounce = 250,
     debug = false,
     default_timeout = 5000,
+    diagnostic_config = nil,
     diagnostics_format = "#{m}",
     fallback_severity = vim.diagnostic.severity.ERROR,
     log_level = "warn",
@@ -108,6 +109,15 @@ users can override the timeout period on a per-source basis, too (see
 Specifying a timeout with a value less than zero will prevent commands from
 timing out.
 
+### diagnostic_config (table, optional)
+
+Specifies diagnostic display options for null-ls sources, as described in
+`:help vim.diagnostic.config()`. (null-ls uses separate namespaces for each
+source, so server-wide configuration will not work as expected.)
+
+You can also configure `diagnostic_config` per built-in by using the `with`
+method, described in [BUILTIN_CONFIG](BUILTIN_CONFIG.md).
+
 ### diagnostics_format (string)
 
 Sets the default format used for diagnostics. The plugin will replace the
@@ -129,8 +139,8 @@ Formats diagnostics as follows:
 [2148] Tips depend on target shell and yours is unknown. Add a shebang or a 'shell' directive. (shellcheck)
 ```
 
-You can also set `diagnostics_format` for built-ins by using the `with` method,
-described in [BUILTIN_CONFIG](BUILTIN_CONFIG.md).
+You can also configure `diagnostics_format` per built-in by using the `with`
+method, described in [BUILTIN_CONFIG](BUILTIN_CONFIG.md).
 
 ### fallback_severity (number)
 

--- a/lua/null-ls/diagnostics.lua
+++ b/lua/null-ls/diagnostics.lua
@@ -8,8 +8,21 @@ local api = vim.api
 
 local namespaces = {}
 local get_namespace = function(id)
-    namespaces[id] = namespaces[id] or api.nvim_create_namespace("NULL_LS_SOURCE_" .. id)
-    return namespaces[id]
+    if namespaces[id] then
+        return namespaces[id]
+    end
+
+    local namespace = api.nvim_create_namespace("NULL_LS_SOURCE_" .. id)
+
+    local source = require("null-ls.sources").get({ id = id })[1]
+    local diagnostic_config = source and source.generator.opts and source.generator.opts.diagnostic_config
+        or c.get().diagnostic_config
+    if diagnostic_config then
+        vim.diagnostic.config(diagnostic_config, namespace)
+    end
+
+    namespaces[id] = namespace
+    return namespace
 end
 
 local M = {}

--- a/lua/null-ls/helpers/make_builtin.lua
+++ b/lua/null-ls/helpers/make_builtin.lua
@@ -28,6 +28,7 @@ local function make_builtin(opts)
         env = opts.env,
         cwd = opts.cwd,
         diagnostics_format = opts.diagnostics_format,
+        diagnostic_config = opts.diagnostic_config,
         filter = opts.filter,
         diagnostics_postprocess = opts.diagnostics_postprocess,
         dynamic_command = opts.dynamic_command,

--- a/test/spec/e2e_spec.lua
+++ b/test/spec/e2e_spec.lua
@@ -243,6 +243,31 @@ describe("e2e", function()
 
             assert.equals(write_good_diagnostic.message, "I have been postprocessed!")
         end)
+
+        it("should configure source diagnostics display", function()
+            local diagnostic_config = {
+                underline = true,
+                virtual_text = true,
+                signs = true,
+                update_in_insert = true,
+                severity_sort = true,
+            }
+            sources.reset()
+            sources.register(builtins.diagnostics.write_good.with({
+                diagnostic_config = diagnostic_config,
+            }))
+
+            -- need to generate diagnostics to configure namespace on first display
+            vim.cmd("e")
+            tu.wait_for_real_source()
+
+            local source = sources.get_all()[1]
+            assert.truthy(source)
+            assert.equals(source.name, "write_good")
+            local namespace = require("null-ls.diagnostics").get_namespace(source.id)
+            assert.truthy(namespace)
+            assert.same(vim.diagnostic.config(nil, namespace), diagnostic_config)
+        end)
     end)
 
     describe("formatting", function()


### PR DESCRIPTION
Closes #1094. @mikatpt

null-ls uses separate diagnostic namespaces per source, which is a prerequisite for multiple-file diagnostics but makes configuration annoying. One option is to allow configuring source namespace generation (or expose existing namespaces more readily), but this increases the chances of collisions and unexpected behavior. 

This PR instead configures source namespaces using the `diagnostic_config` key when the namespace is first generated. The option is available per-source and globally, since null-ls' unique behavior means that there is currently no good way to configure the display of all null-ls diagnostics. 