### PR TITLE
fix: utils.root_pattern not checking the start_path for patterns

### DIFF
--- a/lua/null-ls/utils/init.lua
+++ b/lua/null-ls/utils/init.lua
@@ -254,17 +254,35 @@ M.path = {
 M.root_pattern = function(...)
     local patterns = vim.tbl_flatten({ ... })
 
-    return function(start_path)
-        for path in vim.fs.parents(start_path) do
-            -- escape wildcard characters in the path so that it is not treated like a glob
-            path = path:gsub("([%[%]%?%*])", "\\%1")
-            for _, pattern in ipairs(patterns) do
-                ---@diagnostic disable-next-line: param-type-mismatch
-                for _, p in ipairs(vim.fn.glob(M.path.join(path, pattern), true, true)) do
-                    if M.path.exists(p) then
-                        return path
-                    end
+    local function matcher(path)
+        if not path then
+            return nil
+        end
+
+        -- escape wildcard characters in the path so that it is not treated like a glob
+        path = path:gsub("([%[%]%?%*])", "\\%1")
+        for _, pattern in ipairs(patterns) do
+            ---@diagnostic disable-next-line: param-type-mismatch
+            for _, p in ipairs(vim.fn.glob(M.path.join(path, pattern), true, true)) do
+                if M.path.exists(p) then
+                    return path
                 end
+            end
+        end
+
+        return nil
+    end
+
+    return function(start_path)
+        local start_match = matcher(start_path)
+        if start_match then
+            return start_match
+        end
+
+        for path in vim.fs.parents(start_path) do
+            local match = matcher(path)
+            if match then
+                return match
             end
         end
     end

--- a/test/spec/utils/utils_spec.lua
+++ b/test/spec/utils/utils_spec.lua
@@ -407,4 +407,17 @@ describe("utils", function()
             assert.equals(root, vim.loop.cwd())
         end)
     end)
+
+    describe("root_pattern", function()
+        local test_path = u.path.join(u.get_root(), "test")
+        local start_path = u.path.join(u.get_root(), "test", "spec", "utils")
+
+        it("matches the pattern in the start_path", function()
+            assert.equals(start_path, u.root_pattern("utils_spec.lua")(start_path))
+        end)
+
+        it("matches the pattern in the start_path parents", function()
+            assert.equals(test_path, u.root_pattern("minimal.vim")(start_path))
+        end)
+    end)
 end)


### PR DESCRIPTION
In https://github.com/jose-elias-alvarez/null-ls.nvim/commit/f1182c2d3748da7c94f5288f8054741f26f0cf3b the function was changed from using `M.search_ancestors` which first checked the `start_path` and then the ancestors, to a `vim.fn.parents` iteration which does not include the `start_path` check anymore.

This PR adds a check for the `start_path` first (like it was before that commit) and then does the `vim.fn.parents`.