### PR TITLE
fix for builtin golangci linter

### DIFF
--- a/lua/null-ls/builtins/diagnostics/golangci_lint.lua
+++ b/lua/null-ls/builtins/diagnostics/golangci_lint.lua
@@ -1,5 +1,6 @@
 local h = require("null-ls.helpers")
 local methods = require("null-ls.methods")
+local log = require("null-ls.logger")
 
 local DIAGNOSTICS_ON_SAVE = methods.internal.DIAGNOSTICS_ON_SAVE
 
@@ -21,7 +22,6 @@ return h.make_builtin({
             "--fix=false",
             "--fast",
             "--out-format=json",
-            "$DIRNAME",
             "--path-prefix",
             "$ROOT",
         },
@@ -31,6 +31,10 @@ return h.make_builtin({
         end,
         on_output = function(params)
             local diags = {}
+            if params.output["Report"] and params.output["Report"]["Error"] then
+                log:warn(params.output["Report"]["Error"])
+                return diags
+            end
             local issues = params.output["Issues"]
             if type(issues) == "table" then
                 for _, d in ipairs(issues) do


### PR DESCRIPTION
Hello

Hello, I am using golangci-lint version 1.50.1 and discovered a bug: `golangci-lint run` doesn't accept any positional arguments, only options.
So current builtins `args` are causing linter to fail because `$DIRECTORY` is used as a positional argument.
I am not sure if this error existed always or this is caused by golangci changed its behaviour at some version.

2nd inconsistency is when linter fails - there weren't any notifications or logs from this builtin, so I've added a warning.