### PR TITLE
feat(builtins/formatting/fantomas): A formatter for F#

### DIFF
--- a/lua/null-ls/builtins/_meta/filetype_map.lua
+++ b/lua/null-ls/builtins/_meta/filetype_map.lua
@@ -1,4 +1,3 @@
-local formatting = require "formatting"
 -- THIS FILE IS GENERATED. DO NOT EDIT MANUALLY.
 -- stylua: ignore
 return {

--- a/lua/null-ls/builtins/_meta/filetype_map.lua
+++ b/lua/null-ls/builtins/_meta/filetype_map.lua
@@ -1,3 +1,4 @@
+local formatting = require "formatting"
 -- THIS FILE IS GENERATED. DO NOT EDIT MANUALLY.
 -- stylua: ignore
 return {
@@ -125,6 +126,9 @@ return {
   },
   fortran = {
     formatting = { "fprettify" }
+  },
+  fsharp = {
+    formatting = { "fantomas" }
   },
   gd = {
     formatting = { "gdformat" }

--- a/lua/null-ls/builtins/_meta/formatting.lua
+++ b/lua/null-ls/builtins/_meta/formatting.lua
@@ -118,6 +118,9 @@ return {
   eslint_d = {
     filetypes = { "javascript", "javascriptreact", "typescript", "typescriptreact", "vue" }
   },
+  fantomas = {
+    filetypes = { "fsharp "},
+  },
   fish_indent = {
     filetypes = { "fish" }
   },

--- a/lua/null-ls/builtins/formatting/fantomas.lua
+++ b/lua/null-ls/builtins/formatting/fantomas.lua
@@ -1,0 +1,21 @@
+local h = require("null-ls.helpers")
+local methods = require("null-ls.methods")
+
+local FORMATTING = methods.internal.FORMATTING
+
+return h.make_builtin({
+    name = "fantomas",
+    meta = {
+        url = "https://github.com/fsprojects/fantomas",
+        description = "FSharp source code formatter.",
+    },
+    method = FORMATTING,
+    filetypes = { "fsharp" },
+    generator_opts = {
+        command = "fantomas",
+        args = { "--out", "$FILENAME" },
+        to_temp_file = true,
+        from_temp_file = true,
+    },
+    factory = h.formatter_factory,
+})

--- a/lua/null-ls/builtins/formatting/fantomas.lua
+++ b/lua/null-ls/builtins/formatting/fantomas.lua
@@ -15,7 +15,6 @@ return h.make_builtin({
         command = "fantomas",
         args = { "$FILENAME" },
         to_temp_file = true,
-        from_temp_file = true,
     },
     factory = h.formatter_factory,
 })

--- a/lua/null-ls/builtins/formatting/fantomas.lua
+++ b/lua/null-ls/builtins/formatting/fantomas.lua
@@ -13,7 +13,7 @@ return h.make_builtin({
     filetypes = { "fsharp" },
     generator_opts = {
         command = "fantomas",
-        args = { "--out", "$FILENAME" },
+        args = { "$FILENAME" },
         to_temp_file = true,
         from_temp_file = true,
     },

--- a/lua/null-ls/builtins/formatting/fantomas.lua
+++ b/lua/null-ls/builtins/formatting/fantomas.lua
@@ -15,6 +15,7 @@ return h.make_builtin({
         command = "fantomas",
         args = { "$FILENAME" },
         to_temp_file = true,
+        from_temp_file = true,
     },
     factory = h.formatter_factory,
 })


### PR DESCRIPTION
### Intention
Mentioned in https://github.com/jose-elias-alvarez/null-ls.nvim/issues/1489 this is to add F# formatter [Fantomas](https://github.com/fsprojects/fantomas).

### Question
Both [filetype_map.lua](https://github.com/jose-elias-alvarez/null-ls.nvim/blob/main/lua/null-ls/builtins/_meta/filetype_map.lua) and [_meta/formatting.lua](https://github.com/jose-elias-alvarez/null-ls.nvim/blob/main/lua/null-ls/builtins/_meta/formatting.lua) are marked as _DO NOT EDIT MANUALLY_. I don't see these in other accepted PRs either.
 Then how do I generate the lines in those two files? Without these, the formatter doesn't work.
