### PR TITLE
fix(loop): clean up temp files on exit

### DIFF
--- a/lua/null-ls/loop.lua
+++ b/lua/null-ls/loop.lua
@@ -235,9 +235,26 @@ M.temp_file = function(content, bufname)
     uv.fs_write(fd, content, -1)
     uv.fs_close(fd)
 
+    local autocmd_id
     local cleanup = function()
+        if not temp_path then
+            return
+        end
+
         uv.fs_unlink(temp_path)
+        temp_path = nil
+
+        if autocmd_id then
+            vim.schedule(function()
+                vim.api.nvim_del_autocmd(autocmd_id)
+            end)
+        end
     end
+
+    -- make sure to run cleanup on exit
+    autocmd_id = vim.api.nvim_create_autocmd("VimLeavePre", {
+        callback = cleanup,
+    })
 
     return temp_path, cleanup
 end


### PR DESCRIPTION
Fixes an issue raised in #1075. Temp file-based generators created using `generator_factory` will only call `cleanup` on `stdout` end, so if the user exits Neovim after a generator has started running but before it's done, `cleanup` will not be called. This PR hooks into `VimLeavePre` to ensure that `cleanup` is called in this edge case (shout out to the autocommand API, without which this would have been a pain). 

@soifou I tested this using artificial delays / conditions, but could you give this a try and let me know if it solves the issue for you?