### PR TITLE
feat(builtins/diagnostics/credo): toggle per file/full workspace diagnostics

### DIFF
--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -689,7 +689,22 @@ local sources = { null_ls.builtins.diagnostics.credo }
 - Filetypes: `{ "elixir" }`
 - Method: `diagnostics`
 - Command: `mix`
-- Args: `{ "credo", "suggest", "--format", "json", "--read-from-stdin", "$FILENAME" }`
+- Args: dynamically resolved (see [source](https://github.com/jose-elias-alvarez/null-ls.nvim/blob/main/lua/null-ls/builtins/diagnostics/credo.lua))
+
+#### Config
+
+##### `full_workspace` (boolean)
+
+- `false` (default) - run credo for a single file
+- `true` - run credo on the entire workspace. If this is slow on large projects, you may wish to set `method = null_ls.methods.DIAGNOSTICS_ON_SAVE` in `with()` call.
+
+```lua
+local credo = null_ls.builtins.diagnostics.credo.with({
+    config = {
+        full_workspace = true
+    },
+})
+```
 
 #### Notes
 


### PR DESCRIPTION
Add `full_workspace` boolean config param to credo.

When `false` (default), credo will run for current file in buffer - this preserves existing behaviour.
When `true`, credo will run globally for all files in the project workspace

Attached is a demo showing with config param disabled (default), then enabled. 
- The first  time nvim is opened, only the credo diagnostics for the selected buffer are generated. When a different buffer is opened, diagnostics for that buffer are additionally generated.
- The config is modified to add `full_workspace = true` for credo. nvim is opened again. When credo runs, project wide diagnostics are generated and populated (instead of just the current buffer).

https://user-images.githubusercontent.com/27223/227716696-686c8bfc-7c4a-4f90-9017-aa6f5b99969d.mov

