### PR TITLE
fix(builtins/diagnostics/todo_comments): fix nil access

### DIFF
--- a/lua/null-ls/builtins/diagnostics/todo_comments.lua
+++ b/lua/null-ls/builtins/diagnostics/todo_comments.lua
@@ -13,6 +13,11 @@ local comment_types = {
 
 local function get_document_root(bufnr, filetype)
     local lang = vim.treesitter.language.get_lang(filetype)
+    if not lang then
+        log:debug("no lang available for filetype " .. filetype)
+        return
+    end
+
     local has_parser, parser = pcall(vim.treesitter.get_parser, bufnr, lang)
     if not has_parser then
         log:debug("no parser available for lang " .. lang)


### PR DESCRIPTION
This fixes a string concat with a nil value, if the current file type does not have a language registered with treesitter.