### PR TITLE
fix: builtin.with should use deeply merging instead of shallow merging

### DIFF
--- a/lua/null-ls/helpers/make_builtin.lua
+++ b/lua/null-ls/helpers/make_builtin.lua
@@ -101,7 +101,7 @@ local function make_builtin(opts)
     generator_opts._last_cwd = nil
 
     builtin.with = function(user_opts)
-        return make_builtin(vim.tbl_extend("force", opts, user_opts))
+        return make_builtin(vim.tbl_deep_extend("force", opts, user_opts))
     end
 
     return builtin


### PR DESCRIPTION
For example,

```
builtins.diagnostics.editorconfig_checker.with {
  generator_opts = {
    command = 'editorconfig-checker',
  },
}
```

null-ls will throw an error: `on_output: expected function, got nil`. Because the default values of generator_opts will be overwritten, and `generator_opts.on_output` will be `nil`.