### PR TITLE
fix(builtins): refine 'cwd' for mypy and isort

### DIFF
--- a/lua/null-ls/builtins/diagnostics/mypy.lua
+++ b/lua/null-ls/builtins/diagnostics/mypy.lua
@@ -1,5 +1,6 @@
 local h = require("null-ls.helpers")
 local methods = require("null-ls.methods")
+local u = require("null-ls.utils")
 
 local DIAGNOSTICS = methods.internal.DIAGNOSTICS
 
@@ -63,6 +64,15 @@ benefits of dynamic (or "duck") typing and static typing.]],
                 overrides = overrides,
             },
         }),
+        cwd = h.cache.by_bufnr(function(params)
+            return u.root_pattern(
+                -- https://mypy.readthedocs.io/en/stable/config_file.html
+                "mypy.ini",
+                ".mypy.ini",
+                "pyproject.toml",
+                "setup.cfg"
+            )(params.bufname)
+        end),
     },
     factory = h.generator_factory,
 })

--- a/lua/null-ls/builtins/formatting/isort.lua
+++ b/lua/null-ls/builtins/formatting/isort.lua
@@ -23,6 +23,8 @@ return h.make_builtin({
         to_stdin = true,
         cwd = h.cache.by_bufnr(function(params)
             return u.root_pattern(
+                -- isort will detect files in the CWD as first-party
+                "setup.py",
                 -- https://pycqa.github.io/isort/docs/configuration/config_files.html
                 "setup.cfg",
                 ".isort.cfg",

--- a/lua/null-ls/builtins/formatting/isort.lua
+++ b/lua/null-ls/builtins/formatting/isort.lua
@@ -24,11 +24,11 @@ return h.make_builtin({
         cwd = h.cache.by_bufnr(function(params)
             return u.root_pattern(
                 -- isort will detect files in the CWD as first-party
-                "setup.py",
                 -- https://pycqa.github.io/isort/docs/configuration/config_files.html
-                "setup.cfg",
                 ".isort.cfg",
                 "pyproject.toml",
+                "setup.py",
+                "setup.cfg",
                 "tox.ini",
                 ".editorconfig"
             )(params.bufname)


### PR DESCRIPTION
### mypy
Mypy needs `cwd` to discover the configuration file (https://mypy.readthedocs.io/en/stable/config_file.html)

### isort
Isort will detect files in the CWD as first-party (https://github.com/PyCQA/isort/blob/fa2de4761040a9fd82339fccc7cc42391eb082cf/CHANGELOG.md?plain=1#L434),
So although `setup.py` doesn't contain `isort` configuration, it helps `isort` sort correctly.