### PR TITLE
fix(builtins): ignore haml-lint stderr and use temp file

### DIFF
--- a/lua/null-ls/builtins/diagnostics/haml_lint.lua
+++ b/lua/null-ls/builtins/diagnostics/haml_lint.lua
@@ -36,7 +36,8 @@ return h.make_builtin({
         command = "haml-lint",
         args = { "--reporter", "json", "$FILENAME" },
         to_stdin = true,
-        from_stderr = true,
+        ignore_stderr = true,
+        to_temp_file = true,
         format = "json",
         check_exit_code = function(code)
             return code <= 1


### PR DESCRIPTION
Should fix #1144. 

Not sure why the original built-in has `from_stderr = true` (version incompatibility?) but the linter definitely outputs to `stdout`. I also set `ignore_stderr = true` to ignore an unhelpful warning and set `to_temp_file = true` to make sure diagnostics update on change.