### PR TITLE
feat(formatting):adding range_formatting for google-java-format builtin

### DIFF
--- a/doc/BUILTINS.md
+++ b/doc/BUILTINS.md
@@ -3483,15 +3483,19 @@ Reformats Java source code according to Google Java Style.
 #### Usage
 
 ```lua
-local sources = { null_ls.builtins.formatting.google_java_format }
+local sources = {
+    null_ls.builtins.formatting.google_java_format.with({
+        extra_args = { "-aosp" }, -- Use AOSP style instead of Google Style (4-space indentation).
+    }),
+}
 ```
 
 #### Defaults
 
 - Filetypes: `{ "java" }`
-- Method: `formatting`
+- Method: `formatting`, `range_formatting`
 - Command: `google-java-format`
-- Args: `{ "-" }`
+- Args: dynamically resolved (see [source](https://github.com/jose-elias-alvarez/null-ls.nvim/blob/main/lua/null-ls/builtins/formatting/google_java_format.lua))
 
 ### [haxe_formatter](https://github.com/HaxeCheckstyle/haxe-formatter)
 

--- a/lua/null-ls/builtins/formatting/google_java_format.lua
+++ b/lua/null-ls/builtins/formatting/google_java_format.lua
@@ -2,6 +2,7 @@ local h = require("null-ls.helpers")
 local methods = require("null-ls.methods")
 
 local FORMATTING = methods.internal.FORMATTING
+local RANGE_FORMATTING = methods.internal.RANGE_FORMATTING
 
 return h.make_builtin({
     name = "google_java_format",
@@ -9,13 +10,24 @@ return h.make_builtin({
         url = "https://github.com/google/google-java-format",
         description = "Reformats Java source code according to Google Java Style.",
     },
-    method = FORMATTING,
+    method = { FORMATTING, RANGE_FORMATTING },
     filetypes = { "java" },
     generator_opts = {
         command = "google-java-format",
-        args = {
-            "-",
-        },
+        args = function(params)
+            if params.method == RANGE_FORMATTING and params.range then
+                return {
+                    "--lines",
+                    params.range.row .. ":" .. params.range.end_row,
+                    "--skip-sorting-imports",
+                    "--skip-removing-unused-imports",
+                    "--skip-javadoc-formatting",
+                    "--skip-reflowing-long-strings",
+                    "-",
+                }
+            end
+            return { "-" }
+        end,
         to_stdin = true,
     },
     factory = h.formatter_factory,


### PR DESCRIPTION
Hi there,

This PR is about adding the range_formatting method to the built-in source of google-java-format.
In fact, google-java-format already supports the --lines option for range formatting.
However, there's a trick: you need to add four additional options to properly perform the range formatting operation; otherwise, the entire file will be formatted.
Please see the issue at https://github.com/google/google-java-format/issues/942 for more details.

I chose not to use the helpers because there are extra options involved, and I didn't want to disrupt the range_formatting_args_factory.

Have a nice day.