### PR TITLE
Change $FILEPATH to $FILENAME in the fourmolu configuration.

### DIFF
--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -3236,7 +3236,7 @@ local sources = { null_ls.builtins.formatting.fourmolu }
 - Filetypes: `{ "haskell" }`
 - Method: `formatting`
 - Command: `fourmolu`
-- Args: `{ "--stdin-input-file", "$FILEPATH" }`
+- Args: `{ "--stdin-input-file", "$FILENAME" }`
 
 ### [fprettify](https://github.com/pseewald/fprettify)
 

--- a/lua/null-ls/builtins/formatting/fourmolu.lua
+++ b/lua/null-ls/builtins/formatting/fourmolu.lua
@@ -13,7 +13,7 @@ return h.make_builtin({
     filetypes = { "haskell" },
     generator_opts = {
         command = "fourmolu",
-        args = { "--stdin-input-file", "$FILEPATH" },
+        args = { "--stdin-input-file", "$FILENAME" },
         to_stdin = true,
     },
     factory = h.formatter_factory,


### PR DESCRIPTION
The old configuration was using `$FILEPATH` which appeared to be equal to an empty string at runtime.

If an empty string is passed to `fourmolu` for `--stdin-input-file`, then it can't find your `*.cabal` file and may choke because it's unaware of flags you enabled for the project. Example:
```
$ cat src/Forum/Webapi/Routes.hs  | fourmolu --stdin-input-file ""
Loaded config from: /home/david/Code/forum/fourmolu.yaml
<stdin>:1:1
  The GHC parser (in Haddock mode) failed:
  {ErrorWithoutFlag
   Found `qualified' in postpositive position.
 ErrorWithoutFlag
   Found `qualified' in postpositive position.
 ErrorWithoutFlag
   Found `qualified' in postpositive position.
 ErrorWithoutFlag
   Found `qualified' in postpositive position.
 ErrorWithoutFlag
   Found `qualified' in postpositive position. }
```

Updating the configuration to use `$FILENAME` instead resolved the issue for me.