### PR TITLE
Option to change the default cspell json file name

### DIFF
--- a/lua/null-ls/builtins/code_actions/cspell.lua
+++ b/lua/null-ls/builtins/code_actions/cspell.lua
@@ -83,8 +83,8 @@ return h.make_builtin({
             if not is_cspell_config_file_name(create_cspell_json) then
                 vim.notify(
                     "Invalid default file name for cspell json file: "
-                    .. create_config_file_name
-                    .. '. The name "cpsell.json" will be used instead',
+                        .. create_config_file_name
+                        .. '. The name "cpsell.json" will be used instead',
                     vim.log.levels.WARN
                 )
                 create_config_file_name = "cspell.json"

--- a/lua/null-ls/builtins/code_actions/cspell.lua
+++ b/lua/null-ls/builtins/code_actions/cspell.lua
@@ -84,7 +84,7 @@ return h.make_builtin({
                 vim.notify(
                     "Invalid default file name for cspell json file: "
                         .. create_config_file_name
-                        .. '. The name "cpsell.json" will be used instead',
+                        .. '. The name "cspell.json" will be used instead',
                     vim.log.levels.WARN
                 )
                 create_config_file_name = "cspell.json"

--- a/lua/null-ls/builtins/code_actions/cspell.lua
+++ b/lua/null-ls/builtins/code_actions/cspell.lua
@@ -34,15 +34,6 @@ local find_cspell_config = function(cwd)
     return cspell_json_file
 end
 
-local is_cspell_config_file_name = function(file_name)
-    for _, file in ipairs(CSPELL_CONFIG_FILES) do
-        if file_name == file then
-            return true
-        end
-    end
-    return false
-end
-
 -- create a bare minimum cspell.json file
 local create_cspell_json = function(cwd, file_name)
     local cspell_json = {
@@ -80,7 +71,7 @@ return h.make_builtin({
             local create_config_file = config.create_config_file ~= false
 
             local create_config_file_name = config.create_config_file_name or "cspell.json"
-            if not is_cspell_config_file_name(create_cspell_json) then
+            if not vim.tbl_contains(CSPELL_CONFIG_FILES, create_config_file_name) then
                 vim.notify(
                     "Invalid default file name for cspell json file: "
                         .. create_config_file_name

--- a/lua/null-ls/builtins/code_actions/cspell.lua
+++ b/lua/null-ls/builtins/code_actions/cspell.lua
@@ -82,9 +82,9 @@ return h.make_builtin({
             local create_config_file_name = config.create_config_file_name or "cspell.json"
             if not is_cspell_config_file_name(create_cspell_json) then
                 vim.notify(
-                    "Invalid default file name for cspell.json: "
+                    "Invalid default file name for cspell json file: "
                     .. create_config_file_name
-                    .. ". The name cpsell.json will be used instead",
+                    .. '. The name "cpsell.json" will be used instead',
                     vim.log.levels.WARN
                 )
                 create_config_file_name = "cspell.json"


### PR DESCRIPTION
Currently when choosing the option "Add to cspell json file" and no json file exists, a file of the name `cspell.json` will be created. Since I always use `.cspell.json` I would want a way to always use that name instead.