### PR TITLE
Fix ocamlformat not overwriting

### DIFF
--- a/lua/null-ls/builtins/formatting/ocamlformat.lua
+++ b/lua/null-ls/builtins/formatting/ocamlformat.lua
@@ -13,7 +13,7 @@ return h.make_builtin({
     filetypes = { "ocaml" },
     generator_opts = {
         command = "ocamlformat",
-        args = { "--enable-outside-detected-project", "-" },
+        args = { "--enable-outside-detected-project", "--name", "$FILENAME", "-" },
         to_stdin = true,
     },
     factory = h.formatter_factory,


### PR DESCRIPTION
Before, it was not overwriting the original file for some reason.