### PR TITLE
perf(generators): only deep copy params when needed

### DIFF
--- a/lua/null-ls/generators.lua
+++ b/lua/null-ls/generators.lua
@@ -35,9 +35,17 @@ M.run = function(generators, params, opts, callback)
     end
 
     local futures = {}
+    local copy_params = function(to_copy)
+        if #generators < 2 then
+            return to_copy
+        end
+
+        return vim.deepcopy(to_copy)
+    end
+
     for i, generator in ipairs(generators) do
         table.insert(futures, function()
-            local copied_params = vim.deepcopy(opts.make_params and opts.make_params() or params)
+            local copied_params = copy_params(opts.make_params and opts.make_params() or params)
 
             local runtime_condition = generator.opts and generator.opts.runtime_condition
             if runtime_condition and not runtime_condition(copied_params) then

--- a/test/spec/generators_spec.lua
+++ b/test/spec/generators_spec.lua
@@ -1,5 +1,6 @@
 local stub = require("luassert.stub")
 local mock = require("luassert.mock")
+local spy = require("luassert.spy")
 
 local methods = require("null-ls.methods")
 local sources = require("null-ls.sources")
@@ -118,6 +119,27 @@ describe("generators", function()
             wait_for_results()
 
             assert.equals(vim.tbl_count(results), 0)
+        end)
+
+        it("should not copy params when < 2 generators", function()
+            local s = spy.on(vim, "deepcopy")
+
+            generators.run({ sync_generator }, mock_params, mock_opts, callback)
+            wait_for_results()
+
+            assert.spy(s).was_not_called()
+        end)
+
+        it("should copy params when >= 2 generators", function()
+            local s = spy.on(vim, "deepcopy")
+
+            generators.run({
+                sync_generator,
+                async_generator,
+            }, mock_params, mock_opts, callback)
+            wait_for_results()
+
+            assert.spy(s).was_called()
         end)
 
         it("should get result from sync generator", function()


### PR DESCRIPTION
Follow up to #1048. The goal of deep copying the `params` table is to prevent accidentally leaking changes between different generators, an issue that has come up in the past. I considered using a metatable to make the object itself immutable, but I think this would be worse for performance, and it's not unreasonable for a given generator to modify its own `params` (plus I suspect it would break a bunch of sources that are already doing so). 

The effect of running `vim.deepcopy` is only measurable in nanoseconds, but it does grow as `params` grows larger, and this is an easy optimization to handle the most common case, which is a single generator per method. 