### PR TITLE
feat(builtins/code_actions/cspell): add `on_success` hook to cspell (#1466)

### DIFF
--- a/lua/null-ls/builtins/code_actions/cspell.lua
+++ b/lua/null-ls/builtins/code_actions/cspell.lua
@@ -58,6 +58,35 @@ return h.make_builtin({
             "This source depends on the `cspell` built-in diagnostics source, so make sure to register it, too.",
         },
         usage = "local sources = { null_ls.builtins.diagnostics.cspell, null_ls.builtins.code_actions.cspell }",
+        config = {
+            {
+                key = "find_json",
+                type = "function",
+                description = "Customizing the location of cspell config",
+                usage = [[
+find_json = function(cwd)
+    return vim.fn.expand(cwd .. "/cspell.json")
+end
+]],
+            },
+            {
+                key = "on_success",
+                type = "function",
+                description = "Callback after successful execution of code action.",
+                usage = [[
+function(cspell_config_file, params)
+    -- format the cspell config file
+    os.execute(
+        string.format(
+            "cat %s | jq -S '.words |= sort' | tee %s > /dev/null",
+            cspell_config_file,
+            cspell_config_file
+        )
+    )
+end
+]],
+            },
+        },
     },
     method = CODE_ACTION,
     filetypes = {},
@@ -148,6 +177,11 @@ return h.make_builtin({
                             diagnostic.end_col,
                             { word }
                         )
+
+                        local on_success = config.on_success
+                        if on_success then
+                            on_success(cspell_json_file, params)
+                        end
                     end,
                 })
             end

--- a/lua/null-ls/builtins/code_actions/cspell.lua
+++ b/lua/null-ls/builtins/code_actions/cspell.lua
@@ -64,10 +64,9 @@ return h.make_builtin({
                 type = "function",
                 description = "Customizing the location of cspell config",
                 usage = [[
-find_json = function(cwd)
+function(cwd)
     return vim.fn.expand(cwd .. "/cspell.json")
-end
-]],
+end]],
             },
             {
                 key = "on_success",
@@ -83,8 +82,7 @@ function(cspell_config_file, params)
             cspell_config_file
         )
     )
-end
-]],
+end]],
             },
         },
     },


### PR DESCRIPTION
Discussed in https://github.com/jose-elias-alvarez/null-ls.nvim/issues/1466

With this hook, users can do whatever they like with cspell_config_file, such as beautifying the config file.

```lua
null_ls.builtins.code_actions.cspell.with({
    config = {
        find_json = function(_)
            return vim.fn.expand("~/.config/nvim/cspell.json")
        end,
        on_success = function(cspell_config_file)
            os.execute(
                string.format(
                    "cat %s | jq -S '.words |= sort' | tee %s > /dev/null",
                    cspell_config_file,
                    cspell_config_file
                )
            )
        end,
    },
}),

```

https://github.com/keaising/dotfile/blob/553612b8c5b8456e10bfcf588a7f1c4787f2adb8/nvim/.config/nvim/lua/plugins/lsp.lua#L108-L116