### PR TITLE
fix(builtins/diagnostics/markdownlint): change severity to warning

### DIFF
--- a/lua/null-ls/builtins/diagnostics/markdownlint.lua
+++ b/lua/null-ls/builtins/diagnostics/markdownlint.lua
@@ -25,10 +25,12 @@ return h.make_builtin({
             {
                 pattern = [[:(%d+):(%d+) ([%w-/]+) (.*)]],
                 groups = { "row", "col", "code", "message" },
+                overrides = { diagnostic = { severity = 2 } },
             },
             {
                 pattern = [[:(%d+) ([%w-/]+) (.*)]],
                 groups = { "row", "code", "message" },
+                overrides = { diagnostic = { severity = 2 } },
             },
         }),
     },

--- a/lua/null-ls/builtins/diagnostics/markdownlint_cli2.lua
+++ b/lua/null-ls/builtins/diagnostics/markdownlint_cli2.lua
@@ -24,10 +24,12 @@ return h.make_builtin({
             {
                 pattern = [[(%g+):(%d+):(%d+) ([%w-/]+) (.*)]],
                 groups = { "filename", "row", "col", "code", "message" },
+                overrides = { diagnostic = { severity = 2 } },
             },
             {
                 pattern = [[(%g+):(%d+) ([%w-/]+) (.*)]],
                 groups = { "filename", "row", "code", "message" },
+                overrides = { diagnostic = { severity = 2 } },
             },
         }),
     },

--- a/test/spec/builtins/diagnostics_spec.lua
+++ b/test/spec/builtins/diagnostics_spec.lua
@@ -345,6 +345,7 @@ describe("diagnostics", function()
                 row = "1",
                 col = "1",
                 message = "Inline HTML [Element: a]",
+                severity = 2,
             }, diagnostic)
         end)
         it("should create a diagnostic without a column", function()
@@ -355,6 +356,7 @@ describe("diagnostics", function()
                 row = "2",
                 code = "MD012/no-multiple-blanks",
                 message = "Multiple consecutive blank lines [Expected: 1; Actual: 2]",
+                severity = 2,
             }, diagnostic)
         end)
     end)


### PR DESCRIPTION
I think, the error severity is too strict for markdown issues. This PR relaxes it to warning.