### PR TITLE
fix: filter out permanent cpplint header order warnings

### DIFF
--- a/lua/null-ls/builtins/diagnostics/cpplint.lua
+++ b/lua/null-ls/builtins/diagnostics/cpplint.lua
@@ -37,7 +37,7 @@ return h.make_builtin({
         on_output = function(line, params)
             local rez = diagnostics(line, params)
 
-            if rez.severity == 2 and rez.label == "include_order" then
+            if rez.severity == 2 and (rez.label == "include_order" or rez.label == "header_guard") then
                 return nil
             end
 

--- a/lua/null-ls/builtins/diagnostics/cpplint.lua
+++ b/lua/null-ls/builtins/diagnostics/cpplint.lua
@@ -3,6 +3,20 @@ local methods = require("null-ls.methods")
 
 local DIAGNOSTICS = methods.internal.DIAGNOSTICS
 
+local diagnostics = h.diagnostics.from_pattern(
+    "[^:]+:(%d+):  (.+)  %[(.+)%/(.+)%] %[%d+%]",
+    { "row", "message", "severity", "label" },
+    {
+        severities = {
+            build = h.diagnostics.severities["warning"],
+            whitespace = h.diagnostics.severities["hint"],
+            runtime = h.diagnostics.severities["warning"],
+            legal = h.diagnostics.severities["information"],
+            readability = h.diagnostics.severities["information"],
+        },
+    }
+)
+
 return h.make_builtin({
     name = "cpplint",
     meta = {
@@ -20,19 +34,15 @@ return h.make_builtin({
         to_stdin = false,
         from_stderr = true,
         to_temp_file = true,
-        on_output = h.diagnostics.from_pattern(
-            "[^:]+:(%d+):  (.+)  %[(.+)%/.+%] %[%d+%]",
-            { "row", "message", "severity" },
-            {
-                severities = {
-                    build = h.diagnostics.severities["warning"],
-                    whitespace = h.diagnostics.severities["hint"],
-                    runtime = h.diagnostics.severities["warning"],
-                    legal = h.diagnostics.severities["information"],
-                    readability = h.diagnostics.severities["information"],
-                },
-            }
-        ),
+        on_output = function(line, params)
+            local rez = diagnostics(line, params)
+
+            if rez.severity == 2 and rez.label == "include_order" then
+                return nil
+            end
+
+            return rez
+        end,
         check_exit_code = function(code)
             return code >= 1
         end,


### PR DESCRIPTION
Fixes the situation where header order warnings returned by `cpplint` cannot be fixed because `null-ls` calls the linter on a generated temp file. More details in this [discussion](https://github.com/jose-elias-alvarez/null-ls.nvim/discussions/1300).

It seems there are multiple messages that `cpplint` can return based on improper order of headers in a file, but they are all labelled as `build/include_order`, code [here](https://github.com/cpplint/cpplint/blob/fa12a0bbdafa15291276ddd2a2dcd2ac7a2ce4cb/cpplint.py#L5147).

This PR checks if the returned message from `cpplint` has severity `build` and label `include_order` and filters the message out  if it does.

Fixes #1351

