### PR TITLE
fix(mypy): disable multiple files

### DIFF
--- a/lua/null-ls/builtins/diagnostics/mypy.lua
+++ b/lua/null-ls/builtins/diagnostics/mypy.lua
@@ -43,7 +43,7 @@ benefits of dynamic (or "duck") typing and static typing.]],
         check_exit_code = function(code)
             return code <= 2
         end,
-        multiple_files = true,
+        multiple_files = false,
         on_output = h.diagnostics.from_patterns({
             -- see spec for pattern examples
             {


### PR DESCRIPTION
When a file is passed to mypy, it only checks that file, so the plugin should not handle filename.

Also, filename returned by mypy is relative to cwd of where mypy is run. This cwd may be different from the current cwd of neovim, this result of diagnostic.filename to be unpredictable as neovim toolings will concat cwd to diagnostic.filename to guess the right buffer.