### PR TITLE
fix(loop): use . prefix to make temp files hidden

### DIFF
--- a/lua/null-ls/loop.lua
+++ b/lua/null-ls/loop.lua
@@ -220,7 +220,7 @@ M.temp_file = function(content, bufname)
     local dirname = vim.fn.fnamemodify(bufname, ":h")
     local base_name = vim.fn.fnamemodify(bufname, ":t")
 
-    local filename = string.format("_null-ls_%d_%s", math.random(100000, 999999), base_name)
+    local filename = string.format(".null-ls_%d_%s", math.random(100000, 999999), base_name)
     local temp_path = u.path.join(dirname, filename)
 
     local fd = uv.fs_open(temp_path, "w", 384)

--- a/test/spec/loop_spec.lua
+++ b/test/spec/loop_spec.lua
@@ -621,7 +621,7 @@ describe("loop", function()
         it("should call uv.fs_open with temp path", function()
             local temp_path = loop.temp_file(mock_content, mock_bufname)
 
-            assert.equals(temp_path, string.format("/Users/jose/_null-ls_%d_my-file.lua", mock_random))
+            assert.equals(temp_path, string.format("/Users/jose/.null-ls_%d_my-file.lua", mock_random))
             assert.stub(uv.fs_open).was_called_with(temp_path, "w", 384)
         end)
 


### PR DESCRIPTION
Since #1075, null-ls has been creating temp files at the same path as the actual file. So far, we haven't received any bug reports (knock on wood) so I'd say the change is a definite improvement - for example, in #1107 we are using it to allow the linter to resolve its config file without user intervention - but it has some drawbacks.

In the same issue, a user discussed how the constant creation and deletion of temp files causes nvim-tree to shrink and expand, a minor visual issue solved by making the file hidden (at least on Unix).

At some point, an issue may arise that forces us to make this configurable and potentially even default to `/tmp` again, but I'd like to wait until that happens before making further changes, since I'm happy with the current state of things, both from a maintainer and a user perspective. 