### PR TITLE
Add multiple_files support to golangci_lint builtin

### DIFF
--- a/lua/null-ls/builtins/diagnostics/golangci_lint.lua
+++ b/lua/null-ls/builtins/diagnostics/golangci_lint.lua
@@ -17,6 +17,7 @@ return h.make_builtin({
         to_stdin = true,
         from_stderr = false,
         ignore_stderr = true,
+        multiple_files = true,
         args = {
             "run",
             "--fix=false",
@@ -37,15 +38,14 @@ return h.make_builtin({
             local issues = params.output["Issues"]
             if type(issues) == "table" then
                 for _, d in ipairs(issues) do
-                    if d.Pos.Filename == params.bufname then
-                        table.insert(diags, {
-                            source = string.format("golangci-lint:%s", d.FromLinter),
-                            row = d.Pos.Line,
-                            col = d.Pos.Column,
-                            message = d.Text,
-                            severity = h.diagnostics.severities["warning"],
-                        })
-                    end
+                    table.insert(diags, {
+                        source = string.format("golangci-lint:%s", d.FromLinter),
+                        row = d.Pos.Line,
+                        col = d.Pos.Column,
+                        message = d.Text,
+                        severity = h.diagnostics.severities["warning"],
+                        filename = d.Pos.Filename,
+                    })
                 end
             end
             return diags


### PR DESCRIPTION
This PR adds [multiple_files](https://github.com/jose-elias-alvarez/null-ls.nvim/pull/376) support for the `golangci_lint` builtin. The current implementation runs the linter on the entire project, but due to the `if d.Pos.Filename == params.bufname then` condition the other diagnostics are filtered out. Removing that guard and adding the `multiple_files` flag allows displaying all the diagnostics which are already being generated by the command.