### PR TITLE
Fix crystal formatting

### DIFF
--- a/lua/null-ls/builtins/formatting/crystal_format.lua
+++ b/lua/null-ls/builtins/formatting/crystal_format.lua
@@ -13,7 +13,7 @@ return h.make_builtin({
     filetypes = { "crystal" },
     generator_opts = {
         command = "crystal",
-        args = { "tool", "format" },
+        args = { "tool", "format", "-" },
         to_stdin = true,
     },
     factory = h.formatter_factory,


### PR DESCRIPTION
Crystal formatting is broken as `crystal tool format` by default formats files in-place.

To format stdout (as null-ls expects), one needs to add an argument `-`. That way `crystal tool format` reads from stdin and writes to stdout.