### PR TITLE
fix(builtins): updated prisma formatting to be supported with current syntax

### DIFF
--- a/lua/null-ls/builtins/formatting/prismaFmt.lua
+++ b/lua/null-ls/builtins/formatting/prismaFmt.lua
@@ -12,8 +12,8 @@ return h.make_builtin({
     method = FORMATTING,
     filetypes = { "prisma" },
     generator_opts = {
-        command = "prisma-fmt",
-        args = { "format", "-i", "$FILENAME" },
+        command = "prisma",
+        args = { "format", "$FILENAME" },
         to_stdin = true,
     },
     factory = h.formatter_factory,


### PR DESCRIPTION
Mentioned in issue #1520, the new CLI commands to format prisma files is `prisma format <file>`.