### PR TITLE
fix `djhtml` formatter to support new version

### DIFF
--- a/lua/null-ls/builtins/formatting/djhtml.lua
+++ b/lua/null-ls/builtins/formatting/djhtml.lua
@@ -13,6 +13,7 @@ return h.make_builtin({
     filetypes = { "django", "jinja.html", "htmldjango" },
     generator_opts = {
         command = "djhtml",
+        args = { "-" },
         to_stdin = true,
     },
     factory = h.formatter_factory,


### PR DESCRIPTION
I believe with the new 3.0 upgrade ( https://github.com/rtts/djhtml ) the expected command line arguments changed. 

After the upgrade, this was definitely broken, and adding this `arg` fixes it. 