### PR TITLE
fix(builtins): handle extra files in ansible-lint results

### DIFF
--- a/lua/null-ls/builtins/diagnostics/ansiblelint.lua
+++ b/lua/null-ls/builtins/diagnostics/ansiblelint.lua
@@ -28,19 +28,21 @@ return h.make_builtin({
             }
             params.messages = {}
             for _, message in ipairs(params.output) do
-                local col = nil
-                local row = message.location.lines.begin
-                if type(row) == "table" then
-                    row = row.line
-                    col = row.column
+                if params.temp_path:match(vim.pesc(message.location.path)) then
+                    local col = nil
+                    local row = message.location.lines.begin
+                    if type(row) == "table" then
+                        row = row.line
+                        col = row.column
+                    end
+                    table.insert(params.messages, {
+                        row = row,
+                        col = col,
+                        message = message.check_name,
+                        severity = severities[message.severity],
+                        filename = params.bufname,
+                    })
                 end
-                table.insert(params.messages, {
-                    row = row,
-                    col = col,
-                    message = message.check_name,
-                    severity = severities[message.severity],
-                    filename = message.location.path,
-                })
             end
             return params.messages
         end,

--- a/test/spec/builtins/diagnostics_spec.lua
+++ b/test/spec/builtins/diagnostics_spec.lua
@@ -1035,35 +1035,58 @@ describe("diagnostics", function()
         it("should create a diagnostic", function()
             local output = [[
                 [
-                  {
-                    "type": "issue",
-                    "check_name": "[risky-file-permissions] File permissions unset or incorrect",
-                    "categories": [
-                      "unpredictability",
-                      "experimental"
-                    ],
-                    "severity": "blocker",
-                    "description": "Missing or unsupported mode parameter can cause unexpected file permissions based on version of Ansible being used. Be explicit, like ``mode: 0644`` to avoid hitting this rule. Special ``preserve`` value is accepted only by copy, template modules. See https://github.com/ansible/ansible/issues/71200",
-                    "fingerprint": "b66d9f9db860c0fedb7d1d583c5a808df9a1ed72b8abdbedeff0aad836490951",
-                    "location": {
-                      "path": "playbooks/test-ansible.yaml",
-                      "lines": {
-                        "begin": 5
-                      }
+                    {
+                        "type": "issue",
+                        "check_name": "[risky-file-permissions] File permissions unset or incorrect",
+                        "categories": [
+                            "unpredictability",
+                            "experimental"
+                        ],
+                        "severity": "blocker",
+                        "description": "Missing or unsupported mode parameter can cause unexpected file permissions based on version of Ansible being used. Be explicit, like ``mode: 0644`` to avoid hitting this rule. Special ``preserve`` value is accepted only by copy, template modules. See https://github.com/ansible/ansible/issues/71200",
+                        "fingerprint": "b66d9f9db860c0fedb7d1d583c5a808df9a1ed72b8abdbedeff0aad836490951",
+                        "location": {
+                            "path": "playbooks/.null-ls_123456_test-ansible.yaml",
+                            "lines": {
+                                "begin": 5
+                            }
+                        },
+                        "content": {
+                            "body": "Task/Handler: This tasks is no good"
+                        }
                     },
-                    "content": {
-                      "body": "Task/Handler: This tasks is no good"
+                    {
+                        "type": "issue",
+                        "check_name": "yaml[truthy]",
+                        "categories": [
+                            "formatting",
+                            "yaml"
+                        ],
+                        "severity": "info",
+                        "description": "truthy value should be one of \\[false, true]",
+                        "fingerprint": "8564f80bca9d93054e646e7ec5cfe5ee2c279b821ca183183c79d055bc062b8d",
+                        "location": {
+                            "path": "playbooks/imported-tasks.yaml",
+                            "lines": {
+                                "begin": 3
+                            }
+                        }
                     }
-                  }
                 ]
             ]]
-            local diagnostic = parser({ output = vim.json.decode(output), content = file })
+            local diagnostic = parser({
+                output = vim.json.decode(output),
+                content = file,
+                temp_path = "/home/null-ls/test/playbooks/.null-ls_123456_test-ansible.yaml",
+                root = "/home/null-ls/test",
+                bufname = "/home/null-ls/test/playbooks/test-ansible.yaml",
+            })
             assert.same({
                 {
                     row = 5,
                     severity = 1,
                     message = "[risky-file-permissions] File permissions unset or incorrect",
-                    filename = "playbooks/test-ansible.yaml",
+                    filename = "/home/null-ls/test/playbooks/test-ansible.yaml",
                 },
             }, diagnostic)
         end)


### PR DESCRIPTION
ansible-lint will include lint results from included/imported task files.

```yaml
# roles/foobar/tasks/main.yml
- name: Ping
  ping:

- name: Include other task
  include_tasks: baz.yml
```

```yaml
# roles/foobar/tasks/baz.yml
- name: Some lint results here
  set_fact:
    foo: yes

```

ansible-lint result:
```bash
ansible-lint -P=basic -f codeclimate -q roles/foobar/tasks/main.yml | jq
[
  {
    "type": "issue",
    "check_name": "yaml[truthy]",
    "categories": [
      "formatting",
      "yaml"
    ],
    "severity": "info",
    "description": "truthy value should be one of \\[false, true]",
    "fingerprint": "8564f80bca9d93054e646e7ec5cfe5ee2c279b821ca183183c79d055bc062b8d",
    "location": {
      "path": "roles/foobar/tasks/baz.yml",
      "lines": {
        "begin": 3
      }
    }
  }
]
```

ansible-lint was run against **main.yml** but the result was from **baz.yml**, which will result in a confusing floating text in nvim:
<img width="339" alt="image" src="https://user-images.githubusercontent.com/1898104/217491062-f36a79c4-3aea-421a-be98-46e0d9ba34ce.png">

This PR tries to fix this issue.