### PR TITLE
Remove --fast default from golangci-lint

### DIFF
--- a/lua/null-ls/builtins/diagnostics/golangci_lint.lua
+++ b/lua/null-ls/builtins/diagnostics/golangci_lint.lua
@@ -20,7 +20,6 @@ return h.make_builtin({
         args = {
             "run",
             "--fix=false",
-            "--fast",
             "--out-format=json",
             "--path-prefix",
             "$ROOT",


### PR DESCRIPTION
First, thanks for null-ls! I've found it to be super helpful.

I spent a good amount of time trying if/why debug if null-ls wasn't working and why I would see no errors via golangci-lint. I turned on debug mode for null-ls and tracked down the problem, the `--fast` flag disables a significant amount of the linters it provides, so the feedback in vim is different from other editors (like vscode) and the golangci-lint CLI output (omitting `--fast`).

This change removes `--fast` from the default arguments for `golangci-lint`. To get the old behavior back, you can use the `extra_args` argument when configuring `golangci-lint`. e.g.

```lua
null_ls.builtins.diagnostics.golangci_lint.with({
  extra_args = { "--fast" },
}),
```

Since it's easier to add extra flags, and this isn't a default flag for other editors, I thought it'd make sense to omit the `--fast` flag and prefer running all linters as the default behavior.