### PR TITLE
Resolve rome executable from node modules

### DIFF
--- a/lua/null-ls/builtins/formatting/rome.lua
+++ b/lua/null-ls/builtins/formatting/rome.lua
@@ -1,6 +1,7 @@
 local h = require("null-ls.helpers")
 local cmd_resolver = require("null-ls.helpers.command_resolver")
 local methods = require("null-ls.methods")
+local u = require("null-ls.utils")
 
 local FORMATTING = methods.internal.FORMATTING
 
@@ -23,6 +24,12 @@ return h.make_builtin({
             "$FILENAME",
         },
         dynamic_command = cmd_resolver.from_node_modules(),
+        cwd = h.cache.by_bufnr(function(params)
+            return u.root_pattern(
+                -- https://docs.rome.tools/configuration/
+                "rome.json"
+            )(params.bufname)
+        end),
         to_stdin = false,
         to_temp_file = true,
     },

--- a/lua/null-ls/builtins/formatting/rome.lua
+++ b/lua/null-ls/builtins/formatting/rome.lua
@@ -15,7 +15,7 @@ return h.make_builtin({
         },
     },
     method = FORMATTING,
-    filetypes = { "javascript", "typescript" },
+    filetypes = { "javascript", "typescript", "javascriptreact", "typescriptreact" },
     generator_opts = {
         command = "rome",
         args = {

--- a/lua/null-ls/builtins/formatting/rome.lua
+++ b/lua/null-ls/builtins/formatting/rome.lua
@@ -1,4 +1,5 @@
 local h = require("null-ls.helpers")
+local cmd_resolver = require("null-ls.helpers.command_resolver")
 local methods = require("null-ls.methods")
 
 local FORMATTING = methods.internal.FORMATTING
@@ -21,6 +22,7 @@ return h.make_builtin({
             "--write",
             "$FILENAME",
         },
+        dynamic_command = cmd_resolver.from_node_modules(),
         to_stdin = false,
         to_temp_file = true,
     },


### PR DESCRIPTION
This PR adds local-first resolving order for Rome formatter. I'd argue this should be the default since [Rome docs](https://docs.rome.tools/guides/getting-started/) guide users towards installing Rome to project dependencies.