### PR TITLE
feat(health): document, add executable check functions

### DIFF
--- a/doc/CONTRIBUTING.md
+++ b/doc/CONTRIBUTING.md
@@ -53,7 +53,7 @@
 
 - Make sure your built-in source has a `name`.
 
-- If the source doesn't use `genertor_factory` to spawn an external command,
+- If the source doesn't use `generator_factory` to spawn an external command,
   define a `can_run` field to verify if the plugin is installed. Note that this
   is only necessary for clarification when `:checkhealth` is run. For example,
   the gitrebase source relies on git being installed:

--- a/doc/CONTRIBUTING.md
+++ b/doc/CONTRIBUTING.md
@@ -53,7 +53,20 @@
 
 - Make sure your built-in source has a `name`.
 
-- Define a `can_run` field to verify if the plugin is installed (if possible).
+- If the source doesn't use `genertor_factory` to spawn an external command,
+  define a `can_run` field to verify if the plugin is installed. Note that this
+  is only necessary for clarification when `:checkhealth` is run. For example,
+  the gitrebase source relies on git being installed:
+
+```lua
+local gitrebase = require("null-ls.helpers").make_builtin({
+    name = "gitrebase",
+    -- other fields...
+    can_run = function()
+        return require("null-ls.utils").is_executable("git")
+    end,
+})
+```
 
 - Add the necessary `meta` field to your built-in so that we can generate extra
   documentation (basic information comes from the built-in's definition).

--- a/lua/null-ls/builtins/code_actions/gitrebase.lua
+++ b/lua/null-ls/builtins/code_actions/gitrebase.lua
@@ -20,6 +20,9 @@ return h.make_builtin({
     },
     method = CODE_ACTION,
     filetypes = { "gitrebase" },
+    can_run = function()
+        return require("null-ls.utils").is_executable("git")
+    end,
     generator = {
         fn = function(params)
             local lines = vim.api.nvim_buf_get_lines(params.bufnr, params.range.row - 1, params.range.row, true)

--- a/lua/null-ls/builtins/code_actions/gitsigns.lua
+++ b/lua/null-ls/builtins/code_actions/gitsigns.lua
@@ -12,6 +12,11 @@ return h.make_builtin({
     },
     method = CODE_ACTION,
     filetypes = {},
+    can_run = function()
+        local status, _ = pcall(require, "gitsigns")
+
+        return status
+    end,
     generator = {
         fn = function(params)
             local ok, gitsigns_actions = pcall(require("gitsigns").get_actions)


### PR DESCRIPTION
Here I add executable check functions for girebase and gitsigns, along with some documentation.

Before:
![image](https://user-images.githubusercontent.com/62671086/205369199-52e86785-5250-4466-aef2-5864123624bc.png)
After:
![image](https://user-images.githubusercontent.com/62671086/205369697-5d4f1a2d-808e-4bbb-b896-0452a0ded04e.png)

and when not installed:
![image](https://user-images.githubusercontent.com/62671086/205369898-7cdb4678-94c0-4386-8565-8d64f962ff41.png)
