### PR TITLE
Update markdownlint.lua

### DIFF
--- a/lua/null-ls/builtins/diagnostics/markdownlint.lua
+++ b/lua/null-ls/builtins/diagnostics/markdownlint.lua
@@ -11,6 +11,7 @@ return h.make_builtin({
     },
     method = DIAGNOSTICS,
     filetypes = { "markdown" },
+    disabled_filetypes = { "markdown.mdx" },
     generator_opts = {
         command = "markdownlint",
         args = { "--stdin" },


### PR DESCRIPTION
I know I can configure this locally but this tool isn't designed for MDX and it's feedback is quite noisy/of negative value in most MDX files so I feel there is a case to be made that it should be default configuration.