### PR TITLE
Enable additional filetypes for Terraform files

### DIFF
--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -2050,7 +2050,7 @@ local sources = { null_ls.builtins.diagnostics.terraform_validate }
 
 #### Defaults
 
-- Filetypes: `{ "terraform" }`
+- Filetypes: `{ "terraform", "tf", "terraform-vars" }`
 - Method: `diagnostics_on_save`
 - Command: `terraform`
 - Args: `{ "validate", "-json" }`
@@ -2084,7 +2084,7 @@ local sources = { null_ls.builtins.diagnostics.tfsec }
 
 #### Defaults
 
-- Filetypes: `{ "terraform" }`
+- Filetypes: `{ "terraform", "tf", "terraform-vars" }`
 - Method: `diagnostics_on_save`
 - Command: `tfsec`
 - Args: `{ "-s", "-f", "json", "$DIRNAME" }`

--- a/lua/null-ls/builtins/_meta/diagnostics.lua
+++ b/lua/null-ls/builtins/_meta/diagnostics.lua
@@ -278,13 +278,13 @@ return {
     filetypes = { "teal" }
   },
   terraform_validate = {
-    filetypes = { "terraform" }
+    filetypes = { "terraform", "tf", "terraform-vars" }
   },
   textlint = {
     filetypes = { "txt", "markdown" }
   },
   tfsec = {
-    filetypes = { "terraform" }
+    filetypes = { "terraform", "tf", "terraform-vars" }
   },
   tidy = {
     filetypes = { "html", "xml" }

--- a/lua/null-ls/builtins/_meta/filetype_map.lua
+++ b/lua/null-ls/builtins/_meta/filetype_map.lua
@@ -403,6 +403,7 @@ return {
     formatting = { "terraform_fmt" }
   },
   ["terraform-vars"] = {
+    diagnostics = { "terraform_validate", "tfsec" },
     formatting = { "terraform_fmt" }
   },
   tex = {
@@ -416,6 +417,7 @@ return {
     hover = { "dictionary" }
   },
   tf = {
+    diagnostics = { "terraform_validate", "tfsec" },
     formatting = { "terraform_fmt" }
   },
   toml = {

--- a/lua/null-ls/builtins/diagnostics/terraform_validate.lua
+++ b/lua/null-ls/builtins/diagnostics/terraform_validate.lua
@@ -11,7 +11,7 @@ return h.make_builtin({
         description = "Terraform validate is is a subcommand of terraform to validate configuration files in a directory",
     },
     method = DIAGNOSTICS_ON_SAVE,
-    filetypes = { "terraform" },
+    filetypes = { "terraform", "tf", "terraform-vars" },
     generator_opts = {
         command = "terraform",
         args = {

--- a/lua/null-ls/builtins/diagnostics/tfsec.lua
+++ b/lua/null-ls/builtins/diagnostics/tfsec.lua
@@ -17,7 +17,7 @@ return h.make_builtin({
         description = "Security scanner for Terraform code",
     },
     method = methods.internal.DIAGNOSTICS_ON_SAVE,
-    filetypes = { "terraform" },
+    filetypes = { "terraform", "tf", "terraform-vars" },
     generator_opts = {
         command = "tfsec",
         args = { "-s", "-f", "json", "$DIRNAME" },
@@ -71,6 +71,5 @@ return h.make_builtin({
             done(issues)
         end,
     },
-
     factory = h.generator_factory,
 })


### PR DESCRIPTION
The formatter [lua/null-ls/builtins/formatting/terraform_fmt.lua](https://github.com/jose-elias-alvarez/null-ls.nvim/blob/f8ffcd7cb8fb3325c711d459152ef132b5b65aed/lua/null-ls/builtins/formatting/terraform_fmt.lua#L13) already had these extra filetypes set.