### PR TITLE
Switch sqlfmt to using stdin instead of file

### DIFF
--- a/lua/null-ls/builtins/formatting/sqlfmt.lua
+++ b/lua/null-ls/builtins/formatting/sqlfmt.lua
@@ -19,10 +19,8 @@ return h.make_builtin({
     },
     generator_opts = {
         command = "sqlfmt",
-        args = {
-            "$FILENAME",
-        },
-        to_temp_file = true,
+        args = { "-" },
+        to_stdin = true,
     },
     factory = h.formatter_factory,
 })


### PR DESCRIPTION
When using vim-dadbod-ui to write SQL queries, it creates the query files with no extension, but sets the SQL filetype for the buffer. These files currently will not format using sqlfmt, as sqlfmt ignores non-SQL file extensions when given a filename as input.

This patch switches the sqlfmt built-in formatter to using stdin instead of passing the file, which allows these files to be formatted correctly.