### PR TITLE
fix(builtins): keep ansiblelint in sync

### DIFF
--- a/lua/null-ls/builtins/diagnostics/ansiblelint.lua
+++ b/lua/null-ls/builtins/diagnostics/ansiblelint.lua
@@ -1,26 +1,23 @@
 local h = require("null-ls.helpers")
 local methods = require("null-ls.methods")
 
-local DIAGNOSTICS = methods.internal.DIAGNOSTICS
-
 return h.make_builtin({
     name = "ansiblelint",
     meta = {
         url = "https://github.com/ansible-community/ansible-lint",
         description = "Linter for Ansible playbooks, roles and collections.",
     },
-    method = DIAGNOSTICS,
+    method = methods.internal.DIAGNOSTICS,
     filetypes = { "yaml.ansible" },
     generator_opts = {
         command = "ansible-lint",
-        to_stdin = true,
+        to_temp_file = true,
         ignore_stderr = true,
         args = { "-f", "codeclimate", "-q", "--nocolor", "$FILENAME" },
         format = "json",
         check_exit_code = function(code)
             return code <= 2
         end,
-        multiple_files = true,
         on_output = function(params)
             local severities = {
                 blocker = h.diagnostics.severities.error,


### PR DESCRIPTION
Ansiblelint does not accept input from stdin, so either the null-ls builtin needs to use `methods.internal.DIAGNOSTICS_ON_SAVE` to run ansiblelint on save or it needs to use `to_temp_file` so the buffer content is written to a temporary file on which ansiblelint can run. Otherwise ansiblelint always runs on the previous modification. Ansiblelint is fast enough so `to_temp_file` works well, but it changes the filename in the diagnostic. In combination with `multiple_files` that means that diagnostics do not show up. `multiple_files` seemed unnecessary anyway so removing it should not cause problems.