### PR TITLE
fix: Update the sqlfluff diagnostics built-in

### DIFF
--- a/lua/null-ls/builtins/diagnostics/sqlfluff.lua
+++ b/lua/null-ls/builtins/diagnostics/sqlfluff.lua
@@ -22,18 +22,18 @@ local sources = {
         command = "sqlfluff",
         args = {
             "lint",
-            "-f",
-            "github-annotation",
-            "-n",
+            "--format=github-annotation",
+            "--nocolor",
             "--disable_progress_bar",
             "$FILENAME",
         },
-        from_stderr = false,
+        from_stderr = true,
         to_stdin = false,
-        to_temp_file = true,
+        to_temp_file = false,
         format = "json",
+        -- Return codes https://github.com/sqlfluff/sqlfluff/blob/main/src/sqlfluff/cli/__init__.py
         check_exit_code = function(c)
-            return c <= 1
+            return c < 1
         end,
         on_output = helpers.diagnostics.from_json({
             attributes = {

--- a/lua/null-ls/helpers/generator_factory.lua
+++ b/lua/null-ls/helpers/generator_factory.lua
@@ -51,8 +51,26 @@ local parse_args = function(args, params)
     return parsed
 end
 
+local function find_json(output)
+    local bracket = string.find(output, "%[")
+    local parenthesis = string.find(output, "{")
+    local char = ""
+    if (bracket or parenthesis) and bracket < parenthesis then
+        char = "%["
+    else
+        char = "{"
+    end
+    if output then
+        if output[0] ~= char then
+            output = string.sub(output, string.find(output, char), string.len(output))
+        end
+    end
+    return output
+end
+
 local json_output_wrapper = function(params, done, on_output, format)
     if params.output then
+        params.output = find_json(params.output)
         local ok, decoded = pcall(vim.json.decode, params.output)
         if decoded == vim.NIL or decoded == "" then
             decoded = nil


### PR DESCRIPTION
- The sqlfluff diagnostics linter was treating 1 exit codes as passing which was incorrect.
- I have adjusted the output method to conform to the way sqlfluff outputs diagnostics to stderr.
- Made default arguments more explicit instead of shortened flag