### PR TITLE
fix: prettier bug adding unecessary output to file

### DIFF
--- a/lua/null-ls/builtins/formatting/prettier.lua
+++ b/lua/null-ls/builtins/formatting/prettier.lua
@@ -38,6 +38,7 @@ return h.make_builtin({
     generator_opts = {
         command = "prettier",
         args = h.range_formatting_args_factory({
+            "--no-plugin-search",
             "--stdin-filepath",
             "$FILENAME",
         }, "--range-start", "--range-end", { row_offset = -1, col_offset = -1 }),


### PR DESCRIPTION
Without the --no-plugin-search option, null_ls includes extraneous output from auto loaded prettier plugins into the file. So for example, in the following output, the addition information was being inserted into the neovim buffer.

![image](https://user-images.githubusercontent.com/66522725/213932806-406374f5-144e-406a-960b-ccbf802e6f39.png)
