### PR TITLE
fix(pylint): offset end_col as well

### DIFF
--- a/lua/null-ls/builtins/diagnostics/pylint.lua
+++ b/lua/null-ls/builtins/diagnostics/pylint.lua
@@ -60,6 +60,7 @@ null_ls.setup({
             },
             offsets = {
                 col = 1,
+                end_col = 1,
             },
         }),
     },


### PR DESCRIPTION
Pylint diagnostics show with the correct start column, but the end column is off by one; this fixes it.