### PR TITLE
fix(ansiblelint): Use 'description' and 'check_name' field

### DIFF
--- a/lua/null-ls/builtins/diagnostics/ansiblelint.lua
+++ b/lua/null-ls/builtins/diagnostics/ansiblelint.lua
@@ -38,7 +38,8 @@ return h.make_builtin({
                     table.insert(params.messages, {
                         row = row,
                         col = col,
-                        message = message.check_name,
+                        message = message.description,
+                        code = message.check_name,
                         severity = severities[message.severity],
                         filename = params.bufname,
                     })

--- a/test/spec/builtins/diagnostics_spec.lua
+++ b/test/spec/builtins/diagnostics_spec.lua
@@ -1085,7 +1085,8 @@ describe("diagnostics", function()
                 {
                     row = 5,
                     severity = 1,
-                    message = "[risky-file-permissions] File permissions unset or incorrect",
+                    message = "Missing or unsupported mode parameter can cause unexpected file permissions based on version of Ansible being used. Be explicit, like ``mode: 0644`` to avoid hitting this rule. Special ``preserve`` value is accepted only by copy, template modules. See https://github.com/ansible/ansible/issues/71200",
+                    code = "[risky-file-permissions] File permissions unset or incorrect",
                     filename = "/home/null-ls/test/playbooks/test-ansible.yaml",
                 },
             }, diagnostic)


### PR DESCRIPTION
This is in reference to #1381, this adds the same changes (using the 'description' field of ansiblelint as message and the 'check_name' field as code).

I'm not sure if I'm using the `code` property correctly.

The tests have also been modified accordingly.