### PR TITLE
feat: Make window border and window highlight of NullLsInfo configurable

### DIFF
--- a/doc/CONFIG.md
+++ b/doc/CONFIG.md
@@ -63,6 +63,7 @@ local defaults = {
     root_dir = require("null-ls.utils").root_pattern(".null-ls-root", "Makefile", ".git"),
     sources = nil,
     temp_dir = nil,
+    border = nil,
     update_in_insert = false,
 }
 ```
@@ -237,6 +238,13 @@ project for context and so will not work if this option changes.
 You can also configure `temp_dir` per built-in by using the `with` method,
 described in [BUILTIN_CONFIG](BUILTIN_CONFIG.md).
 
+### border ( table, string, optional)
+
+Defines the border to use for the `:NullLsInfo` UI window. Uses
+`NullLsInfoBorder` highlight group (see [Highlight Groups](#highlight-groups)).
+Accepts same border values as `nvim_open_win()`. See `:help nvim_open_win()` for
+more info.
+
 ### update_in_insert (boolean)
 
 Controls whether diagnostic sources run in insert mode. If set to `false`,
@@ -248,6 +256,16 @@ Note that by default, Neovim will not display updated diagnostics in insert
 mode. Together with the option above, you need to pass `update_in_insert = true`
 to `vim.diagnostic.config` for diagnostics to work as expected. See
 `:help vim.diagnostic.config` for more info.
+
+## Highlight Groups
+
+Below are listed the highlight groups that you can override for the
+`:NullLsInfo` window.
+
+- `NullLsInfoHeader` Window header
+- `NullLsInfoTitle` Titles
+- `NullLsInfoBorder` Window border
+- `NullLsInfoSources` Sources names
 
 ## Explicitly defining the project root
 

--- a/lua/null-ls/config.lua
+++ b/lua/null-ls/config.lua
@@ -30,6 +30,7 @@ local type_overrides = {
     should_attach = { "function", "nil" },
     sources = { "table", "nil" },
     temp_dir = { "string", "nil" },
+    border = { "table", "string", "nil" },
 }
 
 local wanted_type = function(k)
@@ -87,6 +88,15 @@ end
 M.setup = function(user_config)
     if config._setup then
         return
+    end
+
+    for group, hi in pairs({
+        NullLsInfoBorder = { link = "NormalFloat", default = true },
+        NullLsInfoHeader = { link = "Label", default = true },
+        NullLsInfoTitle = { link = "Type", default = true },
+        NullLsInfoSources = { link = "Title", default = true },
+    }) do
+        vim.api.nvim_set_hl(0, group, hi)
     end
 
     local validated = validate_config(user_config)


### PR DESCRIPTION
This commit closes #1197 .
The border option was added to the config, and its possible to set it with the same parameters as nvim_open_win() border.  
Added highlight groups:
- `NullLsInfoHeader` Window header
- `NullLsInfoTitle`      Titles
- `NullLsInfoBorder`  Window border
- `NullLsInfoSources` Sources names

Docs were changed to reflect the new config options.

Example of the `border = "rounded"` option:

![image](https://user-images.githubusercontent.com/48023091/200418626-4812478f-9848-48f9-85d7-cb76dd6a6224.png)
