### PR TITLE
fix(builtins): haml_lint - add to_temp_file = true and notes

### DIFF
--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -882,7 +882,7 @@ local sources = { null_ls.builtins.diagnostics.haml_lint }
 
 ### Notes
 
-- This source interacts with other code analyzers like `rubocop`. If you are using `solargraph` intellisense for your ruby project, it also requires rubocop. If that's the case, make sure rubocop and all dependencies required by rubocop are also installed globally, eg: `gem install rubocop rubocop-rails`.
+- `haml-lint` interacts with other code analyzers like `Rubocop`. Warnings from Rubocop may break diagnostics for this plugin if they are not received in valid JSON format. Common culprits are additional Rubocop dependencies that need to be installed or `parser` version warnings.
 
 ### [jshint](https://github.com/jshint/jshint)
 

--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -882,7 +882,7 @@ local sources = { null_ls.builtins.diagnostics.haml_lint }
 
 ### Notes
 
-- This source interacts with other code analyzers like `rubocop`. If you are using `solargraph` intellisense for your ruby project, it requires rubocop. If that's the caes, make sure rubocop and all dependencies required by rubocop are also installed globally, eg: `gem install rubocop rubocop-rails`.
+- This source interacts with other code analyzers like `rubocop`. If you are using `solargraph` intellisense for your ruby project, it also requires rubocop. If that's the case, make sure rubocop and all dependencies required by rubocop are also installed globally, eg: `gem install rubocop rubocop-rails`.
 
 ### [jshint](https://github.com/jshint/jshint)
 

--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -880,6 +880,10 @@ local sources = { null_ls.builtins.diagnostics.haml_lint }
 - Command: `haml-lint`
 - Args: `{ "--reporter", "json", "$FILENAME" }`
 
+### Notes
+
+- This source interacts with other code analyzers like `rubocop`. If you are using `solargraph` intellisense for your ruby project, it requires rubocop. If that's the caes, make sure rubocop and all dependencies required by rubocop are also installed globally, eg: `gem install rubocop rubocop-rails`.
+
 ### [jshint](https://github.com/jshint/jshint)
 
 JSHint is a tool that helps to detect errors and potential problems in your JavaScript code.

--- a/lua/null-ls/builtins/diagnostics/haml_lint.lua
+++ b/lua/null-ls/builtins/diagnostics/haml_lint.lua
@@ -37,6 +37,7 @@ return h.make_builtin({
         args = { "--reporter", "json", "$FILENAME" },
         to_stdin = true,
         from_stderr = true,
+        to_temp_file = true,
         format = "json",
         check_exit_code = function(code)
             return code <= 1


### PR DESCRIPTION
Should fix #1144 

Added generator option `to_temp_file = true` and notes for `haml_lint` builtin diagnostics.