### PR TITLE
feat(ruff): improve severity mapping

### DIFF
--- a/lua/null-ls/builtins/diagnostics/ruff.lua
+++ b/lua/null-ls/builtins/diagnostics/ruff.lua
@@ -1,6 +1,75 @@
 local h = require("null-ls.helpers")
 local methods = require("null-ls.methods")
 local DIAGNOSTICS = methods.internal.DIAGNOSTICS
+
+local _starts_with = function(str, start)
+    return str:sub(1, #start) == start
+end
+
+local ruff_rule_severities = {
+    { "ANN", 0, h.diagnostics.severities["information"] }, -- flake8-annotations
+    { "COM", 0, h.diagnostics.severities["information"] }, -- flake8-commas
+    { "ISC", 0, h.diagnostics.severities["error"] }, -- flake8-implicit-str-concat
+    { "PIE", 0, h.diagnostics.severities["warning"] }, -- flake8-pie
+    { "PGH", 0, h.diagnostics.severities["information"] }, -- pygrep-hooks
+    { "PLC", 0, h.diagnostics.severities["information"] }, -- pylint conventions
+    { "PLE", 0, h.diagnostics.severities["error"] }, -- pylint errors
+    { "PLR", 0, h.diagnostics.severities["hint"] }, -- pylint refactors
+    { "PLW", 0, h.diagnostics.severities["warning"] }, -- pylint warnings
+    { "PTH", 0, h.diagnostics.severities["hint"] }, -- flake8-use-pathlib
+    { "RET", 0, h.diagnostics.severities["warning"] }, -- flake8-return
+    { "RUF", 0, h.diagnostics.severities["warning"] }, -- ruff-specific
+    { "SIM", 0, h.diagnostics.severities["information"] }, -- flake8-simplify
+    { "TRY", 0, h.diagnostics.severities["information"] }, -- tryceratops
+    { "T20", 0, h.diagnostics.severities["information"] }, -- flake8-print
+    { "C4", 0, h.diagnostics.severities["warning"] }, -- flake8-comprehensions
+    { "EM", 0, h.diagnostics.severities["information"] }, -- flake8-errmsg
+    { "UP", 0, h.diagnostics.severities["information"] }, -- pyupgrade
+    { "A", 0, h.diagnostics.severities["warning"] }, -- flake8-builtins
+    { "B", 0, h.diagnostics.severities["warning"] }, -- flake8-bugbear
+    { "D", 0, h.diagnostics.severities["information"] }, -- pydocstyle
+    { "E", 0, h.diagnostics.severities["error"] }, -- pycodestyle errors
+    { "F", 0, h.diagnostics.severities["warning"] }, -- pyflakes
+    { "I", 0, h.diagnostics.severities["warning"] }, -- isort
+    { "S", 0, h.diagnostics.severities["warning"] }, -- flake8-bandit
+    { "W", 0, h.diagnostics.severities["warning"] }, -- pycodestyle warnings
+}
+-- TODO: account for user-provided severities (custom mappings)
+-- local user_severities = { I = "error", B904 = "error" }
+-- for k, sv in pairs(user_severities) do
+--     sv = h.diagnostics.severities[sv]
+--     table.insert(ruff_rule_severities, {k, 1, sv})
+-- end
+
+table.sort(ruff_rule_severities, function(k1, k2)
+    -- More specific (i.e., longer) codes need to be matched *first* to avoid false
+    -- positives, e.g. I v.s. ISC.
+    local len1 = string.len(k1[1])
+    local len2 = string.len(k2[1])
+    if len1 ~= len2 then
+        return len1 > len2
+    end
+
+    -- Give higher priority to user-provided mappings otherwise.
+    return k1[2] > k2[2]
+end)
+
+--- Assign severity based on the captured code
+local custom_severity_adapter = {
+    severity = function(entries, _)
+        local code = entries["code"]
+
+        for _, datum in next, ruff_rule_severities do
+            local c, sv = datum[1], datum[3]
+            if _starts_with(code, c) then
+                return sv
+            end
+        end
+        -- use fallback severity when `code` does not match
+        return nil
+    end,
+}
+
 local custom_end_col = {
     end_col = function(entries, line)
         if not line then
@@ -67,27 +136,12 @@ return h.make_builtin({
         end,
         to_stdin = true,
         ignore_stderr = true,
-        on_output = h.diagnostics.from_pattern(
-            [[(%d+):(%d+): ((%u)%w+) (.*)]],
-            { "row", "col", "code", "severity", "message" },
-            {
-                adapters = {
-                    custom_end_col,
-                },
-                severities = {
-                    E = h.diagnostics.severities["error"], -- pycodestyle errors
-                    W = h.diagnostics.severities["warning"], -- pycodestyle warnings
-                    F = h.diagnostics.severities["information"], -- pyflakes
-                    A = h.diagnostics.severities["information"], -- flake8-builtins
-                    B = h.diagnostics.severities["warning"], -- flake8-bugbear
-                    C = h.diagnostics.severities["warning"], -- flake8-comprehensions
-                    T = h.diagnostics.severities["information"], -- flake8-print
-                    U = h.diagnostics.severities["information"], -- pyupgrade
-                    D = h.diagnostics.severities["information"], -- pydocstyle
-                    M = h.diagnostics.severities["information"], -- Meta
-                },
-            }
-        ),
+        on_output = h.diagnostics.from_pattern([[(%d+):(%d+): (%w+) (.*)]], { "row", "col", "code", "message" }, {
+            adapters = {
+                custom_end_col,
+                custom_severity_adapter,
+            },
+        }),
     },
     factory = h.generator_factory,
 })


### PR DESCRIPTION
This PR addresses **part 1** of #1488 , which is to use a more flexible approach in assigning severities to code. And addresses the main problem brought up in that issue, which is that purely using a regex approach is insufficient to target specific rules.

Part 2 (exposing an option to configure the severity mapping) to come later.

Please read the review comments for explanation on certain design choices. I'm open to any constructive criticism!
Thanks.

Related to #1488 