### PR TITLE
fix(cspell): diagnostic builtin uses local config

### DIFF
--- a/lua/null-ls/builtins/diagnostics/cspell.lua
+++ b/lua/null-ls/builtins/diagnostics/cspell.lua
@@ -36,7 +36,7 @@ return h.make_builtin({
                 "lint",
                 "--language-id",
                 params.ft,
-                "stdin",
+                params.bufname,
             }
 
             -- only enable suggestions when using the code actions built-in, since they slow down the command


### PR DESCRIPTION
The cspell diagnostic builtin is unable to find local configuration files because `stdin` is being provided to the CLI, which isn't aware of the file's path. Cspell's global configuration file (in the home directory) is used if it exists.

The code_action builtin works correctly. When you choose the "add to cspell json file" action it uses the closest ancestor, or when no config exists it creates on in the current directory. However since the diagnostic builtin is using the global config, the error does not go away.

You can repro when you either
1) Don't have a global config
3) Have a global config and local config

It works correclty when you have a global config and no local config. The code_action builtin adds the word to the global config, which the diagnostic builtin is able to see.

This change resolves the issue. I didn't see a contributing doc, but let me know if I need to change anything or provide additional info, such as repro sample/steps.