### PR TITLE
Added diagnosis builtin for typos-cli

### DIFF
--- a/lua/null-ls/builtins/diagnostics/typos.lua
+++ b/lua/null-ls/builtins/diagnostics/typos.lua
@@ -1,0 +1,86 @@
+local h = require("null-ls.helpers")
+local methods = require("null-ls.methods")
+
+local DIAGNOSTICS = methods.internal.DIAGNOSTICS
+
+local format_message = function(typo, corrections)
+    local message = "`" .. typo .. "` should be "
+
+    local numCorrections = #corrections
+
+    for i, correction in ipairs(corrections) do
+        message = message .. "`" .. correction .. "`"
+
+        if i == numCorrections - 1 then
+            message = message .. " or "
+        elseif i < numCorrections then
+            message = message .. ", "
+        end
+    end
+
+    message = message .. "."
+
+    return message
+end
+
+local handle_typos_output = function(line)
+    -- Sample error format from typos-cli
+    -- {
+    --   "type": "typo",
+    --   "path": "-",
+    --   "line_num": 1,
+    --   "byte_offset": 6,
+    --   "typo": "ther",
+    --   "corrections": [
+    --     "there",
+    --     "their",
+    --     "the",
+    --     "other"
+    --   ]
+    -- }
+
+    local ok, err = pcall(vim.json.decode, line)
+    if not ok then
+        return
+    end
+
+    local severity = vim.diagnostic.severity.WARN
+    local typo = err.typo
+    local row = err.line_num
+    local col = err.byte_offset + 1
+    local corrections = err.corrections
+
+    return {
+        message = format_message(typo, corrections),
+        severity = severity,
+        row = row,
+        col = col,
+        end_col = col + typo:len(),
+        end_row = row,
+        source = "Typos",
+        -- Custom data for the code action builtin
+        user_data = { corrections = corrections },
+    }
+end
+
+return h.make_builtin({
+    name = "typos",
+    meta = {
+        url = "https://github.com/crate-ci/typos",
+        description = "Source code spell checker written in rust",
+    },
+    method = DIAGNOSTICS,
+    filetypes = {},
+    generator_opts = {
+        command = "typos",
+        args = { "--format", "json", "-" },
+        to_stdin = true,
+        format = "line",
+        check_exit_code = function(code)
+            return code == 2
+        end,
+        use_cache = true,
+        on_output = handle_typos_output,
+    },
+    factory = h.generator_factory,
+})

--- a/test/spec/builtins/diagnostics_spec.lua
+++ b/test/spec/builtins/diagnostics_spec.lua
@@ -2153,4 +2153,28 @@ INFO: Analysis cache updated]],
             }, diagnostic)
         end)
     end)
+
+    describe("typos", function()
+        local linter = diagnostics.typos
+        local parser = linter._opts.on_output
+        local file = {
+            [[Did I misspell langauge ?]],
+        }
+
+        it("should crrate a diagnostic with warning severity", function()
+            local output =
+                [[{"type":"typo","path":"diagnostics_spec.lua","line_num":1,"byte_offset":16,"typo":"Ba","corrections":["By","Be"]}]]
+            local diagnostic = parser(output, { content = file })
+            assert.same({
+                message = "`Ba` should be `By` or `Be`.",
+                severity = 2,
+                row = 1,
+                col = 17,
+                end_col = 19,
+                end_row = 1,
+                source = "Typos",
+                user_data = { corrections = { "By", "Be" } },
+            }, diagnostic)
+        end)
+    end)
 end)


### PR DESCRIPTION
Current [PR](https://github.com/jose-elias-alvarez/null-ls.nvim/pull/995) for [typos](https://github.com/crate-ci/typos) builtins is open for a long time. Raising this separate PR to at get the working diagnostics source merged.