### PR TITLE
Change the default argument of the `yamlfmt` formatter

### DIFF
--- a/lua/null-ls/builtins/formatting/yamlfmt.lua
+++ b/lua/null-ls/builtins/formatting/yamlfmt.lua
@@ -14,7 +14,7 @@ return h.make_builtin({
     generator_opts = {
         command = "yamlfmt",
         to_stdin = true,
-        args = { "-" },
+        args = { "-in" },
     },
     factory = h.formatter_factory,
 })


### PR DESCRIPTION
Today I encountered `yamlfmt` replacing the contents of my files with a single hyphen, and then appending new hyphens on new lines with each save. Perhaps, this has something to do with the [new version](https://github.com/google/yamlfmt/releases/tag/v0.7.0). Anyhow, here's a small fix that works for me.