### PR TITLE
fix(builtins): prefer stdin over temp file for yamlfmt

### DIFF
--- a/lua/null-ls/builtins/formatting/yamlfmt.lua
+++ b/lua/null-ls/builtins/formatting/yamlfmt.lua
@@ -11,7 +11,10 @@ return h.make_builtin({
     },
     method = FORMATTING,
     filetypes = { "yaml" },
-    to_temp_file = true,
-    generator_opts = { command = "yamlfmt", args = { "$FILENAME" } },
+    generator_opts = {
+        command = "yamlfmt",
+        to_stdin = true,
+        args = { "-" },
+    },
     factory = h.formatter_factory,
 })


### PR DESCRIPTION
yamlfmt supports `stdin` via `-` since release [v0.3](https://github.com/google/yamlfmt/releases/tag/v0.3.0).
