### PR TITLE
fix(credo): return no errors when output is nil

### DIFF
--- a/lua/null-ls/builtins/diagnostics/credo.lua
+++ b/lua/null-ls/builtins/diagnostics/credo.lua
@@ -50,11 +50,9 @@ return h.make_builtin({
             -- "mix new" project, then changing in mix.exs "def project" to add:
             -- compilers: Mix.compilers(),
             -- Then creating a file config/config.exs containing "use Mix.Config"
-            local output = params.err -- assume there are no elixir warnings
-            if params.output then
-                -- output (stdout) is present! now we assume there are elixir
-                -- warnings, and that therefore the credo output is on stdout...
-                output = params.output
+            local output = params.output or params.err
+            if not output then
+                return done(issues)
             end
 
             local json_index, _ = output:find("{")

--- a/test/spec/builtins/diagnostics_spec.lua
+++ b/test/spec/builtins/diagnostics_spec.lua
@@ -287,6 +287,10 @@ describe("diagnostics", function()
                 },
             }, credo_diagnostics)
         end)
+        it("should return no errors when no output or errors", function()
+            parser({ output = nil, errors = nil }, done)
+            assert.same({}, credo_diagnostics)
+        end)
     end)
 
     describe("luacheck", function()


### PR DESCRIPTION
fix #1476 