### PR TITLE
Fix codespell can't format

### DIFF
--- a/lua/null-ls/builtins/formatting/codespell.lua
+++ b/lua/null-ls/builtins/formatting/codespell.lua
@@ -13,7 +13,7 @@ return h.make_builtin({
     filetypes = {},
     generator_opts = {
         command = "codespell",
-        args = { "--write-changes", "$FILENAME" },
+        args = { "--check-hidden", "--write-changes", "$FILENAME" },
         to_temp_file = true,
     },
     factory = h.formatter_factory,


### PR DESCRIPTION
Fix #1279
Reference: https://github.com/codespell-project/codespell/issues/2633