### PR TITLE
feat(builtins): allow using dprint bin from node_modules

### DIFF
--- a/lua/null-ls/builtins/formatting/dprint.lua
+++ b/lua/null-ls/builtins/formatting/dprint.lua
@@ -1,5 +1,6 @@
 local h = require("null-ls.helpers")
 local methods = require("null-ls.methods")
+local cmd_resolver = require("null-ls.helpers.command_resolver")
 
 local FORMATTING = methods.internal.FORMATTING
 
@@ -32,6 +33,7 @@ return h.make_builtin({
             "$FILENAME",
         },
         to_stdin = true,
+        dynamic_command = cmd_resolver.from_node_modules(),
     },
     factory = h.formatter_factory,
 })


### PR DESCRIPTION
The current dprint config only works when dprint is installed globally (and present on PATH). So, it does not work when dprint is locally installed with some Node.js's package manager (ex: `npm i -D dprint`).

This PR sets the `dynamic_command` option on the dprint formatter to allow that (I just copied/pasted from the prettier config :yum: ).