### PR TITLE
fix(rome): resolve rome from node_modules

### DIFF
--- a/lua/null-ls/builtins/formatting/rome.lua
+++ b/lua/null-ls/builtins/formatting/rome.lua
@@ -1,5 +1,6 @@
 local h = require("null-ls.helpers")
 local methods = require("null-ls.methods")
+local cmd_resolver = require("null-ls.helpers.command_resolver")
 
 local FORMATTING = methods.internal.FORMATTING
 
@@ -16,6 +17,7 @@ return h.make_builtin({
     filetypes = { "javascript", "typescript" },
     generator_opts = {
         command = "rome",
+        dynamic_command = cmd_resolver.from_node_modules(),
         args = {
             "format",
             "--write",


### PR DESCRIPTION
This commit allows `rome` to be resolved from the node_modules folder. This is useful for projects that use `rome` as a dependency and want to use the local version of `rome` instead of the global one.