### PR TITLE
fix(builtins): add golangci_lint support for monorepos

### DIFF
--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -1073,7 +1073,7 @@ local sources = { null_ls.builtins.diagnostics.golangci_lint }
 - Filetypes: `{ "go" }`
 - Method: `diagnostics_on_save`
 - Command: `golangci-lint`
-- Args: `{ "run", "--fix=false", "--out-format=json", "--path-prefix", "$ROOT" }`
+- Args: `{ "run", "--fix=false", "--out-format=json" }`
 
 ### [gospel](https://github.com/kortschak/gospel)
 

--- a/lua/null-ls/builtins/diagnostics/golangci_lint.lua
+++ b/lua/null-ls/builtins/diagnostics/golangci_lint.lua
@@ -1,6 +1,7 @@
 local h = require("null-ls.helpers")
 local methods = require("null-ls.methods")
 local log = require("null-ls.logger")
+local u = require("null-ls.utils")
 
 local DIAGNOSTICS_ON_SAVE = methods.internal.DIAGNOSTICS_ON_SAVE
 
@@ -18,12 +19,13 @@ return h.make_builtin({
         from_stderr = false,
         ignore_stderr = true,
         multiple_files = true,
+        cwd = h.cache.by_bufnr(function(params)
+            return u.root_pattern("go.mod")(params.bufname)
+        end),
         args = {
             "run",
             "--fix=false",
             "--out-format=json",
-            "--path-prefix",
-            "$ROOT",
         },
         format = "json",
         check_exit_code = function(code)
@@ -39,12 +41,12 @@ return h.make_builtin({
             if type(issues) == "table" then
                 for _, d in ipairs(issues) do
                     table.insert(diags, {
-                        source = string.format("golangci-lint:%s", d.FromLinter),
+                        source = string.format("golangci-lint: %s", d.FromLinter),
                         row = d.Pos.Line,
                         col = d.Pos.Column,
                         message = d.Text,
                         severity = h.diagnostics.severities["warning"],
-                        filename = d.Pos.Filename,
+                        filename = u.path.join(params.cwd, d.Pos.Filename),
                     })
                 end
             end


### PR DESCRIPTION

Hi,
I had issues trying to get golangci-lint to work in a monorepo.
I believe this shoud fix the issue. While trying to figure this out myself I also found #1206 which helped me fix the issue, but seems stale.
Please let me know if anything needs to change.
I've also added a space to the string formatting as this looks more in line with for example eslint_d output