### PR TITLE
Fix filename for `prettier.config.js` variants

### DIFF
--- a/lua/null-ls/builtins/formatting/prettier.lua
+++ b/lua/null-ls/builtins/formatting/prettier.lua
@@ -53,9 +53,9 @@ return h.make_builtin({
                 ".prettierrc.json5",
                 ".prettierrc.js",
                 ".prettierrc.cjs",
-                ".prettier.config.js",
-                ".prettier.config.cjs",
                 ".prettierrc.toml",
+                "prettier.config.js",
+                "prettier.config.cjs",
                 "package.json"
             )(params.bufname)
         end),

--- a/lua/null-ls/builtins/formatting/prettier_d_slim.lua
+++ b/lua/null-ls/builtins/formatting/prettier_d_slim.lua
@@ -55,9 +55,9 @@ return h.make_builtin({
                 ".prettierrc.json5",
                 ".prettierrc.js",
                 ".prettierrc.cjs",
-                ".prettier.config.js",
-                ".prettier.config.cjs",
                 ".prettierrc.toml",
+                "prettier.config.js",
+                "prettier.config.cjs",
                 "package.json"
             )(params.bufname)
         end),

--- a/lua/null-ls/builtins/formatting/prettier_standard.lua
+++ b/lua/null-ls/builtins/formatting/prettier_standard.lua
@@ -28,9 +28,9 @@ return h.make_builtin({
                 ".prettierrc.json5",
                 ".prettierrc.js",
                 ".prettierrc.cjs",
-                ".prettier.config.js",
-                ".prettier.config.cjs",
                 ".prettierrc.toml",
+                "prettier.config.js",
+                "prettier.config.cjs",
                 "package.json"
             )(params.bufname)
         end),

--- a/lua/null-ls/builtins/formatting/prettierd.lua
+++ b/lua/null-ls/builtins/formatting/prettierd.lua
@@ -45,9 +45,9 @@ return h.make_builtin({
                 ".prettierrc.json5",
                 ".prettierrc.js",
                 ".prettierrc.cjs",
-                ".prettier.config.js",
-                ".prettier.config.cjs",
                 ".prettierrc.toml",
+                "prettier.config.js",
+                "prettier.config.cjs",
                 "package.json"
             )(params.bufname)
         end),


### PR DESCRIPTION
The Prettier filename variants `prettier.config.js` and `prettier.config.cjs` were incorrectly prefixed with a dot which is not what Prettier expects.  This renames them to the proper non-dot prefix filenames.