### PR TITLE
fix(rubocop): change auto-correct to autocorrect

### DIFF
--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -3979,7 +3979,7 @@ local sources = { null_ls.builtins.formatting.rubocop }
 - Filetypes: `{ "ruby" }`
 - Method: `formatting`
 - Command: `rubocop`
-- Args: `{ "--auto-correct", "-f", "quiet", "--stderr", "--stdin", "$FILENAME" }`
+- Args: `{ "-a", "-f", "quiet", "--stderr", "--stdin", "$FILENAME" }`
 
 ### [ruff](https://github.com/charliermarsh/ruff/)
 

--- a/lua/null-ls/builtins/formatting/rubocop.lua
+++ b/lua/null-ls/builtins/formatting/rubocop.lua
@@ -14,7 +14,9 @@ return h.make_builtin({
     generator_opts = {
         command = "rubocop",
         args = {
-            "--auto-correct",
+            -- NOTE: For backwards compatibility,
+            -- we are still using "-a" shorthand' for both "--auto-correct" (pre-1.3.0) and "--autocorrect" (1.3.0+).
+            "-a",
             "-f",
             "quiet",
             "--stderr",


### PR DESCRIPTION
I encountered an error message stating
`'--auto-correct' is deprecated and should be replaced with '--autocorrect'`

It's due to Rubocop v1.30.0 where 'auto-correct' became a duplicate and was replaced with 'autocorrect'. 
https://github.com/rubocop/rubocop/pull/10547

Therefore, I have made the necessary correction to the code to use '--autocorrect' instead."