### PR TITLE
fix(builtins/diagnostics/vacuum): use report instead of spectral-report

### DIFF
--- a/lua/null-ls/builtins/diagnostics/vacuum.lua
+++ b/lua/null-ls/builtins/diagnostics/vacuum.lua
@@ -2,7 +2,7 @@ local h = require("null-ls.helpers")
 local methods = require("null-ls.methods")
 
 local DIAGNOSTICS = methods.internal.DIAGNOSTICS
-local severities = { 1, 2, 3, 4 }
+local severities = { error = 1, warn = 2, info = 3, hint = 4 }
 
 return h.make_builtin({
     name = "vacuum",
@@ -15,7 +15,7 @@ return h.make_builtin({
     generator_opts = {
         command = "vacuum",
         args = {
-            "spectral-report",
+            "report",
             "--stdin",
             "--stdout",
         },
@@ -27,7 +27,11 @@ return h.make_builtin({
         end,
         on_output = function(params)
             local diags = {}
-            for _, d in ipairs(params.output) do
+            if params.output.resultSet.results == vim.NIL then
+                return diags
+            end
+
+            for _, d in ipairs(params.output.resultSet.results) do
                 table.insert(diags, {
                     row = d.range.start.line,
                     col = d.range.start.character,
@@ -35,12 +39,13 @@ return h.make_builtin({
                     end_col = d.range["end"].character,
                     source = "Vacuum",
                     message = d.message,
-                    severity = severities[d.severity + 1],
-                    code = d.code,
+                    severity = severities[d.ruleSeverity],
+                    code = d.ruleId,
                     path = d.path,
                 })
             end
             return diags
         end,
     },
+    factory = h.generator_factory,
 })


### PR DESCRIPTION
I noticed a few errors with the original addition of this builtin. Notably,

* A generator function was missing
* Using `spectral-report` instead of vacuum's own `report` implementation
* Severities were not quite correct