### PR TITLE
feat(builtin-formatter): python-docformatter

### DIFF
--- a/lua/null-ls/builtins/formatting/docformatter.lua
+++ b/lua/null-ls/builtins/formatting/docformatter.lua
@@ -1,0 +1,22 @@
+local h = require("null-ls.helpers")
+local methods = require("null-ls.methods")
+
+local FORMATTING = methods.internal.FORMATTING
+
+return h.make_builtin({
+    name = "docformatter",
+    meta = {
+        url = "https://github.com/PyCQA/docformatter/",
+        description = "Python formatter complaint with the PEP 257 standard",
+    },
+    method = { FORMATTING },
+    filetypes = { "python" },
+    generator_opts = {
+        command = "docformatter",
+        -- black compatibility added by default because 74 cols is very restrictive
+        -- in modern times
+        args = { "--black", "-" },
+        to_stdin = true,
+    },
+    factory = h.formatter_factory,
+})


### PR DESCRIPTION
`docformatter` is a PEP-257 complaint Python autoformatter. It is compatible with autopep8 and black. It works on docstrings and no other formatter has this capability. It is also highly customizable (see https://docformatter.readthedocs.io/en/latest/usage.html#use-from-the-command-line for additional arguments).