### PR TITLE
fix(chktex): Support exit codes for newer version

### DIFF
--- a/lua/null-ls/builtins/diagnostics/chktex.lua
+++ b/lua/null-ls/builtins/diagnostics/chktex.lua
@@ -22,7 +22,7 @@ return h.make_builtin({
         },
         format = "line",
         check_exit_code = function(code)
-            return code <= 1
+            return code <= 3
         end,
         on_output = h.diagnostics.from_pattern(
             [[(%d+):(%d+):(%d+):(%w+):(%d+):(.+)]],


### PR DESCRIPTION
In the latest chktex commits, chktex also produces exit codes 2 and 3 if there are errors and warnings. The Debian package (and its derivates) have already backported this change to their newest version.

Fixes: #1390
Ref: http://git.savannah.nongnu.org/cgit/chktex.git/commit/?id=ec0fb9b58f02a62ff0bfec98b997208e9d7a5998