### PR TITLE
support for ocamlformat

### DIFF
--- a/lua/null-ls/builtins/formatting/ocamlformat.lua
+++ b/lua/null-ls/builtins/formatting/ocamlformat.lua
@@ -1,0 +1,20 @@
+local h = require("null-ls.helpers")
+local methods = require("null-ls.methods")
+
+local FORMATTING = methods.internal.FORMATTING
+
+return h.make_builtin({
+    name = "ocamlformat",
+    meta = {
+        url = "https://github.com/ocaml-ppx/ocamlformat",
+        description = "Auto-formatter for OCaml code",
+    },
+    method = FORMATTING,
+    filetypes = { "ocaml" },
+    generator_opts = {
+        command = "ocamlformat",
+        args = { "--enable-outside-detected-project", "-" },
+        to_stdin = true,
+    },
+    factory = h.formatter_factory,
+})


### PR DESCRIPTION
I've made a small PR to add ocamlformat as formatter for null-ls.

Right now it can already format every ocaml file with the default settings, just need some time to dig in the docs 
(https://github.com/ocaml-ppx/ocamlformat/blob/main/ocamlformat-help.txt) to support .ocamlformat.