### PR TITLE
Add sqlfmt formatter to built-ins

### DIFF
--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -1845,6 +1845,23 @@ local sources = {
 
 - SQLFluff needs a mandatory `--dialect` argument. Use `extra_args` to add yours, or create a .sqlfluff file in the same directory as the SQL file to specify the dialect (see the sqlfluff docs for details). `extra_args` can also be a function to build more sophisticated logic.
 
+### [sqlfmt](https://sqlfmt.com/)
+
+sqlfmt formats your dbt SQL files so you don't have to. It is similar in nature to Black, gofmt, and rustfmt (but for SQL).
+
+#### Usage
+
+```lua
+local sources = { null_ls.builtins.diagnostics.sqlfmt }
+```
+
+#### Defaults
+
+- Filetypes: `{ "sql", "jinja" }`
+- Method: `formatting`
+- Command: `sqlfmt`
+- Args: `{ }`
+
 ### [standardjs](https://standardjs.com/)
 
 JavaScript style guide, linter, and formatter.

--- a/lua/null-ls/builtins/formatting/sqlfmt.lua
+++ b/lua/null-ls/builtins/formatting/sqlfmt.lua
@@ -24,7 +24,7 @@ return h.make_builtin({
         to_stdin = true,
         check_exit_code = { 0, 1 },
         cwd = h.cache.by_bufnr(function(params)
-            return u.root_pattern("dbt_project.yml")(params.bufnr) or vim.fn.getcwd()
+            return u.root_pattern("dbt_project.yml")(params.bufnr)
         end),
     },
     factory = h.formatter_factory,

--- a/lua/null-ls/builtins/formatting/sqlfmt.lua
+++ b/lua/null-ls/builtins/formatting/sqlfmt.lua
@@ -5,27 +5,27 @@ local u = require("null-ls.utils")
 local FORMATTING = methods.internal.FORMATTING
 
 return h.make_builtin({
-  name = "sqlfmt",
-  meta = {
-    url = "https://sqlfmt.com/",
-    description = "Formats your dbt SQL files so you don't have to",
-    notes = {
-      "Install sqlfmt with `pip install shandy-sqlfmt[jinjafmt]`",
+    name = "sqlfmt",
+    meta = {
+        url = "https://sqlfmt.com/",
+        description = "Formats your dbt SQL files so you don't have to",
+        notes = {
+            "Install sqlfmt with `pip install shandy-sqlfmt[jinjafmt]`",
+        },
     },
-  },
-  METHOD = FORMATTING,
-  filetypes = {
-    "sql",
-    "jinja",
-  },
-  generator_opts = {
-    command = "sqlfmt",
-    args = {},
-    to_stdin = true,
-    check_exit_code = { 0, 1 },
-    cwd = h.cache.by_bufnr(function(params)
-      return u.root_pattern("dbt_project.yml")(params.bufnr) or vim.fn.getcwd()
-    end),
-  },
-  factory = h.formatter_factory,
+    METHOD = FORMATTING,
+    filetypes = {
+        "sql",
+        "jinja",
+    },
+    generator_opts = {
+        command = "sqlfmt",
+        args = {},
+        to_stdin = true,
+        check_exit_code = { 0, 1 },
+        cwd = h.cache.by_bufnr(function(params)
+            return u.root_pattern("dbt_project.yml")(params.bufnr) or vim.fn.getcwd()
+        end),
+    },
+    factory = h.formatter_factory,
 })

--- a/lua/null-ls/builtins/formatting/sqlfmt.lua
+++ b/lua/null-ls/builtins/formatting/sqlfmt.lua
@@ -1,0 +1,31 @@
+local h = require("null-ls.helpers")
+local methods = require("null-ls.methods")
+local u = require("null-ls.utils")
+
+local FORMATTING = methods.internal.FORMATTING
+
+return h.make_builtin({
+  name = "sqlfmt",
+  meta = {
+    url = "https://sqlfmt.com/",
+    description = "Formats your dbt SQL files so you don't have to",
+    notes = {
+      "Install sqlfmt with `pip install shandy-sqlfmt[jinjafmt]`",
+    },
+  },
+  METHOD = FORMATTING,
+  filetypes = {
+    "sql",
+    "jinja",
+  },
+  generator_opts = {
+    command = "sqlfmt",
+    args = {},
+    to_stdin = true,
+    check_exit_code = { 0, 1 },
+    cwd = h.cache.by_bufnr(function(params)
+      return u.root_pattern("dbt_project.yml")(params.bufnr) or vim.fn.getcwd()
+    end),
+  },
+  factory = h.formatter_factory,
+})


### PR DESCRIPTION
 This adds the [sqlfmt](https://sqlfmt.com/) formatter as a built-in to null-ls.