### PR TITLE
feat: add pyink range formatting

### DIFF
--- a/lua/null-ls/builtins/formatting/pyink.lua
+++ b/lua/null-ls/builtins/formatting/pyink.lua
@@ -2,6 +2,7 @@ local h = require("null-ls.helpers")
 local methods = require("null-ls.methods")
 
 local FORMATTING = methods.internal.FORMATTING
+local RANGE_FORMATTING = methods.internal.RANGE_FORMATTING
 
 return h.make_builtin({
     name = "pyink",
@@ -9,16 +10,16 @@ return h.make_builtin({
         url = "https://github.com/google/pyink",
         description = "The Google Python code formatter",
     },
-    method = FORMATTING,
+    method = {FORMATTING, RANGE_FORMATTING},
     filetypes = { "python" },
     generator_opts = {
         command = "pyink",
-        args = {
+        args = h.range_formatting_args_factory({
             "--stdin-filename",
             "$FILENAME",
             "--quiet",
             "-",
-        },
+        }, "--pyink-lines", nil, { use_rows = true, delimiter = "-" }),
         to_stdin = true,
     },
     factory = h.formatter_factory,

--- a/lua/null-ls/builtins/formatting/pyink.lua
+++ b/lua/null-ls/builtins/formatting/pyink.lua
@@ -10,7 +10,7 @@ return h.make_builtin({
         url = "https://github.com/google/pyink",
         description = "The Google Python code formatter",
     },
-    method = {FORMATTING, RANGE_FORMATTING},
+    method = { FORMATTING, RANGE_FORMATTING },
     filetypes = { "python" },
     generator_opts = {
         command = "pyink",


### PR DESCRIPTION
`pyink` supports range formatting through the `--pyink-lines` option. It works if one decides to format a piece of code in visual mode with `vim.lsp.format()`. But for some reason `gqq` doesn't work. I checked and null-ls does set `formatexpr` as `vim.lsp.formatexpr()`. Did I miss something?