### PR TITLE
fix(builtins)!: modify editorconfig-checker to run using standard tool name

### DIFF
--- a/lua/null-ls/builtins/diagnostics/editorconfig_checker.lua
+++ b/lua/null-ls/builtins/diagnostics/editorconfig_checker.lua
@@ -12,7 +12,7 @@ return h.make_builtin({
     method = DIAGNOSTICS,
     filetypes = {},
     generator_opts = {
-        command = "ec",
+        command = "editorconfig-checker",
         args = {
             "-no-color",
             "$FILENAME",


### PR DESCRIPTION
Hello,

There have been a few discussions around the name of the command that runs when using this source.

- https://github.com/williamboman/mason.nvim/pull/722
- https://github.com/jay-babu/mason-null-ls.nvim/issues/37

This tool currently runs a command call `ec`, which is not the default name of the tool when installed.

https://github.com/editorconfig-checker/editorconfig-checker

after installing using one of the methods described in the repo, I get a tool named: `editorconfig-checker` unless I do some special tinkering to make it work with the `null-ls` wants it. This change now adheres to the standard name of the tool.