### PR TITLE
fix(ansiblelint): Use 'description' field

### DIFF
--- a/lua/null-ls/builtins/diagnostics/ansiblelint.lua
+++ b/lua/null-ls/builtins/diagnostics/ansiblelint.lua
@@ -37,7 +37,7 @@ return h.make_builtin({
                 table.insert(params.messages, {
                     row = row,
                     col = col,
-                    message = message.check_name,
+                    message = message.description,
                     severity = severities[message.severity],
                     filename = message.location.path,
                 })


### PR DESCRIPTION
For ansiblelint, typically the `check_name` field does not contain particularly helpful content, such as `yaml[indentation]`. The `description` field is human-readable, containing the equivalent `Wrong indentation: expected 8 but found 7`. This makes for much more helpful reading when looking at the diagnostics output from `ansiblelint`.