### PR TITLE
Fix markdownlint_cli2 built-in

### DIFF
--- a/lua/null-ls/builtins/diagnostics/markdownlint_cli2.lua
+++ b/lua/null-ls/builtins/diagnostics/markdownlint_cli2.lua
@@ -19,7 +19,7 @@ return h.make_builtin({
         command = "markdownlint-cli2",
         from_stderr = true,
         format = "line",
-        multiple_files = true,
+        multiple_files = false,
         on_output = h.diagnostics.from_patterns({
             {
                 pattern = [[(%g+):(%d+):(%d+) ([%w-/]+) (.*)]],


### PR DESCRIPTION
Fixes: https://github.com/jose-elias-alvarez/null-ls.nvim/issues/1256

It seems to work for me.