### PR TITLE
feat(builtins): add support for typescript.nvim code actions

### DIFF
--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -194,6 +194,21 @@ local sources = { null_ls.builtins.code_actions.statix }
 - Command: `statix`
 - Args: `{ "check", "--stdin", "--format=json" }`
 
+### [typescript](https://github.com/jose-elias-alvarez/typescript.nvim)
+
+Injects actions for Typescript Language Server's code actions on save (addMissingImports, fixAll, removeUnused, and organizeImports)
+
+#### Usage
+
+```lua
+local sources = { null_ls.builtins.code_actions.typescript }
+```
+
+#### Defaults
+
+- Filetypes: `{ "javascript", "javascriptreact", "typescript", "typescriptreact" }`
+- Method: `code_action`
+
 ### [xo](https://github.com/xojs/xo)
 
 ❤️ JavaScript/TypeScript linter (ESLint wrapper) with great defaults

--- a/lua/null-ls/builtins/code_actions/typescript.lua
+++ b/lua/null-ls/builtins/code_actions/typescript.lua
@@ -1,0 +1,34 @@
+local h = require("null-ls.helpers")
+local methods = require("null-ls.methods")
+
+local CODE_ACTION = methods.internal.CODE_ACTION
+
+return h.make_builtin({
+    name = "typescript",
+    meta = {
+        url = "https://github.com/jose-elias-alvarez/typescript.nvim",
+        description = "A Lua plugin, written in TypeScript, to write TypeScript (Lua optional).",
+    },
+    method = CODE_ACTION,
+    filetypes = { "javascript", "javascriptreact", "typescript", "typescriptreact" },
+    generator = {
+        fn = function(params)
+            local ok, typescript = pcall(require, "typescript")
+            if not ok or not typescript then
+                return
+            end
+
+            local actions = {}
+            for name, action in pairs(typescript.actions) do
+                local cb = action
+                table.insert(actions, {
+                    title = name:gsub(".%f[%l]", " %1"):gsub("%l%f[%u]", "%1 "):gsub("^.", string.upper),
+                    action = function()
+                        vim.api.nvim_buf_call(params.bufnr, cb)
+                    end,
+                })
+            end
+            return actions
+        end,
+    },
+})


### PR DESCRIPTION
Add code actions for [typescript.nvim](https://github.com/jose-elias-alvarez/typescript.nvim)