### PR TITLE
feat: add ability to root file match to conditional utils

### DIFF
--- a/lua/null-ls/utils.lua
+++ b/lua/null-ls/utils.lua
@@ -180,6 +180,7 @@ end
 ---@class ConditionalUtils
 ---@field has_file fun(patterns: ...): boolean checks if file exists
 ---@field root_has_file fun(patterns: ...): boolean checks if file exists at root level
+---@field root_has_file_matches fun(pattern: string): boolean checks if pattern matches a file at root level
 ---@field root_matches fun(pattern: string): boolean checks if root matches pattern
 
 --- creates a table of conditional utils based on the current root directory
@@ -205,6 +206,20 @@ M.make_conditional_utils = function()
                     return true
                 end
             end
+            return false
+        end,
+        root_has_file_matches = function(pattern)
+            local handle = vim.loop.fs_scandir(root)
+            local entry = vim.loop.fs_scandir_next(handle)
+
+            while entry do
+                if entry:match(pattern) then
+                    return true
+                end
+
+                entry = vim.loop.fs_scandir_next(handle)
+            end
+
             return false
         end,
         root_matches = function(pattern)

--- a/test/spec/utils_spec.lua
+++ b/test/spec/utils_spec.lua
@@ -324,6 +324,7 @@ describe("utils", function()
         it("should return object containing utils", function()
             assert.truthy(type(utils.has_file) == "function")
             assert.truthy(type(utils.root_has_file) == "function")
+            assert.truthy(type(utils.root_has_file_matches) == "function")
             assert.truthy(type(utils.root_matches) == "function")
         end)
 
@@ -360,6 +361,16 @@ describe("utils", function()
 
             it("should return false if file does not exist at root", function()
                 assert.falsy(utils.root_has_file("bad-file"))
+            end)
+        end)
+
+        describe("root_has_file_matches", function()
+            it("should return true if some file exists at root", function()
+                assert.truthy(utils.root_has_file_matches(".?stylua.toml"))
+            end)
+
+            it("should return false if some file not exists at root", function()
+                assert.falsy(utils.root_has_file_matches("bad-file"))
             end)
         end)
 


### PR DESCRIPTION
Implemented the functionality discussed in #1225

I added some unit tests following the format of the previous conditional utils but for some reason it fails. I printed out the table that I get from this line ```local utils = u.make_conditional_utils()``` in ```utils_spec.lua``` and it doesn't include the ```root_has_file_matches``` function for some reason. I'm not sure what that is about haha.

Edit: Of course it passes in here haha, weird.