### PR TITLE
feat(builtins): added nelua

### DIFF
--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -1351,6 +1351,23 @@ local sources = { null_ls.builtins.diagnostics.mypy }
 - Command: `mypy`
 - Args: dynamically resolved (see [source](https://github.com/jose-elias-alvarez/null-ls.nvim/blob/main/lua/null-ls/builtins/diagnostics/mypy.lua))
 
+### [nelua](https://github.com/edubart/nelua-lang)
+
+Nelua can analize code using `nelua -a`
+
+#### Usage
+
+```lua
+local sources = { null_ls.builtins.diagnostics.nelua }
+```
+
+#### Defaults
+
+- Filetypes: `{ "nelua" }`
+- Method: `diagnostics`
+- Command: `nelua`
+- Args: `{ "-a", "$FILENAME", "-L", "$DIRNAME" }`
+
 ### [npm_groovy_lint](https://github.com/nvuillam/npm-groovy-lint)
 
 Lint, format and auto-fix Groovy, Jenkinsfile, and Gradle files.

--- a/lua/null-ls/builtins/diagnostics/nelua.lua
+++ b/lua/null-ls/builtins/diagnostics/nelua.lua
@@ -1,0 +1,39 @@
+local h = require("null-ls.helpers")
+local methods = require("null-ls.methods")
+
+return h.make_builtin({
+    name = "nelua",
+    meta = {
+        url = "https://github.com/edubart/nelua",
+        description = "Nelua can analize code using `nelua -a`.",
+    },
+    method = methods.internal.DIAGNOSTICS,
+    filetypes = { "nelua" },
+    generator_opts = {
+        command = "nelua",
+        args = { "-a", "$FILENAME", "-L", "$DIRNAME" },
+        format = "line",
+        to_stdin = false,
+        from_stderr = true,
+        to_temp_file = true,
+        check_exit_code = function(code)
+            return code <= 1
+        end,
+        on_output = function(line, params)
+            return h.diagnostics.from_pattern(
+                [[(.*):(%d+):(%d+): (%w+): (.*)]],
+                { "filename", "row", "col", "severity", "message" },
+                {
+                    severities = {
+                        info = h.diagnostics.severities["information"],
+                    },
+                }
+            )(
+                -- don't match AST nodes information
+                line:gsub([[.*:%d+:%d+: from: .*]], ""),
+                params
+            )
+        end,
+    },
+    factory = h.generator_factory,
+})


### PR DESCRIPTION
im currently selecting only `error` cause nelua -a prints AST nodes as well which makes no sense in this context
nelua --lint does not get "normal" errors, eg: array size inference stuff

i need a way to remove `from` from the capture or to capture only the necessary words, skimming through the source code `error`, `warning` and `info` seem to be the ones 

but since im not sure @edubart can you help here?

also nelua -a is a thing that get executed on the file one time so does not look like an lsp so i figured this is the place this goes and not lspconfig