### PR TITLE
add mh_lint

### DIFF
--- a/lua/null-ls/builtins/_meta/diagnostics.lua
+++ b/lua/null-ls/builtins/_meta/diagnostics.lua
@@ -127,11 +127,14 @@ return {
   mdl = {
     filetypes = { "markdown" }
   },
+  mh_lint = {
+    filetypes = { "matlab", "octave" }
+  },
   misspell = {
     filetypes = {}
   },
   mlint = {
-    filetypes = { "matlab" }
+    filetypes = { "matlab", "octave" }
   },
   mypy = {
     filetypes = { "python" }

--- a/lua/null-ls/builtins/_meta/filetype_map.lua
+++ b/lua/null-ls/builtins/_meta/filetype_map.lua
@@ -232,7 +232,7 @@ return {
     formatting = { "prettier", "prettier_d_slim", "prettierd" }
   },
   matlab = {
-    diagnostics = { "mlint" }
+    diagnostics = { "mlint", "mh_lint" }
   },
   nginx = {
     formatting = { "nginx_beautifier" }
@@ -247,6 +247,9 @@ return {
   },
   ocaml = {
     formatting = { "ocamlformat" }
+  },
+  octave = {
+    diagnostics = { "mlint", "mh_lint" }
   },
   org = {
     formatting = { "cbfmt" },

--- a/lua/null-ls/builtins/diagnostics/mh_lint.lua
+++ b/lua/null-ls/builtins/diagnostics/mh_lint.lua
@@ -1,0 +1,37 @@
+local h = require("null-ls.helpers")
+local methods = require("null-ls.methods")
+
+local DIAGNOSTICS = methods.internal.DIAGNOSTICS
+
+return h.make_builtin({
+    name = "mh_lint",
+    meta = {
+        url = "https://github.com/florianschanda/miss_hit",
+        description = "MATLAB Independent, Small & Safe, High Integrity Tools - code formatter and more",
+    },
+    method = DIAGNOSTICS,
+    filetypes = { "matlab", "octave" },
+    generator_opts = {
+        command = "mh_lint",
+        args = {
+            "--brief",
+            "$FILENAME",
+        },
+        format = "line",
+        to_stdin = false,
+        from_stderr = true,
+        to_temp_file = true,
+        on_output = h.diagnostics.from_pattern([[(%d+):(%d+): (%w+): (.*)]], { "row", "col", "severity", "message" }, {
+            severities = {
+                note = h.diagnostics.severities["information"],
+                style = h.diagnostics.severities["hint"],
+                performance = h.diagnostics.severities["warning"],
+                portability = h.diagnostics.severities["information"],
+            },
+        }),
+        -- check_exit_code = function(code)
+        --     return code >= 1
+        -- end,
+    },
+    factory = h.generator_factory,
+})

--- a/lua/null-ls/builtins/diagnostics/mlint.lua
+++ b/lua/null-ls/builtins/diagnostics/mlint.lua
@@ -14,7 +14,7 @@ return h.make_builtin({
         description = "Linter for MATLAB files",
     },
     method = DIAGNOSTICS_ON_SAVE,
-    filetypes = { "matlab" },
+    filetypes = { "matlab", "octave" },
     generator_opts = {
         command = "mlint",
         args = { "$FILENAME" },


### PR DESCRIPTION
Matlab linter form [miss_hit](https://github.com/florianschanda/miss_hit) can work with `Octave` too

This `PR` use the output from `mh_lint`, but can do better if we use `json` that officially supported by `mh_lint`