### PR TITLE
fix(gomodifytags): make gomodifytags more flexible

### DIFF
--- a/lua/null-ls/builtins/code_actions/gomodifytags.lua
+++ b/lua/null-ls/builtins/code_actions/gomodifytags.lua
@@ -4,94 +4,6 @@ local methods = require("null-ls.methods")
 
 local CODE_ACTION = methods.internal.CODE_ACTION
 
-local exec = function(generator_opts, bufname, struct_name, field_name, op, tag)
-    local opts = {}
-    table.insert(opts, "-w")
-    table.insert(opts, "-quiet")
-    table.insert(opts, "-file")
-    table.insert(opts, bufname)
-    table.insert(opts, "-struct")
-    table.insert(opts, struct_name)
-    if field_name ~= nil then
-        table.insert(opts, "-field")
-        table.insert(opts, field_name)
-    end
-    table.insert(opts, op)
-    table.insert(opts, tag)
-
-    vim.fn.execute(":update") -- write when the buffer has been modified
-    local cmd = generator_opts.command .. " " .. table.concat(opts, " ")
-    local output = vim.fn.system(cmd)
-    if vim.api.nvim_get_vvar("shell_error") == 0 then
-        vim.fn.execute(":e " .. bufname) -- reload the file
-    else
-        log:error(output) -- print error message
-    end
-end
-
-local get_input_tag_and_exec = function(generator_opts, bufname, struct_name, field_name, op)
-    vim.ui.input({ prompt = "Enter tags: " }, function(tag)
-        if tag == nil then
-            return
-        end
-        exec(generator_opts, bufname, struct_name, field_name, op, tag)
-    end)
-end
-
-local add_tags = function(generator_opts, bufname, struct_name, field_name)
-    return {
-        title = "gomodifytags: add tags",
-        action = function()
-            get_input_tag_and_exec(generator_opts, bufname, struct_name, field_name, "-add-tags")
-        end,
-    }
-end
-
-local remove_tags = function(generator_opts, bufname, struct_name, field_name)
-    return {
-        title = "gomodifytags: remove tags",
-        action = function()
-            get_input_tag_and_exec(generator_opts, bufname, struct_name, field_name, "-remove-tags")
-        end,
-    }
-end
-
-local clear_tags = function(generator_opts, bufname, struct_name, field_name)
-    return {
-        title = "gomodifytags: clear tags",
-        action = function()
-            exec(generator_opts, bufname, struct_name, field_name, "-clear-tags", nil)
-        end,
-    }
-end
-
-local add_options = function(generator_opts, bufname, struct_name, field_name)
-    return {
-        title = "gomodifytags: add options",
-        action = function()
-            get_input_tag_and_exec(generator_opts, bufname, struct_name, field_name, "-add-options")
-        end,
-    }
-end
-
-local remove_options = function(generator_opts, bufname, struct_name, field_name)
-    return {
-        title = "gomodifytags: remove options",
-        action = function()
-            get_input_tag_and_exec(generator_opts, bufname, struct_name, field_name, "-remove-options")
-        end,
-    }
-end
-
-local clear_options = function(generator_opts, bufname, struct_name, field_name)
-    return {
-        title = "gomodifytags: clear options",
-        action = function()
-            exec(generator_opts, bufname, struct_name, field_name, "-clear-options", nil)
-        end,
-    }
-end
-
 return h.make_builtin({
     name = "gomodifytags",
     meta = {
@@ -106,38 +18,119 @@ return h.make_builtin({
     end,
     generator_opts = {
         command = "gomodifytags",
+        args = { "-quiet" },
     },
     factory = function(opts)
         return {
             fn = function(params)
+                -- Global vars
                 local bufnr = params.bufnr
                 local bufname = params.bufname
-
                 local row = params.range.row
                 local col = params.range.col
-                local tsnode = vim.treesitter.get_node_at_pos(bufnr, row - 1, col - 1, {})
 
+                -- Execution helpers
+                local exec = function(struct_name, field_name, op, tag)
+                    local cmd_opts = vim.list_extend(
+                        { opts.command },
+                        opts.args or {} -- customizable common args
+                    )
+                    vim.list_extend(cmd_opts, { "-w", "-file", bufname, "-struct", struct_name })
+                    if field_name ~= nil then
+                        vim.list_extend(cmd_opts, { "-field", field_name })
+                    end
+                    vim.list_extend(cmd_opts, { op, tag })
+
+                    vim.fn.execute(":update") -- write when the buffer has been modified
+                    local cmd = table.concat(cmd_opts, " ")
+                    local output = vim.fn.system(cmd)
+                    if vim.api.nvim_get_vvar("shell_error") == 0 then
+                        vim.fn.execute(":e " .. bufname) -- reload the file
+                    else
+                        log:error(output) -- print error message
+                    end
+                end
+                local get_input_tag_and_exec = function(struct_name, field_name, op)
+                    vim.ui.input({ prompt = "Enter tags: " }, function(tag)
+                        if tag == nil then
+                            return
+                        end
+                        exec(struct_name, field_name, op, tag)
+                    end)
+                end
+                local add_tags = function(struct_name, field_name)
+                    return {
+                        title = "gomodifytags: add tags",
+                        action = function()
+                            get_input_tag_and_exec(struct_name, field_name, "-add-tags")
+                        end,
+                    }
+                end
+                local remove_tags = function(struct_name, field_name)
+                    return {
+                        title = "gomodifytags: remove tags",
+                        action = function()
+                            get_input_tag_and_exec(struct_name, field_name, "-remove-tags")
+                        end,
+                    }
+                end
+                local clear_tags = function(struct_name, field_name)
+                    return {
+                        title = "gomodifytags: clear tags",
+                        action = function()
+                            exec(struct_name, field_name, "-clear-tags", nil)
+                        end,
+                    }
+                end
+                local add_options = function(struct_name, field_name)
+                    return {
+                        title = "gomodifytags: add options",
+                        action = function()
+                            get_input_tag_and_exec(struct_name, field_name, "-add-options")
+                        end,
+                    }
+                end
+                local remove_options = function(struct_name, field_name)
+                    return {
+                        title = "gomodifytags: remove options",
+                        action = function()
+                            get_input_tag_and_exec(struct_name, field_name, "-remove-options")
+                        end,
+                    }
+                end
+                local clear_options = function(struct_name, field_name)
+                    return {
+                        title = "gomodifytags: clear options",
+                        action = function()
+                            exec(struct_name, field_name, "-clear-options", nil)
+                        end,
+                    }
+                end
+                -- End of Execution helpers
+
+                -- Main
+                local tsnode = vim.treesitter.get_node_at_pos(bufnr, row - 1, col - 1, {})
                 local actions = {}
                 local struct_name
 
-                -- struct
+                -- Ops on struct
                 if (tsnode:type()) == "type_identifier" then
                     struct_name = vim.treesitter.query.get_node_text(tsnode, 0)
                     if struct_name == nil then
                         return
                     end
 
-                    table.insert(actions, add_tags(opts, bufname, struct_name))
-                    table.insert(actions, remove_tags(opts, bufname, struct_name))
-                    table.insert(actions, clear_tags(opts, bufname, struct_name))
+                    table.insert(actions, add_tags(struct_name))
+                    table.insert(actions, remove_tags(struct_name))
+                    table.insert(actions, clear_tags(struct_name))
 
-                    table.insert(actions, add_options(opts, bufname, struct_name))
-                    table.insert(actions, remove_options(opts, bufname, struct_name))
-                    table.insert(actions, clear_options(opts, bufname, struct_name))
+                    table.insert(actions, add_options(struct_name))
+                    table.insert(actions, remove_options(struct_name))
+                    table.insert(actions, clear_options(struct_name))
                     return actions
                 end
 
-                -- struct field
+                -- Ops on struct field
                 if (tsnode:type()) == "field_identifier" then
                     local field_name = vim.treesitter.query.get_node_text(tsnode, 0)
                     local tspnode = tsnode:parent():parent():parent()
@@ -150,13 +143,13 @@ return h.make_builtin({
                         return
                     end
 
-                    table.insert(actions, add_tags(opts, bufname, struct_name, field_name))
-                    table.insert(actions, remove_tags(opts, bufname, struct_name, field_name))
-                    table.insert(actions, clear_tags(opts, bufname, struct_name, field_name))
+                    table.insert(actions, add_tags(struct_name, field_name))
+                    table.insert(actions, remove_tags(struct_name, field_name))
+                    table.insert(actions, clear_tags(struct_name, field_name))
 
-                    table.insert(actions, add_options(opts, bufname, struct_name, field_name))
-                    table.insert(actions, remove_options(opts, bufname, struct_name, field_name))
-                    table.insert(actions, clear_options(opts, bufname, struct_name, field_name))
+                    table.insert(actions, add_options(struct_name, field_name))
+                    table.insert(actions, remove_options(struct_name, field_name))
+                    table.insert(actions, clear_options(struct_name, field_name))
                     return actions
                 end
             end,


### PR DESCRIPTION
# Context

`gomodifytags` code actions currently hard coded binary path and does don't support customization from `generator_opts`

# Solution

Make a simple `factory` wrapper around current `generator` object to accept resolved generator opts

This PR does not change behavior of the current code actions. Only add additional layer for customization