### PR TITLE
feat(builtins/code_actions): cspell dictionaries

### DIFF
--- a/lua/null-ls/builtins/code_actions/cspell.lua
+++ b/lua/null-ls/builtins/code_actions/cspell.lua
@@ -60,6 +60,17 @@ local get_word = function(diagnostic)
     )[1]
 end
 
+local set_word = function(diagnostic, word)
+    vim.api.nvim_buf_set_text(
+        diagnostic.bufnr,
+        diagnostic.lnum,
+        diagnostic.col,
+        diagnostic.end_lnum,
+        diagnostic.end_col,
+        { word }
+    )
+end
+
 return h.make_builtin({
     name = "cspell",
     meta = {
@@ -122,14 +133,7 @@ return h.make_builtin({
                     table.insert(actions, {
                         title = string.format("Use %s", suggestion),
                         action = function()
-                            vim.api.nvim_buf_set_text(
-                                diagnostic.bufnr,
-                                diagnostic.lnum,
-                                diagnostic.col,
-                                diagnostic.end_lnum,
-                                diagnostic.end_col,
-                                { suggestion }
-                            )
+                            set_word(diagnostic, suggestion)
                         end,
                     })
                 end
@@ -154,14 +158,7 @@ return h.make_builtin({
                         vim.fn.writefile({ vim.json.encode(cspell) }, cspell_json_path)
 
                         -- replace word in buffer to trigger cspell to update diagnostics
-                        vim.api.nvim_buf_set_text(
-                            diagnostic.bufnr,
-                            diagnostic.lnum,
-                            diagnostic.col,
-                            diagnostic.end_lnum,
-                            diagnostic.end_col,
-                            { word }
-                        )
+                        set_word(diagnostic, word)
                     end,
                 })
 
@@ -207,6 +204,9 @@ return h.make_builtin({
 
                             vim.fn.writefile(dictionary_body, dictionary_path)
                             vim.notify('Added "' .. word .. '" to ' .. definition.path, vim.log.levels.INFO)
+
+                            -- replace word in buffer to trigger cspell to update diagnostics
+                            set_word(diagnostic, word)
                         end
 
                         vim.ui.select(options, custom_dictionary_options, custom_dictionary_action)

--- a/lua/null-ls/builtins/code_actions/cspell.lua
+++ b/lua/null-ls/builtins/code_actions/cspell.lua
@@ -138,9 +138,11 @@ return h.make_builtin({
                     })
                 end
 
+                local word = get_word(diagnostic)
+
                 -- add word to "words" in cspell.json
                 table.insert(actions, {
-                    title = "Add to cspell json file",
+                    title = 'Add "' .. word .. '" to cspell json file',
                     action = function()
                         local cspell, cspell_json_path = get_or_create_cspell_config()
                         if cspell == nil or cspell_json_path == nil then
@@ -151,8 +153,6 @@ return h.make_builtin({
                             cspell.words = {}
                         end
 
-                        local word = get_word(diagnostic)
-
                         table.insert(cspell.words, word)
 
                         vim.fn.writefile({ vim.json.encode(cspell) }, cspell_json_path)
@@ -162,8 +162,9 @@ return h.make_builtin({
                     end,
                 })
 
+                local custom_dictionary_title = 'Add "' .. word .. '" to a custom dictionary'
                 table.insert(actions, {
-                    title = "Add to a custom dictionary",
+                    title = custom_dictionary_title,
                     action = function()
                         local cspell = get_or_create_cspell_config()
                         if cspell == nil then
@@ -181,10 +182,9 @@ return h.make_builtin({
                             )
                             return
                         end
-                        local word = get_word(diagnostic)
 
                         local custom_dictionary_options = {
-                            prompt = 'Add "' .. word .. '" to a custom dictionary',
+                            prompt = custom_dictionary_title,
                             format_item = function(definition)
                                 return definition.name .. " - " .. definition.path
                             end,


### PR DESCRIPTION
Hi @jose-elias-alvarez,

I've been playing with the configuration of CSpell for one of the projects at my job, and I noticed that the code actions for CSpell could use a custom dictionary integration.

Custom dictionaries are local files referenced in the CSpell config file, see: https://cspell.org/docs/dictionaries-custom/

There's one things I would like to add, but I'm not sure what's the best approach:

- [ ] It would be great if we could display the list of custom dictionaries without having to drill drown into a second select.

  But reading and parsing the config file in the generator's callback function seems to slow down the warm up significantly.

  One idea I have is to defer the read/parse of the config, keep the results in a local cache, and invalidate that cache on the refresh mentioned in the previous point.
 
  Another idea is to expose a 'on_attach' callback at the source level, so we can run initializations there, which sounds close to #1373
  
What do you think?