### PR TITLE
feat(builtins): add erb-formatter support

### DIFF
--- a/lua/null-ls/builtins/formatting/erb_format.lua
+++ b/lua/null-ls/builtins/formatting/erb_format.lua
@@ -1,0 +1,20 @@
+local h = require("null-ls.helpers")
+local methods = require("null-ls.methods")
+
+local FORMATTING = methods.internal.FORMATTING
+
+return h.make_builtin({
+    name = "erb-format",
+    meta = {
+        url = "https://github.com/nebulab/erb-formatter",
+        description = "Format ERB files with speed and precision.",
+    },
+    method = FORMATTING,
+    filetypes = { "eruby" },
+    generator_opts = {
+        command = "erb-format",
+        args = { "--stdin" },
+        to_stdin = true,
+    },
+    factory = h.formatter_factory,
+})


### PR DESCRIPTION
Adds a built-in formatter to support `erb-formatter` to handle embedded Ruby files (https://github.com/nebulab/erb-formatter)

`erb-formatter` seems to produce much better results than `erb_lint`.