### PR TITLE
fix: bslint extra whitespace in message removed

### DIFF
--- a/lua/null-ls/builtins/diagnostics/bslint.lua
+++ b/lua/null-ls/builtins/diagnostics/bslint.lua
@@ -43,7 +43,7 @@ return h.make_builtin({
                             col = col,
                             code = code,
                             source = "bslint",
-                            message = " " .. message,
+                            message = message,
                             severity = severity[err],
                         })
                     end


### PR DESCRIPTION
Sorry I missed this when I first added the code.