### PR TITLE
feat: add leptosfmt formatter

### DIFF
--- a/lua/null-ls/builtins/formatting/leptosfmt.lua
+++ b/lua/null-ls/builtins/formatting/leptosfmt.lua
@@ -1,0 +1,20 @@
+local h = require("null-ls.helpers")
+local methods = require("null-ls.methods")
+
+local FORMATTING = methods.internal.FORMATTING
+
+return h.make_builtin({
+    name = "leptosfmt",
+    meta = {
+        url = "https://github.com/bram209/leptosfmt",
+        description = "A formatter for the leptos view! macro",
+    },
+    method = FORMATTING,
+    filetypes = { "rust" },
+    generator_opts = {
+        command = "leptosfmt",
+        args = { "--quiet=true", "--stdin=true" },
+        to_stdin = true,
+    },
+    factory = h.formatter_factory,
+})


### PR DESCRIPTION
Adds leptosfmt for formatting inline code blocks in the leptos rust web
framework: https://github.com/leptos-rs/leptos

the formatter is here: https://github.com/bram209/leptosfmt

The PR is currently waiting for: https://github.com/bram209/leptosfmt/pull/30
before it can be merged.

This may be too niche of a tool, if so I will keep it in my own fork
