### PR TITLE
perf(client): Make conditional source registration faster

### DIFF
--- a/lua/null-ls/client.lua
+++ b/lua/null-ls/client.lua
@@ -178,7 +178,10 @@ M.on_source_change = vim.schedule_wrap(function()
             M.retry_add(bufnr)
 
             -- if in named buffer, we can register conditional sources immediately
-            if s.has_conditional_sources() and api.nvim_buf_get_name(bufnr) ~= "" then
+            -- we need to check only for normal buffers, excluding nofile and terminals
+            local buftype = api.nvim_buf_get_option(bufnr, "buftype")
+            local bufname = api.nvim_buf_get_name(bufnr)
+            if s.has_conditional_sources() and bufname ~= "" and buftype == "" then
                 s.register_conditional_sources()
             end
         else


### PR DESCRIPTION
null_ls.client.on_source_change is called upon null_ls.setup() or
enabling null-ls, but this method can often be slow and blocking
when searching all the existing buffers and trying to register
conditional sources, especially when their conditions may do some
slow I/O operations (e.g., file existence check).

Scanning all the existing buffers is also done over non-file buffers,
including terminal or nofile (temporary) buffers, which is not necessary
because they usually don't have any files associated with.
Skipping those buffers when trying to register sources will make
null-ls initialization performance much faster; in particular,
rendering of terminal buffers that are open before null_ls is loaded
will no longer stall.
