### PR TITLE
Add --stdin-filename to mix formatter

### DIFF
--- a/lua/null-ls/builtins/formatting/mix.lua
+++ b/lua/null-ls/builtins/formatting/mix.lua
@@ -13,7 +13,7 @@ return h.make_builtin({
     filetypes = { "elixir" },
     generator_opts = {
         command = "mix",
-        args = { "format", "-" },
+        args = { "format", "--stdin-filename", "$FILENAME", "-" },
         format = "raw",
         to_stdin = true,
     },


### PR DESCRIPTION
This allows the mix format command to correctly format non-elixir files, such as heex templates.