### PR TITLE
fix(builtins): Separate diagnostic messages for 'checkmake' linter

### DIFF
--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -462,7 +462,7 @@ local sources = { null_ls.builtins.diagnostics.checkmake }
 - Filetypes: `{ "make" }`
 - Method: `diagnostics`
 - Command: `checkmake`
-- Args: `{ "--format='{{.LineNumber}}:{{.Rule}}:{{.Violation}}'", "$FILENAME" }`
+- Args: `{ "--format='{{.LineNumber}}:{{.Rule}}:{{.Violation}}\n'", "$FILENAME" }`
 
 ### [checkstyle](https://checkstyle.org)
 

--- a/lua/null-ls/builtins/diagnostics/checkmake.lua
+++ b/lua/null-ls/builtins/diagnostics/checkmake.lua
@@ -14,7 +14,7 @@ return h.make_builtin({
     generator_opts = {
         command = "checkmake",
         args = {
-            "--format='{{.LineNumber}}:{{.Rule}}:{{.Violation}}'",
+            "--format='{{.LineNumber}}:{{.Rule}}:{{.Violation}}\n'",
             "$FILENAME",
         },
         to_stdin = false,


### PR DESCRIPTION
It appears that due to the format specified for `checkmake` (missing newline character at the end of each line), all diagnostic messages are provided to `null-ls` on a single line, instead of several lines.

Before:
<img width="1296" alt="Screenshot 2023-03-15 at 10 45 04" src="https://user-images.githubusercontent.com/22768251/225290865-e82570bb-2533-4a97-86d0-15095cca47af.png">

WIth fix:
<img width="668" alt="Screenshot 2023-03-15 at 10 58 57" src="https://user-images.githubusercontent.com/22768251/225290926-732748f4-b114-43c3-b874-e8e58d09dc1f.png">
