### PR TITLE
docs: fix from_temp_file option for generator_factory helper

### DIFF
--- a/doc/HELPERS.md
+++ b/doc/HELPERS.md
@@ -167,7 +167,7 @@ Not compatible with `ignore_stderr`.
 ### from_temp_file
 
 Reads the contents of the temp file created by `to_temp_file` after running
-`command` and assigns it to `params.content`. Useful for formatters that don't
+`command` and assigns it to `params.output`. Useful for formatters that don't
 output to `stdin` (see `formatter_factory`).
 
 This option depends on `to_temp_file`.


### PR DESCRIPTION
When reading the following source code, it assigns to `params.output`.

https://github.com/jose-elias-alvarez/null-ls.nvim/blob/33b853a3933eed3137cd055aac4e539e69832ad0/lua/null-ls/helpers/generator_factory.lua#L304-L306