### PR TITLE
feat: let sources define executable check functions

### DIFF
--- a/doc/CONTRIBUTING.md
+++ b/doc/CONTRIBUTING.md
@@ -53,6 +53,8 @@
 
 - Make sure your built-in source has a `name`.
 
+- Define a `can_run` field to verify if the plugin is installed (if possible).
+
 - Add the necessary `meta` field to your built-in so that we can generate extra
   documentation (basic information comes from the built-in's definition).
   Metadata should have the following structure:

--- a/lua/null-ls/health.lua
+++ b/lua/null-ls/health.lua
@@ -3,6 +3,8 @@ local health
 local M = {}
 
 local messages = {
+    ["can-run"] = [[%s: the source "%s" can be ran.]],
+    ["cannot-run"] = [[%s: the source "%s" cannot be ran.]],
     ["executable"] = [[%s: the command "%s" is executable.]],
     ["not-executable"] = [[%s: the command "%s" is not executable.]],
     ["unable"] = [[%s: cannot verify if the command is an executable.]],
@@ -10,9 +12,18 @@ local messages = {
 }
 
 local function report(source)
-    local name = source.name
+    local name, can_run = source.name, source.can_run
     local opts = source.generator.opts or {}
     local command, only_local, prefer_local = opts.command, opts.only_local, opts.prefer_local
+
+    if can_run then
+        if can_run() then
+            health.report_ok(string.format(messages["can-run"], name, name))
+        else
+            health.report_error(string.format(messages["cannot-run"], name, name))
+        end
+        return
+    end
 
     if type(command) ~= "string" then
         health.report_info(string.format(messages["unable"], name, command))

--- a/lua/null-ls/helpers/make_builtin.lua
+++ b/lua/null-ls/helpers/make_builtin.lua
@@ -2,13 +2,14 @@ local cmd_resolver = require("null-ls.helpers.command_resolver")
 local u = require("null-ls.utils")
 
 local function make_builtin(opts)
-    local method, filetypes, extra_filetypes, disabled_filetypes, factory, condition, generator_opts, generator =
+    local method, filetypes, extra_filetypes, disabled_filetypes, factory, condition, can_run, generator_opts, generator =
         opts.method,
         opts.filetypes,
         opts.extra_filetypes,
         opts.disabled_filetypes,
         opts.factory,
         opts.condition,
+        opts.can_run,
         vim.deepcopy(opts.generator_opts) or {},
         vim.deepcopy(opts.generator) or {}
 
@@ -45,6 +46,7 @@ local function make_builtin(opts)
     local builtin = {
         method = method,
         filetypes = filetypes,
+        can_run = can_run,
         disabled_filetypes = disabled_filetypes,
         condition = condition,
         name = opts.name or generator_opts.command,

--- a/lua/null-ls/sources.lua
+++ b/lua/null-ls/sources.lua
@@ -199,7 +199,7 @@ M.validate_and_transform = function(source)
         return source
     end
 
-    local generator, name = source.generator, source.name or "anonymous source"
+    local generator, name, can_run = source.generator, source.name or "anonymous source", source.can_run
     generator.opts = generator.opts or {}
     generator.opts.name = name
     local source_methods = type(source.method) == "table" and source.method or { source.method }
@@ -211,6 +211,7 @@ M.validate_and_transform = function(source)
         disabled_filetypes = { disabled_filetypes, "table", true },
         condition = { condition, "function", true },
         name = { name, "string" },
+        can_run = { can_run, "function", true },
         fn = { generator.fn, "function" },
         opts = { generator.opts, "table" },
         async = { generator.async, "boolean", true },
@@ -258,6 +259,7 @@ M.validate_and_transform = function(source)
     return {
         id = id,
         name = name,
+        can_run = can_run,
         generator = generator,
         filetypes = filetype_map,
         methods = method_map,


### PR DESCRIPTION
(Attempts) to solve [this](https://github.com/jose-elias-alvarez/null-ls.nvim/discussions/1215) issue.

Currently:
![image](https://user-images.githubusercontent.com/62671086/201500011-0d6da976-e6b8-4a1a-a86d-4b7e858c02c6.png)

After PR:
![image](https://user-images.githubusercontent.com/62671086/201500009-64f3d8ae-46b5-4428-8ee8-e89edd5e39c6.png)

While the functionality works I'm curious on your input on the actual language of the healthcheck itself. Let me know what you think or if there's a clearer way to get the point across.

Also, if this gets merged I already have PRs ready for gitsigns and gitrebase to exploit this new functionality.