### PR TITLE
fix: set buflisted to false after apply_text_edits

### DIFF
--- a/lua/null-ls/formatting.lua
+++ b/lua/null-ls/formatting.lua
@@ -70,6 +70,7 @@ M.handler = function(method, original_params, handler)
         local after_each = function(edits)
             local ok, err =
                 pcall(lsp.util.apply_text_edits, edits, temp_bufnr, require("null-ls.client").get_offset_encoding())
+            api.nvim_buf_set_option(temp_bufnr, 'buflisted', false) -- apply_text_edits sets buflisted to true
             if not ok then
                 handle_err(err)
             end

--- a/lua/null-ls/formatting.lua
+++ b/lua/null-ls/formatting.lua
@@ -70,7 +70,7 @@ M.handler = function(method, original_params, handler)
         local after_each = function(edits)
             local ok, err =
                 pcall(lsp.util.apply_text_edits, edits, temp_bufnr, require("null-ls.client").get_offset_encoding())
-            api.nvim_buf_set_option(temp_bufnr, 'buflisted', false) -- apply_text_edits sets buflisted to true
+            api.nvim_buf_set_option(temp_bufnr, "buflisted", false) -- apply_text_edits sets buflisted to true
             if not ok then
                 handle_err(err)
             end


### PR DESCRIPTION
[apply_text_edits is setting buflisted to true](https://github.com/neovim/neovim/blob/8b84a10db76ef2bd15bbd3c06ae2d5dfaadc1482/runtime/lua/vim/lsp/util.lua#L404), which causes the temporary buffer to be visible in bufferline.nvim for a split second