### PR TITLE
Add rubyfmt formatter to built-ins

### DIFF
--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -4067,6 +4067,23 @@ local sources = { null_ls.builtins.formatting.ruff }
 - Command: `ruff`
 - Args: `{ "--fix", "-e", "-n", "--stdin-filename", "$FILENAME", "-" }`
 
+### [rubyfmt](https://github.com/fables-tales/rubyfmt)
+
+Ruby autoformatter, written in Rust. Can be installed on macOS with `brew install rubyfmt`.
+
+#### Usage
+
+```lua
+local sources = { null_ls.builtins.formatting.rubyfmt }
+```
+
+#### Defaults
+
+- Filetypes: `{ "ruby" }`
+- Method: `formatting`
+- Command: `rubyfmt`
+- Args: `{ }`
+
 ### [rufo](https://github.com/ruby-formatter/rufo)
 
 Opinionated ruby formatter.

--- a/lua/null-ls/builtins/formatting/rubyfmt.lua
+++ b/lua/null-ls/builtins/formatting/rubyfmt.lua
@@ -1,0 +1,30 @@
+local h = require('null-ls.helpers')
+local methods = require('null-ls.methods')
+local u = require('null-ls.utils')
+
+local FORMATTING = methods.internal.FORMATTING
+
+return h.make_builtin({
+  name = 'rubyfmt',
+  meta = {
+    url = 'https://github.com/fables-tales/rubyfmt',
+    description = 'Format your Ruby code!',
+    notes = {
+      'Install to your PATH with `brew install rubyfmt`. Ensure you have the latest version.',
+    },
+  },
+  method = FORMATTING,
+  filetypes = {
+    'ruby',
+  },
+  generator_opts = {
+    command = 'rubyfmt',
+    args = {},
+    to_stdin = true,
+    check_exit_code = { 0, 1 },
+    cwd = h.cache.by_bufnr(function(params)
+      return u.root_pattern('Gemfile', 'Gemfile.lock', 'sorbet')(params.bufname)
+    end),
+  },
+  factory = h.formatter_factory,
+})

--- a/lua/null-ls/builtins/formatting/rubyfmt.lua
+++ b/lua/null-ls/builtins/formatting/rubyfmt.lua
@@ -1,30 +1,30 @@
-local h = require('null-ls.helpers')
-local methods = require('null-ls.methods')
-local u = require('null-ls.utils')
+local h = require("null-ls.helpers")
+local methods = require("null-ls.methods")
+local u = require("null-ls.utils")
 
 local FORMATTING = methods.internal.FORMATTING
 
 return h.make_builtin({
-  name = 'rubyfmt',
-  meta = {
-    url = 'https://github.com/fables-tales/rubyfmt',
-    description = 'Format your Ruby code!',
-    notes = {
-      'Install to your PATH with `brew install rubyfmt`. Ensure you have the latest version.',
+    name = "rubyfmt",
+    meta = {
+        url = "https://github.com/fables-tales/rubyfmt",
+        description = "Format your Ruby code!",
+        notes = {
+            "Install to your PATH with `brew install rubyfmt`. Ensure you have the latest version.",
+        },
     },
-  },
-  method = FORMATTING,
-  filetypes = {
-    'ruby',
-  },
-  generator_opts = {
-    command = 'rubyfmt',
-    args = {},
-    to_stdin = true,
-    check_exit_code = { 0, 1 },
-    cwd = h.cache.by_bufnr(function(params)
-      return u.root_pattern('Gemfile', 'Gemfile.lock', 'sorbet')(params.bufname)
-    end),
-  },
-  factory = h.formatter_factory,
+    method = FORMATTING,
+    filetypes = {
+        "ruby",
+    },
+    generator_opts = {
+        command = "rubyfmt",
+        args = {},
+        to_stdin = true,
+        check_exit_code = { 0, 1 },
+        cwd = h.cache.by_bufnr(function(params)
+            return u.root_pattern("Gemfile", "Gemfile.lock", "sorbet")(params.bufname)
+        end),
+    },
+    factory = h.formatter_factory,
 })


### PR DESCRIPTION
This adds the Rust-based [rubyfmt](https://github.com/fables-tales/rubyfmt) formatter as a built-in to null-ls.