### PR TITLE
fix(builtins/diagnostics/clazy): Handle fatal errors

### DIFF
--- a/lua/null-ls/builtins/diagnostics/clazy.lua
+++ b/lua/null-ls/builtins/diagnostics/clazy.lua
@@ -4,7 +4,7 @@ local methods = require("null-ls.methods")
 local DIAGNOSTICS_ON_SAVE = methods.internal.DIAGNOSTICS_ON_SAVE
 
 local get_severity = function(severity)
-    if severity == "error" then
+    if severity == "error" or severity == "fatal error" then
         return h.diagnostics.severities.error
     elseif severity == "warning" then
         return h.diagnostics.severities.warning
@@ -50,7 +50,7 @@ local sources = {
                 return
             end
 
-            local row, col, sev, msg = string.match(line, "[^:]+:(%d+):(%d+): (%w+): (.*)$")
+            local row, col, sev, msg = string.match(line, "[^:]+:(%d+):(%d+): ([%w ]+): (.*)$")
             return {
                 row = row,
                 col = col,


### PR DESCRIPTION
clazy can sometimes output fatal errors, for example when a file doesn't exist:
```
main.cpp:1:10: fatal error: 'non-existent' file not found
#include <non-existent>
         ^~~~~~~~~~~~~~
1 error generated.
```

These weren't caught by the regex and that resulted in 'msg' being nil.

Fix this by allowing a space when parsing the severity.