### PR TITLE
fix(builtins/diagnostics/todo_comments): convert filetype to lang before calling vim.treesitter.get_parser

### DIFF
--- a/lua/null-ls/builtins/diagnostics/todo_comments.lua
+++ b/lua/null-ls/builtins/diagnostics/todo_comments.lua
@@ -1,4 +1,5 @@
 local h = require("null-ls.helpers")
+local log = require("null-ls.logger")
 local methods = require("null-ls.methods")
 
 local DIAGNOSTICS = methods.internal.DIAGNOSTICS
@@ -14,6 +15,7 @@ local function get_document_root(bufnr, filetype)
     local lang = vim.treesitter.language.get_lang(filetype)
     local has_parser, parser = pcall(vim.treesitter.get_parser, bufnr, lang)
     if not has_parser then
+        log:debug("no parser available for lang " .. lang)
         return
     end
 

--- a/lua/null-ls/builtins/diagnostics/todo_comments.lua
+++ b/lua/null-ls/builtins/diagnostics/todo_comments.lua
@@ -11,7 +11,8 @@ local comment_types = {
 }
 
 local function get_document_root(bufnr, filetype)
-    local has_parser, parser = pcall(vim.treesitter.get_parser, bufnr, filetype)
+    local lang = vim.treesitter.language.get_lang(filetype)
+    local has_parser, parser = pcall(vim.treesitter.get_parser, bufnr, lang)
     if not has_parser then
         return
     end

--- a/lua/null-ls/builtins/diagnostics/todo_comments.lua
+++ b/lua/null-ls/builtins/diagnostics/todo_comments.lua
@@ -89,11 +89,6 @@ return h.make_builtin({
     generator = {
         fn = function(params)
             local ft = params.ft
-
-            if ft == "tex" then
-                ft = "latex"
-            end
-
             local result = {}
             for _, node in ipairs(get_comments(params.bufnr, ft)) do
                 local content = vim.treesitter.get_node_text(node, params.bufnr):match("^%s*(.*)")


### PR DESCRIPTION
Fixes issue #1527. Same reproduction steps with this patch does not produce the syntax bug.

I also created a separate bug with nvim-treesitter about the syntax breaking when `get_parser` is called with an invalid lang: https://github.com/nvim-treesitter/nvim-treesitter/issues/4693