### PR TITLE
refactor(docs): more consistent setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,11 +72,13 @@ To get started, you must set up null-ls and register at least one source. See
 null-ls.
 
 ```lua
-require("null-ls").setup({
+local null_ls = require("null-ls")
+
+null_ls.setup({
     sources = {
-        require("null-ls").builtins.formatting.stylua,
-        require("null-ls").builtins.diagnostics.eslint,
-        require("null-ls").builtins.completion.spell,
+        null_ls.builtins.formatting.stylua,
+        null_ls.builtins.diagnostics.eslint,
+        null_ls.builtins.completion.spell,
     },
 })
 ```

--- a/doc/CONFIG.md
+++ b/doc/CONFIG.md
@@ -31,11 +31,13 @@ example below and [BUILTIN_CONFIG](BUILTIN_CONFIG.md) for information on how to
 configure these sources.
 
 ```lua
-require("null-ls").setup({
+local null_ls = require("null-ls")
+
+null_ls.setup({
     sources = {
-        require("null-ls").builtins.formatting.stylua,
-        require("null-ls").builtins.diagnostics.eslint,
-        require("null-ls").builtins.completion.spell,
+        null_ls.builtins.formatting.stylua,
+        null_ls.builtins.diagnostics.eslint,
+        null_ls.builtins.completion.spell,
     },
 })
 ```


### PR DESCRIPTION
I think it will be better for setup to be consistent with the rest of the docs, copy/pasting from [BUILTINS.md](https://github.com/jose-elias-alvarez/null-ls.nvim/blob/main/doc/BUILTINS.md) will also be easier