### PR TITLE
feat(builtins): allow overriding temp dir

### DIFF
--- a/doc/BUILTIN_CONFIG.md
+++ b/doc/BUILTIN_CONFIG.md
@@ -149,7 +149,7 @@ local sources = {
 
 You can inject environment variables to the process via utilizing the `env`
 option. This option can be in the form of a dictionary. It can also, just like
-`args` and `extra_args`, take a function receiving a `params` object. 
+`args` and `extra_args`, take a function receiving a `params` object.
 
 ```lua
 -- Using a dictionary:
@@ -327,28 +327,28 @@ ever timing out.
 
 ### Temp file sources
 
-Some builtins write the buffer's content to a temp file before command
-execution, as a workaround for commands that don't accept `stdin`. null-ls uses
-the following logic to determine where to put temp files:
+Some built-in sources write the buffer's content to a temp file before command
+execution and / or read from a temp file after execution, as a workaround for
+commands that don't support `stdio`. To maximize compatibility, null-ls defaults
+to creating temp files in the same directory as the parent file.
 
-1. On Unix, use `XDG_RUNTIME_DIR` if set. Otherwise, use `/tmp`.
-2. On Windows, use `TEMP`
-
-In most cases, temp file sources will work as expected without user
-intervention. For special cases, you can turn this off by setting `to_temp_file`
-to `false`:
+Under normal circumstances, this will work seamlessly, but if you run into
+issues with file watchers / other integrations, you can override the directory
+to `/tmp` (or another appropriate directory) using the `temp_dir` option:
 
 ```lua
 local sources = {
     null_ls.builtins.formatting.phpstan.with({
-        to_temp_file = false,
+        temp_dir = "/tmp",
     }),
 }
 ```
 
-For diagnostics sources, you should also update the source to
-[run on save](#diagnostics-on-save), since otherwise diagnostics will go out of
-sync with buffer changes.
+**Note**: some null-ls built-in sources expect temp files to exist within a
+project for context and so will not work if this option changes.
+
+If you want to override this globally, you can change the `temp_dir` option in
+[CONFIG](CONFIG.md).
 
 ## Using local executables
 

--- a/doc/CONFIG.md
+++ b/doc/CONFIG.md
@@ -62,6 +62,7 @@ local defaults = {
     on_exit = nil,
     root_dir = require("null-ls.utils").root_pattern(".null-ls-root", "Makefile", ".git"),
     sources = nil,
+    temp_dir = nil,
     update_in_insert = false,
 }
 ```
@@ -219,6 +220,22 @@ add built-in sources (see [BUILTINS.md](BUILTINS.md)) or custom sources (see
 If you've installed an integration that provides its own sources and aren't
 interested in built-in sources, you don't have to define any sources here. The
 integration will register them independently.
+
+### temp_dir (string, optional)
+
+Defines the directory used to create temporary files for sources that rely on
+them (a workaround used for command-based sources that do not support `stdio`).
+
+To maximize compatibility, null-ls defaults to creating temp files in the same
+directory as the parent file. If this is causing issues, you can set it to
+`/tmp` (or another appropriate directory) here. Otherwise, there is no need to
+change this setting.
+
+**Note**: some null-ls built-in sources expect temp files to exist within a
+project for context and so will not work if this option changes.
+
+You can also configure `temp_dir` per built-in by using the `with` method,
+described in [BUILTIN_CONFIG](BUILTIN_CONFIG.md).
 
 ### update_in_insert (boolean)
 

--- a/lua/null-ls/config.lua
+++ b/lua/null-ls/config.lua
@@ -29,6 +29,7 @@ local type_overrides = {
     on_exit = { "function", "nil" },
     should_attach = { "function", "nil" },
     sources = { "table", "nil" },
+    temp_dir = { "string", "nil" },
 }
 
 local wanted_type = function(k)

--- a/lua/null-ls/helpers/generator_factory.lua
+++ b/lua/null-ls/helpers/generator_factory.lua
@@ -101,7 +101,7 @@ local line_output_wrapper = function(params, done, on_output)
 end
 
 return function(opts)
-    local command, args, env, on_output, format, ignore_stderr, from_stderr, to_stdin, check_exit_code, timeout, to_temp_file, from_temp_file, use_cache, runtime_condition, cwd, dynamic_command, multiple_files =
+    local command, args, env, on_output, format, ignore_stderr, from_stderr, to_stdin, check_exit_code, timeout, to_temp_file, from_temp_file, use_cache, runtime_condition, cwd, dynamic_command, multiple_files, temp_dir =
         opts.command,
         opts.args,
         opts.env,
@@ -118,7 +118,8 @@ return function(opts)
         opts.runtime_condition,
         opts.cwd,
         opts.dynamic_command,
-        opts.multiple_files
+        opts.multiple_files,
+        opts.temp_dir
 
     if type(check_exit_code) == "table" then
         local codes = check_exit_code
@@ -297,7 +298,7 @@ return function(opts)
 
             if to_temp_file then
                 local content = get_content(params)
-                local temp_path, cleanup = loop.temp_file(content, params.bufname)
+                local temp_path, cleanup = loop.temp_file(content, params.bufname, temp_dir or c.get().temp_dir)
 
                 spawn_opts.on_stdout_end = function()
                     if from_temp_file then

--- a/lua/null-ls/helpers/make_builtin.lua
+++ b/lua/null-ls/helpers/make_builtin.lua
@@ -37,6 +37,7 @@ local function make_builtin(opts)
         runtime_condition = opts.runtime_condition,
         timeout = opts.timeout,
         to_temp_file = opts.to_temp_file,
+        temp_dir = opts.temp_dir,
         -- this isn't ideal, but since we don't have a way to modify on_output's behavior,
         -- it's better than nothing
         on_output = opts.on_output,

--- a/lua/null-ls/loop.lua
+++ b/lua/null-ls/loop.lua
@@ -223,9 +223,10 @@ end
 --- creates a temp file at a given file's location
 ---@param content string
 ---@param bufname string
+---@param dirname string|nil
 ---@return string temp_path, fun() cleanup
-M.temp_file = function(content, bufname)
-    local dirname = vim.fn.fnamemodify(bufname, ":h")
+M.temp_file = function(content, bufname, dirname)
+    dirname = dirname or vim.fn.fnamemodify(bufname, ":h")
     local base_name = vim.fn.fnamemodify(bufname, ":t")
 
     local filename = string.format(".null-ls_%d_%s", math.random(100000, 999999), base_name)

--- a/test/spec/helpers/generator_factory_spec.lua
+++ b/test/spec/helpers/generator_factory_spec.lua
@@ -51,6 +51,8 @@ describe("generator_factory", function()
 
         validate:clear()
         vim.validate = validate
+
+        c.reset()
     end)
 
     describe("parse_args", function()
@@ -560,37 +562,70 @@ describe("generator_factory", function()
 
         describe("to_temp_file", function()
             local cleanup = stub.new()
+            loop.temp_file.returns("temp-path", cleanup)
 
-            local params
+            local params, temp_file_generator_opts
             before_each(function()
-                loop.temp_file.returns("temp-path", cleanup)
-
                 params = { content = { "buffer content" }, bufname = "mock-file.lua" }
-                generator_opts.to_temp_file = true
-                generator_opts.args = { "$FILENAME" }
 
-                local generator = helpers.generator_factory(generator_opts)
-                generator.fn(params)
+                temp_file_generator_opts = vim.deepcopy(generator_opts)
+                temp_file_generator_opts.to_temp_file = true
+                temp_file_generator_opts.args = { "$FILENAME" }
             end)
+
             after_each(function()
                 cleanup:clear()
             end)
 
-            it("should call loop.temp_file with content and bufname", function()
-                assert.stub(loop.temp_file).was_called_with("buffer content", params.bufname)
+            it("should call loop.temp_file with content, bufname, and nil dirname", function()
+                local generator = helpers.generator_factory(temp_file_generator_opts)
+
+                generator.fn(params)
+
+                assert.stub(loop.temp_file).was_called_with("buffer content", params.bufname, nil)
+            end)
+
+            it("should call loop.temp_file with source-specific temp_dir", function()
+                temp_file_generator_opts.temp_dir = "/source-temp-dir"
+                local generator = helpers.generator_factory(temp_file_generator_opts)
+
+                generator.fn(params)
+
+                assert
+                    .stub(loop.temp_file)
+                    .was_called_with("buffer content", params.bufname, temp_file_generator_opts.temp_dir)
+            end)
+
+            it("should call loop.temp_file with global temp_dir", function()
+                c._set({ temp_dir = "/global-temp-dir" })
+                local generator = helpers.generator_factory(temp_file_generator_opts)
+
+                generator.fn(params)
+
+                assert.stub(loop.temp_file).was_called_with("buffer content", params.bufname, c.get().temp_dir)
             end)
 
             it("should replace $FILENAME arg with temp path", function()
+                local generator = helpers.generator_factory(temp_file_generator_opts)
+
+                generator.fn(params)
+
                 assert.same(loop.spawn.calls[1].refs[2], { "temp-path" })
             end)
 
             it("should assign temp_path to params", function()
+                local generator = helpers.generator_factory(temp_file_generator_opts)
+
+                generator.fn(params)
+
                 assert.equals(params.temp_path, "temp-path")
             end)
 
             it("should call cleanup callback in on_stdout_end", function()
-                local on_stdout_end = loop.spawn.calls[1].refs[3].on_stdout_end
+                local generator = helpers.generator_factory(temp_file_generator_opts)
+                generator.fn(params)
 
+                local on_stdout_end = loop.spawn.calls[1].refs[3].on_stdout_end
                 on_stdout_end()
 
                 assert.stub(cleanup).was_called()

--- a/test/spec/loop_spec.lua
+++ b/test/spec/loop_spec.lua
@@ -607,7 +607,7 @@ describe("loop", function()
 
     describe("temp_file", function()
         local mock_content = "write me to a temp file"
-        local mock_fd, mock_bufname = 57, "/Users/jose/my-file.lua"
+        local mock_fd, mock_bufname, mock_dirname = 57, "/Users/jose/my-file.lua", "/tmp"
         before_each(function()
             uv.fs_open.returns(mock_fd)
         end)
@@ -618,10 +618,17 @@ describe("loop", function()
             uv.fs_unlink:clear()
         end)
 
-        it("should call uv.fs_open with temp path", function()
+        it("should call uv.fs_open with temp path at bufname's parent dir", function()
             local temp_path = loop.temp_file(mock_content, mock_bufname)
 
             assert.equals(temp_path, string.format("/Users/jose/.null-ls_%d_my-file.lua", mock_random))
+            assert.stub(uv.fs_open).was_called_with(temp_path, "w", 384)
+        end)
+
+        it("should use dirname when defined", function()
+            local temp_path = loop.temp_file(mock_content, mock_bufname, mock_dirname)
+
+            assert.equals(temp_path, string.format("/tmp/.null-ls_%d_my-file.lua", mock_random))
             assert.stub(uv.fs_open).was_called_with(temp_path, "w", 384)
         end)
 


### PR DESCRIPTION
See #1075 for context and discussion. The previously raised issues were cosmetic, but #1223 raises a deeper issue (the kind that I expected to arise at some point).

This PR makes the directory in which temp files are created configurable globally and per-source, which should solve the issues that have been raised so far. I do believe that maintaining the current default makes sense, since any temp file-related issues are either bugs that we need to fix or bad interactions with integrations that are beyond our control. The PR also updates some outdated documentation.

Of course, this PR doesn't solve the fundamental issue that some sources *require* temp files to exist within a project for context, but that's something that has to be solved upstream.