### PR TITLE
fix(goimports_reviser): remove the deprecated -file-path arg

### DIFF
--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -3178,7 +3178,7 @@ local sources = { null_ls.builtins.formatting.goimports_reviser }
 - Filetypes: `{ "go" }`
 - Method: `formatting`
 - Command: `goimports-reviser`
-- Args: `{ "-file-path", "$FILENAME", "-output", "stdout" }`
+- Args: `{ "$FILENAME" }`
 
 ### [golines](https://pkg.go.dev/github.com/segmentio/golines)
 

--- a/lua/null-ls/builtins/formatting/goimports_reviser.lua
+++ b/lua/null-ls/builtins/formatting/goimports_reviser.lua
@@ -13,8 +13,11 @@ return h.make_builtin({
     filetypes = { "go" },
     generator_opts = {
         command = "goimports-reviser",
-        args = { "-file-path", "$FILENAME", "-output", "stdout" },
-        to_stdin = true,
+        args = { "$FILENAME" },
+        -- goimports-reviser doesn't support reading from stdin
+        -- can use `to_stdin = true` with args = { "-output", "stdout", "$FILENAME" }
+        -- when it does
+        to_temp_file = true,
     },
     factory = h.formatter_factory,
 })


### PR DESCRIPTION
Removed the deprecated -file-path arg and moved $FILENAME to the end as suggested. https://github.com/incu6us/goimports-reviser/commit/979c6e70f1b9dd25a30af74d8ae3efd4205a1bd2

EDIT: based on the discussion #1472, using temp file for now, till the issue with `stdin` gets resolved upstream.