### PR TITLE
fix(gomodifytags): detect struct type declaration

### DIFF
--- a/lua/null-ls/builtins/code_actions/gomodifytags.lua
+++ b/lua/null-ls/builtins/code_actions/gomodifytags.lua
@@ -121,6 +121,15 @@ return h.make_builtin({
 
                 -- Ops on struct
                 if (tsnode:type()) == "type_identifier" then
+                    local tspnode = tsnode:parent()
+                    if tspnode == nil or tspnode:type() ~= "type_spec" then
+                        return
+                    end
+                    local typename_node = tspnode:field("type")[1]
+                    if typename_node == nil or typename_node:type() ~= "struct_type" then
+                        return
+                    end
+
                     struct_name = vim.treesitter.query.get_node_text(tsnode, 0)
                     if struct_name == nil then
                         return


### PR DESCRIPTION
Before all type identifiers were detected as struct declarations. This led to the next problems:
* declarations of other types were always struct declarations;
* using types for fields were detected the same way.